### PR TITLE
use gill sans mt instead of just gill sans

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -6,7 +6,7 @@ $contentPatternUrl: $imageBasePath + "/content.png";
 $headPatternUrl: $imageBasePath + "/head.png";
 
 //------------------------------------------------------------------font
-$fontFamily:"Calluna Sans", "Gill Sans", Calibri, "Trebuchet MS", sans-serif;
+$fontFamily:"Calluna Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
 $fontSize:14px;
 
 //-----------------------------------------------------------------other


### PR DESCRIPTION
The gill sans font on windows is a very wide font and breaks most layouts.