### PR TITLE
Fix print default font size setting

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -388,8 +388,9 @@ class PrintService
 
         // fill text fields
         if (isset($this->conf['fields']) ) {
-            foreach ($this->conf['fields'] as $k => $v) {
-                $pdf->SetFont('Arial', '', $this->conf['fields'][$k]['fontsize']);
+            foreach ($this->conf['fields'] as $k => $fontConfiguration) {
+                $fontsize = isset($fontConfiguration['fontsize']) ? $fontConfiguration['fontsize']: 20;
+                $pdf->SetFont('Arial', '',$fontsize);
                 $pdf->SetXY($this->conf['fields'][$k]['x'] - 1,
                     $this->conf['fields'][$k]['y']);
 


### PR DESCRIPTION
Fix for application crashes if no fontsize is set. Now it will use default value 20 instead. @swinkelmann Please check before we can merge