### PR TITLE
Hotfix/basesourceswitcher initialization

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -352,6 +352,18 @@ class Application
                 }
             }
         }
+        // Let (active, visible) Elements update the Application config
+        // This is useful for BaseSourceSwitcher, SuggestMap, potentially many more, that influence the initially
+        // visible state of the frontend.
+        $configBeforeElement = $configAfterElements = $configuration;
+        foreach ($this->getElements() as $elementList) {
+            foreach ($elementList as $elementInstance) {
+                /** @var \Mapbender\CoreBundle\Component\Element $elementInstance */
+                $configAfterElements = $configBeforeElement = $elementInstance->updateAppConfig($configBeforeElement);
+            }
+        }
+
+        $configuration = $configAfterElements;
 
         // Convert to asset
         $asset = new StringAsset(json_encode((object)$configuration));

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -555,4 +555,16 @@ abstract class Element
         $className = substr($className,1);
         return $className;
     }
+
+    /**
+     * Hook function for embedded elements to influence the effective application config on initial load.
+     * We (can) use this for BaseSourceSwitchter (deactivates layers), SuggestMap element reloading state etc.
+     *
+     * @param array
+     * @return array
+     */
+    public function updateAppConfig($configIn)
+    {
+        return $configIn;
+    }
 }

--- a/src/Mapbender/CoreBundle/Resources/views/Element/basesourceswitcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/basesourceswitcher.html.twig
@@ -1,14 +1,14 @@
 <ul id="{{ id }}" class="mb-element mb-element-basesourceswitcher"  title="{{ configuration.tooltip|default(title)|trans }}">
 {% if configuration.groups is defined %}
   {% for name, opts in configuration.groups %}
-    {% if opts.title is defined %}
-    <li class="basesourcesetswitch notgroup" data-state="{% if loop.first %}active{% endif %}" data-sourceset="{% for source in opts.sources %}{% if not loop.first %},{% endif %}{% spaceless %}{{- source -}}{% endspaceless %}{% endfor %}" >{{ opts.title | trans }}</li>
+    {% if opts.type == 'item' %}
+    <li class="basesourcesetswitch notgroup" {% if opts.active is defined and opts.active %}data-state="active"{% endif %} data-sourceset="{% for source in opts.sources %}{% if not loop.first %},{% endif %}{% spaceless %}{{- source -}}{% endspaceless %}{% endfor %}" >{{ opts.title | trans }}</li>
     {% else %}
-    <li class="basesourcegroup" data-state="{% if loop.first %}active{% endif %}">
+    <li class="basesourcegroup" {% if opts.active is defined and opts.active %}data-state="active"{% endif %}>
       <!--span-->{{ name | trans }}<!--/span-->
       <ul class="basesourcesubswitcher hidden">
-      {% for opt in opts %}
-          <li class="basesourcesetswitch" data-state="{% if loop.first %}active{% endif %}" data-sourceset="{% for source in opt.sources %}{% if not loop.first %},{% endif %}{% spaceless %}{{- source -}}{% endspaceless %}{% endfor %}" >{{ opt.title | trans }}</li>
+      {% for opt in opts.items %}
+          <li class="basesourcesetswitch" {% if opt.active is defined and opts.active %}data-state="active"{%  endif %} data-sourceset="{% for source in opt.sources %}{% if not loop.first %},{% endif %}{% spaceless %}{{- source -}}{% endspaceless %}{% endfor %}" >{{ opt.title | trans }}</li>
       {% endfor %}
       </ul>
     </li>


### PR DESCRIPTION
Fixes weird / wasteful base source requests on currently invisible base sources when embedding BaseSourceSwitcher.
With an active BaseSourceSwitcher, only one layer may be active, but previously, all base sources would start loading anyway, which is wasteful on more extreme use cases of the BSS (some people use 60+ base sources). Also, depending on the layer source nesting, some requests may go out with LAYERS= empty, which can cause secondary issues with proxies.

Fix is built on a (small) extension to Application + Element classes, which allow server-side Application config modifications by active Element instances.

This might be a better approach than previous purely client-side fixes to e.g. SuggestMap Elements, where the common root of the problem is that the application is initialized into a certain "default" state on the client, and then that configuration is immediately altered. Working around event order dependencies with that model is challenging. Amending the initial configuration server-side allows much easier, more robust fixes.