### PR TITLE
add utf8_decode to handle öüä for dynamic textes

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -784,7 +784,7 @@ class PrintService
         $this->pdf->SetFont('Arial', '', $this->conf['fields']['dynamic_text']['fontsize']);
         $this->pdf->MultiCell($this->conf['fields']['dynamic_text']['width'],
                 $this->conf['fields']['dynamic_text']['height'],
-                $group->getDescription());
+                utf8_decode($group->getDescription()));
         
     }
 


### PR DESCRIPTION
* If you use öüä in group names and want to print the group name to the pdf at the moment öüä are bloken
* just add utf8_decode(..) to display them in the right way
*  utf8_decode($group->getDescription()));