### PR TITLE
Reenable default text selection in nested elements in map

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/map.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/map.scss
@@ -5,10 +5,14 @@
     width:100%;
     height:100%;
     z-index: 1;
-    -webkit-user-select: none;  /* Chrome all / Safari all */
-    -moz-user-select: none;     /* Firefox all */
-    -ms-user-select: none;      /* IE 10+ */
-    user-select: none;          /* Likely future */
+    /* disable map tile selection on the lowest level possible
+       => no effect on text selection in e.g. .olPopup (nested inside map viewport */
+    .olLayerDiv {
+      -webkit-user-select: none;  /* Chrome all / Safari all */
+      -moz-user-select: none;     /* Firefox all */
+      -ms-user-select: none;      /* IE 10+ */
+      user-select: none;          /* Likely future */
+    }
     @include absolute(0 0 0 0);
   }
 }


### PR DESCRIPTION
Layer tiles remain non-selectable.
Text inside Openlayers popups becomes selectable again (previously not possible).
Solved by pushing user-select attribute change down from .mb-element-map to a nested .olLayerDiv selector.

This fixes internal ticket #8068.
