### PR TITLE
remove 'move' check on click event

### DIFF
--- a/src/Mapbender/MobileBundle/Resources/public/js/mapbender.mobile.js
+++ b/src/Mapbender/MobileBundle/Resources/public/js/mapbender.mobile.js
@@ -115,9 +115,8 @@ $(function(){
         });
     });
 
-    $('.search-results').on('click', function(){
-        if(moved){
-            moved = false;
+    $('.search-results').on('click', function(e){
+        if(e.target.nodeName =="TD"){
             $('#mobilePaneClose').click();
         }
     });


### PR DESCRIPTION
fixes #548

edited event listener for searchroutrer result click only on mobile template.

now the search overlay closes if the user clicks an an search-result

