### PR TITLE
Hotfix/featureinfo translation for print button mb.core.featureinfo.popup.btn.print

### DIFF
--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -110,10 +110,7 @@ class FeatureInfo extends Element
             'css' => array(
                 '@MapbenderCoreBundle/Resources/public/sass/element/featureinfo.scss'
             ),
-            'trans' => array(
-                'MapbenderCoreBundle:Element:featureinfo.json.twig',
-                'MapbenderCoreBundle:Element:printclient.json.twig'
-            )
+            'trans' => array('MapbenderCoreBundle:Element:featureinfo.json.twig')
         );
     }
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -413,7 +413,7 @@
                     if (options.printResult === true) {
                         widget.popup.addButtons({
                             'print': {
-                                label: Mapbender.trans('mb.core.printclient.popup.btn.ok'),
+                                label: Mapbender.trans('mb.core.featureinfo.popup.btn.print'),
                                 cssClass: 'button right',
                                 callback: function() {
                                     widget._printContent();

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -8,6 +8,7 @@ mb:
       popup:
         btn:
           ok: Schließen
+          print: Drucken
       class:
         title: Information
         description: Information

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,7 @@ mb:
       popup:
         btn:
           ok: Close
+          print: Print
       class:
         title: FeatureInfo
         description: FeatureInfo

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.es.yml
@@ -8,6 +8,7 @@ mb:
       popup:
         btn:
           ok: Cerrar
+          print: Imprimir
       class:
         title: FeatureInfo
         description: FeatureInfo

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yml
@@ -8,6 +8,7 @@ mb:
       popup:
         btn:
           ok: Fechar
+          print: Imprimir
       class:
         title: Informação
         description: Informação

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yml
@@ -8,6 +8,7 @@ mb:
       popup:
         btn:
           ok: Закрыть
+          print: Печать
       class:
         title: Инфосвойства
         description: Инфосвойства

--- a/src/Mapbender/CoreBundle/Resources/views/Element/featureinfo.json.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/featureinfo.json.twig
@@ -1,6 +1,7 @@
 {
 "mb.core.metadata.popup.title": "{{ "mb.core.metadata.popup.title" | trans }}",
 "mb.core.featureinfo.popup.btn.ok": "{{ "mb.core.featureinfo.popup.btn.ok" | trans }}",
+"mb.core.featureinfo.popup.btn.print": "{{ "mb.core.featureinfo.popup.btn.print" | trans }}",
 "mb.core.featureinfo.error.nolayer": "{{"mb.core.featureinfo.error.nolayer" | trans}}",
 "mb.core.featureinfo.error.noresult": "{{"mb.core.featureinfo.error.noresult" | trans}}"
 }


### PR DESCRIPTION
…esult

ticket #552 was already fixed with https://github.com/mapbender/mapbender/commit/d11dd2fd1bde139225a388ddb6d125cb24562260

Due to modularisation this solution may be better. Does not need  'MapbenderCoreBundle:Element:printclient.json.twig' in  src/Mapbender/CoreBundle/Element/FeatureInfo.php