### PR TITLE
added EPSG:4839 and EPSG:5243 to the list

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/proj4/proj4js_epsg.txt
+++ b/src/Mapbender/CoreBundle/Resources/proj4/proj4js_epsg.txt
@@ -2452,6 +2452,8 @@
   EPSG:4812|New Beijing / 3-degree Gauss-Kruger CM 132E|+proj=tmerc +lat_0=0 +lon_0=132 +k=1 +x_0=500000 +y_0=0 +ellps=krass +units=m +no_defs
   EPSG:4822|New Beijing / 3-degree Gauss-Kruger CM 135E|+proj=tmerc +lat_0=0 +lon_0=135 +k=1 +x_0=500000 +y_0=0 +ellps=krass +units=m +no_defs
   EPSG:4826|WGS 84 / Cape Verde National|+proj=lcc +lat_1=15 +lat_2=16.66666666666667 +lat_0=15.83333333333333 +lon_0=-24 +x_0=161587.83 +y_0=128511.202 +datum=WGS84 +units=m +no_defs
+  EPSG:4839|ETRS89 / LCC Germany (N-E)|+proj=lcc +lat_1=48.66666666666666 +lat_2=53.66666666666666 +lat_0=51 +lon_0=10.5 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+  EPSG:5243|ETRS89 / LCC Germany (E-N)|+proj=lcc +lat_1=48.66666666666666 +lat_2=53.66666666666666 +lat_0=51 +lon_0=10.5 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
   EPSG:20004|Pulkovo 1995 / Gauss-Kruger zone 4|+proj=tmerc +lat_0=0 +lon_0=21 +k=1 +x_0=4500000 +y_0=0 +ellps=krass +towgs84=24.82,-131.21,-82.66,-0,-0,0.16,-0.12 +units=m +no_defs
   EPSG:20005|Pulkovo 1995 / Gauss-Kruger zone 5|+proj=tmerc +lat_0=0 +lon_0=27 +k=1 +x_0=5500000 +y_0=0 +ellps=krass +towgs84=24.82,-131.21,-82.66,-0,-0,0.16,-0.12 +units=m +no_defs
   EPSG:20006|Pulkovo 1995 / Gauss-Kruger zone 6|+proj=tmerc +lat_0=0 +lon_0=33 +k=1 +x_0=6500000 +y_0=0 +ellps=krass +towgs84=24.82,-131.21,-82.66,-0,-0,0.16,-0.12 +units=m +no_defs


### PR DESCRIPTION
See ticket #562 

Checked the EPSG Codes
- 4326 Geographisch, weltweit:
- 25832 ETRS89 / UTM zone 32N und 33N:
- 25833 ETRS89 / UTM zone 32N und 33N:
- 31466 Gauß-Krüger Zonen 2 bis 5:
- 31467 Gauß-Krüger Zonen 2 bis 5:
- 31468 Gauß-Krüger Zonen 2 bis 5:
- 31469 Gauß-Krüger Zonen 2 bis 5:
- 3044 ETRS89 / UTM zone 32N und 33N
- 3045 ETRS89 / UTM zone 32N und 33N
- 5243 ETRS89 / LCC Germany (Lambert) E-N und N-E
- 4839 ETRS89 / LCC Germany (Lambert) E-N und N-E
- 3857 WGS 84 / Pseudo-Mercator -- Spherical Mercator
- 31254 MGI Austria GK West
- 31255 MG Austria GK Central
- 31256 MG Austria GK East
- 3035 ETRS89 / LAEA
- 25832 ETRS89 / UTM zone 32N
- 3068 DHDN / Soldner Berlin

and added the missing ones.

Please delete the branch after merge. Thanks.