### PR TITLE
Replace usort => array_multisort to skip around PHP bug #50688 (MB3 #586)

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
@@ -128,14 +128,17 @@ class TargetElementType extends AbstractType
 
             public function buildView(FormView $view, FormInterface $form, array $options)
             {
-                $choices = $view->vars['choices'];
+                /** @var \Symfony\Component\Translation\TranslatorInterface $translator */
                 $translator = $this->container->get('translator');
-
-                usort($choices,
-                      function($a, $b) use ($translator) {
-                    return strcasecmp($translator->trans($a->label), $translator->trans($b->label));
-                });
-                $view->vars = array_replace($view->vars, array('choices' => $choices));
+                $translatedLcLabels = array_map(function($element) use ($translator) {
+                    $transLabel = $translator->trans($element->label);
+                    // sorting should be case-insensitive
+                    return mb_strtolower($transLabel);
+                    }, $view->vars['choices']);
+                // we use array_multisort instead of usort to avoid a bug in many
+                // PHP5.x versions
+                // see https://bugs.php.net/bug.php?id=50688
+                array_multisort($view->vars['choices'], $translatedLcLabels);
             }
 
         }


### PR DESCRIPTION
See #586.
This patch replaces usort with array_multisort.

Sorting still functions as expected (observe value ordering in "Type" dropdown of newly created Button element).

It may be worth hunting for similar usort usages in the code and also update them.