### PR TITLE
URL signer spoof hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * **v.3.0.6.3**
     - Fix WMS with Scale fails to load #584 - see commit message #2783540 for more information
+    - Fix possible URL signing spoof with input URLs missing query parameters (internal issue #8375)
 
 * **v.3.0.6.2** - 2017-07-20
     - Fix create legend URL


### PR DESCRIPTION
See internal ticket 8375.

Previously, url signing was not properly handling service URLs with no question mark (before query params). The detected base url length was sometimes 0, allowing client-side URL tampering using the same signature.

Changes in this PR enforce that with any given signature, only requests with the same scheme, host and path will pass signature validation. Client code needs to remain able to modify request type, bbox etc on map services, so enforcing same full url would be too strict.

This branch looks equally mergable on the release/3.0.7 branch.