### PR TITLE
WmcParser: small fix to set version parameter in map requests

### DIFF
--- a/src/Mapbender/WmcBundle/Component/WmcParser110.php
+++ b/src/Mapbender/WmcBundle/Component/WmcParser110.php
@@ -242,7 +242,8 @@ class WmcParser110 extends WmcParser
         $options = new WmsInstanceConfigurationOptions();
         $options->setUrl($wms->getGetMap()->getHttpGet())
             ->setVisible($wmsinst->getVisible())
-            ->setFormat($wmsinst->getFormat());
+            ->setFormat($wmsinst->getFormat())
+            ->setVersion($wms->getVersion());
 
         $extensionEl = $this->getValue("./cntxt:Extension", $layerElm);
         $layerList = null;


### PR DESCRIPTION
Fix to parse WMC documents from Xml files correctly.
There was a default version parameter before, but it doesn't work anymore. :-(