### PR TITLE
Fix/element inheritance 639 [restore BC]

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -658,7 +658,10 @@ abstract class Element
      *
      * By default, inheritance is enabled.
      * If you want to control this inheritance fine-grained, see the static $inheritedFromParent attribute.
-     * If you just want to replace one of the values, implement the getType
+     * If you just want to replace one of the values, reimplement the getType, getFormTemplate, getHtmlTemplatePath
+     * methods.
+     * If you want your values to be automatically calculated but NOT inherited from the parent, adjust the
+     * value of the $inheritedFromParent static property accordingly.
      *
      * @param string $what see above for valid values
      * @return bool

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -368,10 +368,10 @@ abstract class Element
      *************************************************************************/
 
     /**
-     * Get the element configuration form type.
+     * Get the element configuration form type. By default, this class needs to have the same name
+     * as the element, suffixed with "AdminType" and located in the Element\Type sub-namespace.
      *
-     * Override this method to provide a custom configuration form instead of
-     * the default YAML form.
+     * Override this method and return null to get a simple YAML entry form.
      *
      * @return string Administration type class name
      */

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -343,6 +343,29 @@ abstract class Element
      *************************************************************************/
 
     /**
+     * Walk up through the class hierarchy and return the name of the first-generation child class immediately
+     * inheriting from the abstract Element
+     *
+     * @return string
+     */
+    protected static function getBaseClassName()
+    {
+        $delegateClass = get_called_class();
+        $abstractRoot = __CLASS__;      // == Mapbender\CoreBundle\Component\Element
+        while (is_subclass_of($delegateClass, $abstractRoot, true)) {
+            $parentClass = get_parent_class($delegateClass);
+            if (is_subclass_of($parentClass, $abstractRoot, true)) {
+                // parent is still not abstract, good to delegate calls to
+                $delegateClass = $parentClass;
+            } else {
+                // we're down to abstract element, stop and keep delegateClass on the first-level child class
+                break;
+            }
+        }
+        return $delegateClass;
+    }
+
+    /**
      * Get the element configuration form type.
      *
      * Override this method to provide a custom configuration form instead of
@@ -352,7 +375,8 @@ abstract class Element
      */
     public static function getType()
     {
-        $clsInfo = explode('\\', get_called_class());
+
+        $clsInfo = explode('\\', static::getBaseClassName());
         return $clsInfo[0] . '\\' . $clsInfo[1] . '\\' . $clsInfo[2] . '\\Type\\' . $clsInfo[3] . 'AdminType';
     }
 
@@ -363,7 +387,7 @@ abstract class Element
      */
     public static function getFormTemplate()
     {
-        $clsInfo = explode('\\', get_called_class());
+        $clsInfo = explode('\\', static::getBaseClassName());
         return $clsInfo[0] .  $clsInfo[1] . ':' . $clsInfo[2] . 'Admin:' . static::getTemplateName($clsInfo[3]) . '.html.twig';
     }
 


### PR DESCRIPTION
See #639 
This may seem like a lot of code, because it is.

This addresses a BC break somewhere in the 3.0.5 timeline where Elements inheriting from each other would at some point require `getType`, `getFormTemplate`, potentially `render` re-implementations, because automagically calculated template paths and admin types would be different from the earlier (always explicit) values coded into each element.

The motivation for that refactoring was to get rid of endless c&p of the three methods mentioned above.

This pull kind of "concludes" that work. C&P is not necessary for new elements inheriting directly from Element, and no necessity exists to override methods in child classes of concrete elements either, if the (intuitive) inheritance of AdminType and templates is desired. Old-style overrides (just reimplementing any or all of the methods) still works on this branch. Only the automatically generated values are affected at all.

Because this was already a BC break, and this pull is supposed to reestablish BC, its merge target is 3.0.5.

One issue was that there has not been a method to get the template path for the frontend. This logic was so far hard-embedded into the render method(s), and I assume a lot of C&Ping of that render method has been going on for that reason alone that makes it hard to analyze.
To cover all potential cases, I included some fine-grained configurability of which of the automagically calculated values exactly should be inherited from the parent element.
This should support all sorts of mixed cases (inherit automatic AdminType but not automatic frontend template path, inherit frontend template but not admin type etc).

If there are no such complex use cases this configurability could be stripped back to make for a more concise pull.

To see exactly what's happening, the (not included) Omg639Command code from the original issue #639 may be a good starting point.