### PR TITLE
Change visibility of some fields in WmsLayerSource and Wmc Entites

### DIFF
--- a/src/Mapbender/WmcBundle/Entity/Wmc.php
+++ b/src/Mapbender/WmcBundle/Entity/Wmc.php
@@ -57,13 +57,13 @@ class Wmc
      * @var LegendUrl A description url
      * @ORM\Column(type="object", nullable=true)
      */
-    public $logourl;
+    protected $logourl;
 
     /**
      * @var OnlineResource A description url
      * @ORM\Column(type="object", nullable=true)
      */
-    public $descriptionurl;
+    protected $descriptionurl;
 
     /**
      * @var string $screenshotPath The wmc description

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -87,12 +87,10 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * @ORM\Column(type="object", nullable=true)
      */
-
     protected $latlonBounds;
     /**
      * @ORM\Column(type="array", nullable=true)
      */
-
     protected $boundingBoxes;
     /**
      * @ORM\Column(type="array", nullable=true)
@@ -105,27 +103,22 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * @ORM\Column(type="object",nullable=true)
      */
-
     protected $scale;
     /**
      * @ORM\Column(type="object",nullable=true)
      */
-
     protected $scaleHint;
     /**
      * @ORM\Column(type="object", nullable=true)
      */
-
     protected $attribution;
     /**
      * @ORM\Column(type="array",nullable=true)
      */
-
     protected $identifier;
     /**
      * @ORM\Column(type="array",nullable=true)
      */
-
     protected $authority;
     /**
      * @ORM\Column(type="array", nullable=true)

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -87,13 +87,13 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * @ORM\Column(type="object", nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $latlonBounds;
+
+    protected $latlonBounds;
     /**
      * @ORM\Column(type="array", nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $boundingBoxes;
+
+    protected $boundingBoxes;
     /**
      * @ORM\Column(type="array", nullable=true)
      */
@@ -105,28 +105,28 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * @ORM\Column(type="object",nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $scale;
+
+    protected $scale;
     /**
      * @ORM\Column(type="object",nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $scaleHint;
+
+    protected $scaleHint;
     /**
      * @ORM\Column(type="object", nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $attribution;
+
+    protected $attribution;
     /**
      * @ORM\Column(type="array",nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $identifier;
+
+    protected $identifier;
     /**
      * @ORM\Column(type="array",nullable=true)
      */
-    //@TODO Doctrine bug: "protected" replaced with "public"
-    public $authority;
+
+    protected $authority;
     /**
      * @ORM\Column(type="array", nullable=true)
      */


### PR DESCRIPTION
Some fields in both entities had the visibility set to protected as a workaround for some prehistoric doctrine bug. But with these visibilities the entities are invalid and doctrine:schema:validate would fail and you could not create a new db with the console commands. The doctrine bug is now fixed, so we can change the visibility to the correct protected value.