### PR TITLE
PrintClient - fixed feature exists

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -456,13 +456,13 @@ class PrintService
 
                         // fill digitizer feature fields
                         if(preg_match("/^feature./", $k)){
-                            if($feature == false){
+                            if(!isset($feature) OR $feature == false){
                                 continue;
                             }
                             $attribute = substr(strrchr($k, "."), 1);
                             $pdf->MultiCell($this->conf['fields'][$k]['width'],
                                 $this->conf['fields'][$k]['height'],
-                                $feature->getAttribute($attribute));
+                                utf8_decode($feature->getAttribute($attribute)));
                         }
                         break;
                 }


### PR DESCRIPTION
* if the template with feature is defined and the template is used in a use case without an feature an error occurs
* the pull request checks this and prevents the error
* in combination with https://github.com/mapbender/mapbender/pull/691
* see ticket #692