### PR TITLE
Feature/reversible layer order

### DIFF
--- a/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
+++ b/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
@@ -9,30 +9,27 @@ namespace Mapbender\CoreBundle\Component;
 abstract class InstanceConfiguration
 {
     /**
-     * ORM\Column(type="string", nullable=true)
      * @var string
      */
     public $type;
 
     /**
-     * ORM\Column(type="string", nullable=ture)
      * @var string
      */
     public $title;
 
     /**
-     * ORM\Column(type="text", nullable=true)
-     * @var string
+     * @var InstanceConfigurationOptions
      */
     public $options;
 
     /**
-     * ORM\Column(type="text", nullable=false)
+     * @var array
      */
     public $children;
     
     /**
-     * ORM\Column(type="boolean", nullable=false)
+     * @var boolean
      */
     public $isBaseSource = true;
 
@@ -41,7 +38,6 @@ abstract class InstanceConfiguration
      */
     public function __construct()
     {
-        $this->options = array();
         $this->children = array();
     }
 
@@ -122,7 +118,7 @@ abstract class InstanceConfiguration
     /**
      * Returns options
      * 
-     * @return string
+     * @return InstanceConfigurationOptions|null
      */
     public abstract function getOptions();
 
@@ -137,7 +133,7 @@ abstract class InstanceConfiguration
     /**
      * Returns a title
      * 
-     * @return integer children
+     * @return array children
      */
     public abstract function getChildren();
     

--- a/src/Mapbender/CoreBundle/Component/SourceMetadata.php
+++ b/src/Mapbender/CoreBundle/Component/SourceMetadata.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Mapbender\CoreBundle\Component;
+
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * Class SourceMetadata prepares and renders an OGC Service metadata
@@ -343,7 +346,7 @@ abstract class SourceMetadata
 
     /**
      * Renders the SourceMetadata.
-     * @param boolean $templating
+     * @param EngineInterface $templating
      * @param integer $itemName unic item name
      */
     abstract public function render($templating, $itemName);

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -113,4 +113,15 @@ class WmsInstanceConfiguration extends InstanceConfiguration
         return $wmsconf;
     }
 
+    /**
+     * Helper method that converts an entity to its array representation
+     * @todo: this probably belongs directly in the entity
+     *
+     * @param WmsInstance $entity
+     * @return array
+     */
+    public static function entityToArray($entity)
+    {
+        return static::fromEntity($entity)->toArray();
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -4,6 +4,7 @@ namespace Mapbender\WmsBundle\Component;
 
 use Mapbender\CoreBundle\Component\InstanceConfiguration;
 use Mapbender\CoreBundle\Component\InstanceConfigurationOptions;
+use Mapbender\WmsBundle\Entity\WmsInstance;
 
 /**
  * Description of WmsInstanceConfiguration
@@ -91,6 +92,25 @@ class WmsInstanceConfiguration extends InstanceConfiguration
             }
         }
         return $ic;
+    }
+
+    /**
+     * Factory method that populates new instance from given entity
+     *
+     * @param WmsInstance $entity
+     * @return static
+     */
+    public static function fromEntity($entity)
+    {
+        $wmsconf = new static();
+
+        $wmsconf->setType(strtolower($entity->getType()));
+        $wmsconf->setTitle($entity->getTitle());
+        $wmsconf->setIsBaseSource($entity->isBasesource());
+        $options = WmsInstanceConfigurationOptions::fromEntity($entity);
+        $wmsconf->setOptions($options);
+
+        return $wmsconf;
     }
 
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
@@ -396,29 +396,29 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
                 }
             }
         }
-        $vendorsecifics = array();
+        $vendorspecifics = array();
         foreach ($entity->getVendorspecifics() as $key => $vendorspec) {
             $handler = new VendorSpecificHandler($vendorspec);
             /* add to url only simple vendor specific with valid default value */
             if ($vendorspec->getVstype() === VendorSpecific::TYPE_VS_SIMPLE && $handler->isVendorSpecificValueValid()) {
-                $vendorsecifics[] = $handler->getConfiguration();
+                $vendorspecifics[] = $handler->getConfiguration();
                 $help             = $handler->getKvpConfiguration(null);
                 $options->setUrl(UrlUtil::validateUrl($options->getUrl(), $help, array()));
             }
         }
 
         $bboxes = $entity->getRootLayer()->getSourceItem()->getMergedBboxes();
-        // reformat bboxes to coordinate arrays keyed on SRS
-        $bboxesOut = array();
+        // reformat bboxes to coordinate arrays, keyed on SRS
+        // @todo: when the same SRS comes up again, calculate the minimum box (current: last occurence per SRS wins)
+        $bboxArrays = array();
         foreach ($bboxes as $bbox) {
-            $bboxesOut[$bbox->getSrs()] = array(
+            $bboxArrays[$bbox->getSrs()] = array(
                 floatval($bbox->getMinx()),
                 floatval($bbox->getMiny()),
                 floatval($bbox->getMaxx()),
                 floatval($bbox->getMaxy()),
             );
         }
-
 
         $options->setProxy($entity->getProxy())
             ->setVisible($entity->getVisible())
@@ -427,11 +427,11 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             ->setTransparency($entity->getTransparency())
             ->setOpacity($entity->getOpacity() / 100)
             ->setTiled($entity->getTiled())
-            ->setBbox($bboxesOut)
+            ->setBbox($bboxArrays)
             ->setDimensions($dimensions)
             ->setBuffer($entity->getBuffer())
             ->setRatio($entity->getRatio())
-            ->setVendorspecifics($vendorsecifics)
+            ->setVendorspecifics($vendorspecifics)
             ->setVersion($entity->getSource()->getVersion())
             ->setExceptionformat($entity->getExceptionformat());
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
@@ -68,6 +68,9 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
      * ORM\Column(type="decimal", scale=2, options={"default" = 1.25})
      */
     public $ratio = 1.25;
+
+    /** @var  string */
+    public $layerOrder;
     
     /**
      * Returns a version
@@ -298,6 +301,24 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
     }
 
     /**
+     * @return string
+     */
+    public function getLayerOrder()
+    {
+        return $this->layerOrder;
+    }
+
+    /**
+     * @param string $layerOrder for valid values see WmsInstance constants LAYER_ORDER_...
+     * @return $this
+     */
+    public function setLayerOrder($layerOrder)
+    {
+        $this->layerOrder = $layerOrder;
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     public function toArray()
@@ -318,6 +339,7 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             "dimensions" => $this->dimensions,
             "buffer" => $this->buffer,
             "ratio" => $this->ratio,
+            "layerOrder" => $this->layerOrder,
         );
     }
 
@@ -370,6 +392,9 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             }
             if (isset($options["exception_format"])) {
                 $ico->exceptionformat = $options["exception_format"];
+            }
+            if (isset($options["layerOrder"])) {
+                $ico->setLayerOrder($options["layerOrder"]);
             }
         }
         return $ico;
@@ -433,7 +458,9 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             ->setRatio($entity->getRatio())
             ->setVendorspecifics($vendorspecifics)
             ->setVersion($entity->getSource()->getVersion())
-            ->setExceptionformat($entity->getExceptionformat());
+            ->setExceptionformat($entity->getExceptionformat())
+            ->setLayerOrder($entity->getLayerOrder())
+        ;
 
         return $options;
     }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\WmsBundle\Component;
 
+use Doctrine\ORM\EntityManager;
 use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Component\Signer;
 use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
@@ -157,6 +158,7 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         if ($this->entity->getRootlayer()) {
             self::createHandler($this->container, $this->entity->getRootlayer())->save();
         }
+        $layerSet = $this->entity->getLayerset();
         $num = 0;
         foreach ($this->entity->getLayerset()->getInstances() as $instance) {
             /** @var WmsInstanceEntityHandler $instHandler */
@@ -166,9 +168,12 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             $this->container->get('doctrine')->getManager()->persist($instHandler->getEntity());
             $num++;
         }
-        $this->container->get('doctrine')->getManager()->persist(
-            $this->entity->getLayerset()->getApplication()->setUpdated(new \DateTime('now')));
-        $this->container->get('doctrine')->getManager()->persist($this->entity);
+        $application = $layerSet->getApplication();
+        $application->setUpdated(new \DateTime('now'));
+        /** @var EntityManager $entityManager */
+        $entityManager = $this->container->get('doctrine')->getManager();
+        $entityManager->persist($application);
+        $entityManager->persist($this->entity);
     }
     
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -301,14 +301,7 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
      */
     public function generateConfiguration()
     {
-        $wmsconf = new WmsInstanceConfiguration();
-        $wmsconf->setType(strtolower($this->entity->getType()));
-        $wmsconf->setTitle($this->entity->getTitle());
-        $wmsconf->setIsBaseSource($this->entity->isBasesource());
-
-        $options = WmsInstanceConfigurationOptions::fromEntity($this->entity);
-
-        $wmsconf->setOptions($options);
+        $wmsconf = WmsInstanceConfiguration::fromEntity($this->entity);
         $persistableConfig = $wmsconf->toArray();
         $this->entity->setConfiguration($persistableConfig);
     }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -143,11 +143,33 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         $this->entity->setDimensions($dimensions);
 
         $this->entity->setWeight(-1);
+        $this->initializeLayerOrder($this->entity);
         $wmslayer_root = $this->entity->getSource()->getRootlayer();
 
         $newInstanceLayerHandler = new WmsInstanceLayerEntityHandler($this->container, new WmsInstanceLayer());
         $newInstanceLayerHandler->create($this->entity, $wmslayer_root);
     }
+
+    /**
+     * Populates the layer order of an (assumed) newly created WmsInstance
+     *
+     * @param WmsInstance $entity
+     */
+    public function initializeLayerOrder(WmsInstance $entity)
+    {
+        $layerOrderDefaultKey = 'wms.default_layer_order';
+        if ($this->container->hasParameter($layerOrderDefaultKey)) {
+            $configuredDefaultLayerOrder = $this->container->getParameter($layerOrderDefaultKey);
+            $entity->setLayerOrder($configuredDefaultLayerOrder);
+        }
+        /**
+         * NOTE: the entity has a built-in default, so new instances will work fine even without setting
+         *       layer order explicitly
+         * @see WmsInstance::getLayerOrder()
+         */
+
+    }
+
 
     /**
      * @inheritdoc

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -2,7 +2,6 @@
 namespace Mapbender\WmsBundle\Component;
 
 use Doctrine\ORM\EntityManager;
-use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Component\Signer;
 use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
 use Mapbender\CoreBundle\Entity\Source;
@@ -301,9 +300,7 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
      */
     public function generateConfiguration()
     {
-        $wmsconf = WmsInstanceConfiguration::fromEntity($this->entity);
-        $persistableConfig = $wmsconf->toArray();
-        $this->entity->setConfiguration($persistableConfig);
+        $this->entity->updateConfiguration();
     }
 
     protected function getRootLayerConfig()

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -237,27 +237,16 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             "minScale" => $this->entity->getMinScale() !== null ? floatval($this->entity->getMinScale()) : null,
             "maxScale" => $this->entity->getMaxScale() !== null ? floatval($this->entity->getMaxScale()) : null
         );
-        /*
-        $srses = array();
-        $llbbox = $this->entity->getSourceItem()->getLatlonBounds();
-        if ($llbbox !== null) {
-            $srses[$llbbox->getSrs()] = array(
-                floatval($llbbox->getMinx()),
-                floatval($llbbox->getMiny()),
-                floatval($llbbox->getMaxx()),
-                floatval($llbbox->getMaxy())
-            );
-        }
-        foreach ($this->entity->getSourceItem()->getBoundingBoxes() as $bbox) {
-            $srses[$bbox->getSrs()] = array(
+        $configuration['bbox'] = array();
+        $bboxes = $this->entity->getSourceItem()->getMergedBboxes();
+        foreach ($bboxes as $bbox) {
+            $configuration['bbox'][$bbox->getSrs()] = array(
                 floatval($bbox->getMinx()),
                 floatval($bbox->getMiny()),
                 floatval($bbox->getMaxx()),
                 floatval($bbox->getMaxy())
             );
         }
-        */
-        $configuration['bbox'] = $this->entity->getSourceItem()->getMergedBboxes();
         $styles = $this->entity->getSourceItem()->getStyles();
         if ($styles) {
             $legendurl = $styles[count($styles) - 1]->getLegendUrl(); // the last style from object's styles

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -157,9 +157,9 @@ class RepositoryController extends Controller
                 return $this->redirect($this->generateUrl("mapbender_manager_repository_new", array(), true));
             }
             $wmsWithSameTitle = $this->getRepository("MapbenderWmsBundle:WmsSource")
-                ->findByTitle($wmssource->getTitle());
+                ->findBy(array('title' => $wmssource->getTitle()));
 
-            if (count($wmsWithSameTitle) > 0) {
+            if ($wmsWithSameTitle) {
                 $wmssource->setAlias(count($wmsWithSameTitle));
             }
             $this->getDoctrine()->getManager()->getConnection()->beginTransaction();
@@ -333,7 +333,7 @@ class RepositoryController extends Controller
     {
         $wmssource    = $this->loadEntityByPk("MapbenderWmsBundle:WmsSource", $sourceId);
         $wmsinstances = $this->getRepository("MapbenderWmsBundle:WmsInstance")
-            ->findBySource($sourceId);
+            ->findBy(array('source' => $sourceId));
         $em           = $this->getDoctrine()->getManager();
         $em->getConnection()->beginTransaction();
 

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\WmsBundle\Component\DimensionInst;
 use Mapbender\WmsBundle\Component\VendorSpecific;
+use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -577,4 +578,13 @@ class WmsInstance extends SourceInstance
     {
         return new WmsMetadata($this);
     }
+
+    /**
+     * Recalculates the "configuration" array attribute
+     */
+    public function updateConfiguration()
+    {
+        $this->configuration = WmsInstanceConfiguration::entityToArray($this);
+    }
+
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -105,6 +105,14 @@ class WmsInstance extends SourceInstance
      */
     protected $ratio = 1.25;
 
+    const LAYER_ORDER_TOP_DOWN  = 'standard';
+    const LAYER_ORDER_BOTTOM_UP = 'reverse';
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $layerOrder;
+
     /**
      * WmsInstance constructor.
      */
@@ -577,6 +585,43 @@ class WmsInstance extends SourceInstance
     public function getMetadata()
     {
         return new WmsMetadata($this);
+    }
+
+    /**
+     * @return string
+     */
+    public function getLayerOrder()
+    {
+        // NOTE: this is a recently added column; there will be NULLs in the DB for updated applications
+        //       we convert these NULLs to our desired default (not the default for new instances, which can
+        //       be configured)
+        //       the layerOrder column will be properly populated when instances are saved
+        return $this->layerOrder ?: self::LAYER_ORDER_TOP_DOWN;
+    }
+
+    /**
+     * @param string $value use "conformant" or "traditional" (see consts)
+     * @return $this
+     * @throws \InvalidArgumentException if $value is not one of the expected values
+     */
+    public function setLayerOrder($value)
+    {
+        if (!in_array($value, $this->validLayerOrderChoices())) {
+            throw new \InvalidArgumentException("Invalid layer order value '$value'");
+        }
+        $this->layerOrder = $value;
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function validLayerOrderChoices()
+    {
+        return array(
+            self::LAYER_ORDER_TOP_DOWN,
+            self::LAYER_ORDER_BOTTOM_UP,
+        );
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -5,6 +5,8 @@ namespace Mapbender\WmsBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\WmsBundle\Component\DimensionInst;
+use Mapbender\WmsBundle\Component\VendorSpecific;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -136,7 +138,7 @@ class WmsInstance extends SourceInstance
     /**
      * Returns dimensions
      *
-     * @return array of DimensionIst
+     * @return DimensionInst[]
      */
     public function getDimensions()
     {
@@ -146,7 +148,7 @@ class WmsInstance extends SourceInstance
     /**
      * Sets dimensions
      *
-     * @param array $dimensions array of DimensionIst
+     * @param DimensionInst[] $dimensions
      * @return \Mapbender\WmsBundle\Entity\WmsInstance
      */
     public function setDimensions(array $dimensions)
@@ -156,7 +158,7 @@ class WmsInstance extends SourceInstance
     }
 
     /**
-     * @return VendorSpecific[]|DimensionInst[]
+     * @return VendorSpecific[]
      */
     public function getVendorspecifics()
     {
@@ -169,7 +171,8 @@ class WmsInstance extends SourceInstance
 
     /**
      * Sets vendorspecifics
-     * @param ArrayCollection $vendorspecifics array of DimensionIst
+     *
+     * @param VendorSpecific[] $vendorspecifics
      * @return \Mapbender\WmsBundle\Entity\WmsInstance
      */
     public function setVendorspecifics(array $vendorspecifics)
@@ -527,7 +530,7 @@ class WmsInstance extends SourceInstance
     /**
      * Add layers
      *
-     * @param WmsInstanceLayer $layers
+     * @param WmsInstanceLayer $layer
      * @return WmsInstance
      */
     public function addLayer(WmsInstanceLayer $layer)

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -566,4 +566,13 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         return (string) $this->getId();
     }
+
+    /**
+     * @return boolean
+     */
+    public function isRoot()
+    {
+        return !$this->getParent();
+    }
+
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -1059,4 +1059,21 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     {
         return (string)$this->id;
     }
+
+    /**
+     * Returns a filtered array containing both the `latlonBounds` and boundingBox list (empty elements ommitted)
+     * @todo: add an $inherit param for forwarding to getLatlonBounds?
+     *
+     * @return BoundingBox[]
+     */
+    public function getMergedBboxes()
+    {
+        $bboxes = array();
+
+        $latlonBounds = $this->getLatlonBounds();
+        if ($latlonBounds) {
+            $bboxes[] = $latlonBounds;
+        }
+        return array_merge($bboxes, $this->getBoundingBoxes());
+    }
 }

--- a/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
@@ -2,6 +2,7 @@
 
 namespace Mapbender\WmsBundle\Form\Type;
 
+use Mapbender\WmsBundle\Entity\WmsInstance;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -109,5 +110,16 @@ class WmsInstanceInstanceLayersType extends AbstractType
                 'options' => array(
                     'data_class' => 'Mapbender\WmsBundle\Entity\WmsInstanceLayer',
                     'num_layers' => count($wmsinstance->getLayers()))));
+
+        $layerOrderChoices = array();
+        foreach (WmsInstance::validLayerOrderChoices() as $validChoice) {
+            $translationKey = "mb.wms.wmsloader.repo.instance.label.layerOrder.$validChoice";
+            $layerOrderChoices[$validChoice] = $translationKey;
+        }
+        $builder->add('layerOrder', 'choice', array(
+            'choices' => $layerOrderChoices,
+            'required' => true,
+            'auto_initialize' => true,
+        ));
     }
 }

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
@@ -80,8 +80,8 @@ mb:
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
             layerOrder: Layer-Reihenfolge
-            layerOrder.standard: Standard (v. oben nach unten)
-            layerOrder.reverse: Umgekehrt (v. unten nach oben)
+            layerOrder.standard: Standard (umgekehrt)
+            layerOrder.reverse: QGIS Style (gleiche Reihenfolge)
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
@@ -79,6 +79,9 @@ mb:
             cancel2: Abbrechen
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
+            layerOrder: Layer-Reihenfolge
+            layerOrder.standard: Standard (v. oben nach unten)
+            layerOrder.reverse: Umgekehrt (v. unten nach oben)
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
@@ -79,6 +79,9 @@ mb:
             cancel2: Cancel
             ratio: 'BBOX factor'
             buffer: 'Tile buffer'
+            layerOrder: Layer ordering
+            layerOrder.standard: standard (top-down)
+            layerOrder.reverse: reverse (bottom-up)
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
@@ -80,8 +80,8 @@ mb:
             ratio: 'BBOX factor'
             buffer: 'Tile buffer'
             layerOrder: Layer ordering
-            layerOrder.standard: standard (top-down)
-            layerOrder.reverse: reverse (bottom-up)
+            layerOrder.standard: standard
+            layerOrder.reverse: QGIS
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
@@ -69,6 +69,10 @@
         {{ form_widget(form.tiled) }}<label for="{{form.tiled.vars.id}}" class="labelCheck">{{"mb.wms.wmsloader.repo.instance.label.tiled"|trans}}</label>
         </div>
         <div class="clear"></div>
+        <div class="left">
+          {{ form_label(form.layerOrder, 'mb.wms.wmsloader.repo.instance.label.layerOrder', {}) }}{{ form_widget(form.layerOrder) }}
+        </div>
+        <div class="clear"></div>
       </div>
       <div class="extendedGroup">
         {% if form.dimensions is not null and form.dimensions | length > 0 %}


### PR DESCRIPTION
To solve issue #554 

**THIS REQUIRES A DATABASE SCHEMA UPDATE** because it adds a column to mb_wms_wmsinstance.
```$ app/console doctrine:schema:update --force```

(use the same command if / after you leave this feature branch, then the new column will be dropped again)

Pull adds layer rendering order reversal, controllable by the admin on a per-layerset instance basis.
Default behavior is the same as before. 

There's a new dropdown in the backend (via application => edit => Layersets tab => add or edit instance).
Dropdown label and value labels are translated for DE and EN locales, see WmsBundle/Resources/translations/messages.*.yml.

The default layer order for existing instances is fixed to the old behavior, so running installations can be upgraded with no change on ordering for existing layersets.
The default layer order for **new** instances can be configured in parameters.yml (not included here, but see below).



Open Tasks: Changelog, User Documentation, parameters.yml.dist extension (external; goes into mapbender-starter)

For parameters.yml.dist, I have the following suggestion (tested)
```
    # default layer order when creating *new* WMS layerset instances
    # allowed values are either
    # * "standard": top-down rendering in GetCapabilities order; also the default if this parameter is not defined
    # * "reverse": bottom-up, for QGIS server, ArcGIS etc
    wms.default_layer_order: standard
```