### PR TITLE
HTMLElement: handle Twig exceptions, log a warning

### DIFF
--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle\Element;
 
 use Doctrine\DBAL\Connection;
 use Mapbender\CoreBundle\Component\Element;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -189,5 +190,25 @@ class HTMLElement extends Element
             }
         }
         return $assets;
+    }
+
+    /**
+     * Render markup.
+     * Because the entire template is user-configurable, we add some error handling here.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        /** @var LoggerInterface $logger */
+        $logger = $this->container->get('logger');
+
+        try {
+            return parent::render();
+        } catch (\Twig_Error $e) {
+            $message = "Invalid content in " . get_class($this) . " caused " . get_class($e);
+            $logger->warning($message . ", suppressing content", $this->getConfiguration());
+            return "<div id=\"{$this->getEntity()->getId()}\"><!-- $message --></div>";
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #707

If the user-editable content of the HTML element is broken enough to cause a Twig error, we log a warning, and fill the element div with a little HTML comment summarizing the error.
The rest of the application remains functional.