### PR TITLE
Move layer menu out of button to fix event flow

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -890,7 +890,7 @@
                 }
 
                 menu.removeClass('hidden');
-                $element.append(menu);
+                $element.after(menu);
                 $(menu).on('mousedown mousemove', function(e) {
                     e.stopPropagation();
                 });


### PR DESCRIPTION
Fixes issue #709

Layer menu moves in the DOM. It's now a sibling instead of a child of the layer-menu-btn.

Embedded checkboxes (e.g. layer dimensions) become functional again.