### PR TITLE
Feature/repeatable cli print

### DIFF
--- a/src/Mapbender/PrintBundle/Command/RunJobCommand.php
+++ b/src/Mapbender/PrintBundle/Command/RunJobCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Command;
+
+use Mapbender\PrintBundle\Component\PrintService;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+
+/**
+ * Class JobCommand
+ *
+ * @package   Mapbender\PrintBundle\Component
+ * @author    Rolf Neuberger <rolf.neuberger@wheregroup.com>
+ * @copyright 2017 by WhereGroup GmbH & Co. KG
+ */
+class RunJobCommand extends ContainerAwareCommand
+{
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setDescription("Run a print job from a dumped job definition json or yaml")
+            ->setName('mapbender:print:runJob')
+            ->addArgument('inputFile', InputArgument::REQUIRED, 'JSON or YAML job file to load ("-" for stdin)')
+            ->addArgument('outputFile', InputArgument::REQUIRED, 'Output PDF file path')
+        ;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $jobArray = $this->getJobArray($input->getArgument('inputFile'));
+
+        // PrintService::doPrint returns the PDF body as a binary string
+        $service = new PrintService($this->getContainer());
+        $outputBody = $service->doPrint($jobArray);
+
+        $outputFileName= $input->getArgument('outputFile');
+        file_put_contents($outputFileName, $outputBody);
+        $outputSize = strlen($outputBody);
+        $output->writeln("$outputSize bytes written to $outputFileName");
+    }
+
+    /**
+     * Check if an option value is part of a limited choice set, and return it if it is. Otherwise throws.
+     * If $caseInsensitive (default), return value will be taken from the given $validValues as is.
+     *
+     * @param InputInterface $input
+     * @param string $optionName
+     * @param string[] $allowedChoices
+     * @param bool $caseInsensitive
+     * @return mixed
+     * @throws \InvalidArgumentException
+     */
+    protected function getChoiceOption(InputInterface $input, $optionName, $allowedChoices, $caseInsensitive=true)
+    {
+        $requestedMode = $input->getOption($optionName);
+        foreach ($allowedChoices as $validChoice) {
+            if ($caseInsensitive) {
+                $match = mb_strtolower($requestedMode) == mb_strtolower($validChoice);
+            } else {
+                $match = $requestedMode == $validChoice;
+            }
+            if ($match) {
+                return $validChoice;
+            }
+        }
+        throw new \InvalidArgumentException("Unsupported $optionName " . var_export($requestedMode, true));
+    }
+
+    /**
+     * @param $fileName
+     * @return mixed
+     * @throws ParseException
+     */
+    protected function getJobArray($fileName)
+    {
+        if ($fileName == '-') {
+            $body = file_get_contents('php://stdin');
+        } else {
+            $body = file_get_contents($fileName);
+        }
+        try {
+            $decoded = Yaml::parse($body);
+        } catch (ParseException $e) {
+            $decoded = json_decode($body, true);
+            if ($decoded === NULL) {
+                throw $e;
+            }
+        }
+        return $decoded;
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -26,8 +26,8 @@ class ImageExportService
     protected $urlHostPath;
     /** @var array */
     protected $data;
-    /** @var string[] */
-    protected $requests = array();
+    /** @var string[] plain WMS URLs */
+    protected $mapRequests = array();
 
     public function __construct($container)
     {
@@ -66,14 +66,14 @@ class ImageExportService
     public function export($content)
     {
         // Clean up internally modified / collected state
-        $this->requests = array();
+        $this->mapRequests = array();
         $this->data = json_decode($content, true);
 
         foreach ($this->data['requests'] as $i => $layer) {
             if ($layer['type'] != 'wms') {
                 continue;
             }
-            $this->requests[$i] = $layer['url'];
+            $this->mapRequests[$i] = $layer['url'];
         }
 
         if(isset($this->data['vectorLayers'])){
@@ -95,7 +95,7 @@ class ImageExportService
     private function getImages()
     {
         $temp_names = array();
-        foreach ($this->requests as $k => $url) {
+        foreach ($this->mapRequests as $k => $url) {
             
             $url = strstr($url, '&WIDTH', true);
             $width = '&WIDTH=' . $this->data['width'];

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -37,9 +37,16 @@ class ImageExportService
             }
         }
 
-        $this->getImages();
+        $imagePath = $this->getImages();
+        $this->emitImageToBrowser($imagePath);
+        unlink($imagePath);
     }
 
+    /**
+     * Collect and merge WMS tiles and vector layers into a PNG file.
+     *
+     * @return string path to merged PNG file
+     */
     private function getImages()
     {
         $temp_names = array();
@@ -144,8 +151,15 @@ class ImageExportService
         if (isset($this->data['vectorLayers'])) {
             $this->drawFeatures($finalImageName);
         }
+        return $finalImageName;
+    }
 
-        $finalImage = imagecreatefrompng($finalImageName);
+    /**
+     * @param string $imagePath
+     */
+    protected function emitImageToBrowser($imagePath)
+    {
+        $finalImage = imagecreatefrompng($imagePath);
         if ($this->data['format'] == 'png') {
             header("Content-type: image/png");
             header("Content-Disposition: attachment; filename=export_" . date("YmdHis") . ".png");
@@ -157,7 +171,6 @@ class ImageExportService
             //header('Content-Length: ' . filesize($file));
             imagejpeg($finalImage, null, 85);
         }
-        unlink($finalImageName);
     }
 
     private function drawFeatures($finalImageName)

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -17,7 +17,15 @@ class ImageExportService
     {
         $this->container = $container;
         $this->tempdir = sys_get_temp_dir();
-        $this->urlHostPath = $this->container->get('request')->getHttpHost() . $this->container->get('request')->getBaseURL();
+        # Extract URL base path so we can later decide to let Symfony handle internal requests or make proper
+        # HTTP connections.
+        # NOTE: This is only possible in web, not CLI
+        if (php_sapi_name() != "cli") {
+            $request = $this->container->get('request');
+            $this->urlHostPath = $request->getHttpHost() . $request->getBaseURL();
+        } else {
+            $this->urlHostPath = null;
+        }
     }
 
     public function export($content)

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -4,6 +4,7 @@ namespace Mapbender\PrintBundle\Component;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Image export service.
@@ -27,6 +28,16 @@ class ImageExportService
         } else {
             $this->urlHostPath = null;
         }
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    protected function getLogger()
+    {
+        /** @var LoggerInterface $logger */
+        $logger = $this->container->get("logger");
+        return $logger;
     }
 
     public function export($content)
@@ -66,61 +77,21 @@ class ImageExportService
             $height = '&HEIGHT=' . $this->data['height'];
             $url .= $width . $height;
             
-            $this->container->get("logger")->debug("Image Export Request Nr.: " . $k . ' ' . $url);
+            $this->getLogger()->debug("Image Export Request Nr.: " . $k . ' ' . $url);
 
-            $parsed   = parse_url($url);
-            $hostpath = $parsed['host'] . $parsed['path'];
-            $pos      = strpos($hostpath, $this->urlHostPath);
-            if ($pos === 0 && ($routeStr = substr($hostpath, strlen($this->urlHostPath))) !== false) {
-                $attributes = $this->container->get('router')->match($routeStr);
-                $gets       = array();
-                parse_str($parsed['query'], $gets);
-                $subRequest = new Request($gets, array(), $attributes, array(), array(), array(), '');
-            } else {
-                $attributes = array(
-                    '_controller' => 'OwsProxy3CoreBundle:OwsProxy:entryPoint'
-                );
-                $subRequest = new Request(array('url' => $url), array(), $attributes, array(), array(), array(), '');
-            }
-            $response = $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+            $mapRequestResponse = $this->mapRequest($url);
 
             $imagename = tempnam($this->tempdir, 'mb_imgexp');
             $temp_names[] = $imagename;
-            $rawImage = $this->serviceResponseToGdImage($imagename, $response);
+            $rawImage = $this->serviceResponseToGdImage($imagename, $mapRequestResponse);
+
 
             if ($rawImage !== null) {
+                $this->forceToRgba($imagename, $rawImage, $this->data['requests'][$k]['opacity']);
                 $width = imagesx($rawImage);
                 $height = imagesy($rawImage);
-
-                // Make sure input image is truecolor with alpha, regardless of input mode!
-                $image = imagecreatetruecolor($width, $height);
-                imagealphablending($image, false);
-                imagesavealpha($image, true);
-                imagecopyresampled($image, $rawImage, 0, 0, 0, 0, $width, $height, $width, $height);
-
-                // Taking the painful way to alpha blending. Stupid PHP-GD
-                $opacity = floatVal($this->data['requests'][$k]['opacity']);
-                if(1.0 !== $opacity) {
-                    for ($x = 0; $x < $width; $x++) {
-                        for ($y = 0; $y < $height; $y++) {
-                            $colorIn = imagecolorsforindex($image, imagecolorat($image, $x, $y));
-                            $alphaOut = 127 - (127 - $colorIn['alpha']) * $opacity;
-
-                            $colorOut = imagecolorallocatealpha(
-                                $image,
-                                $colorIn['red'],
-                                $colorIn['green'],
-                                $colorIn['blue'],
-                                $alphaOut);
-                            imagesetpixel($image, $x, $y, $colorOut);
-                            imagecolordeallocate($image, $colorOut);
-                        }
-                    }
-                }
-                imagepng($image, $imagename);
             }
         }
-
         // create final merged image
         $finalImageName = tempnam($this->tempdir, 'mb_imgexp_merged');
         $mergedImage = imagecreatetruecolor($width, $height);
@@ -146,6 +117,76 @@ class ImageExportService
     }
 
     /**
+     * Convert a GD image to true-color RGBA and write it back to the file
+     * system.
+     *
+     * @param string $imageName will be overwritten
+     * @param resource $imageResource source image
+     * @param float $opacity in [0;1]
+     */
+    protected function forceToRgba($imageName, $imageResource, $opacity)
+    {
+        $width = imagesx($imageResource);
+        $height = imagesy($imageResource);
+
+        // Make sure input image is truecolor with alpha, regardless of input mode!
+        $image = imagecreatetruecolor($width, $height);
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+        imagecopyresampled($image, $imageResource, 0, 0, 0, 0, $width, $height, $width, $height);
+
+        // Taking the painful way to alpha blending. Stupid PHP-GD
+        if (1.0 !== $opacity) {
+            for ($x = 0; $x < $width; $x++) {
+                for ($y = 0; $y < $height; $y++) {
+                    $colorIn = imagecolorsforindex($image, imagecolorat($image, $x, $y));
+                    $alphaOut = 127 - (127 - $colorIn['alpha']) * $opacity;
+
+                    $colorOut = imagecolorallocatealpha(
+                        $image,
+                        $colorIn['red'],
+                        $colorIn['green'],
+                        $colorIn['blue'],
+                        $alphaOut);
+                    imagesetpixel($image, $x, $y, $colorOut);
+                    imagecolordeallocate($image, $colorOut);
+                }
+            }
+        }
+        imagepng($image, $imageName);
+    }
+
+    /**
+     * Query a (presumably) WMS service $url and return the Response object.
+     *
+     * @param string $url
+     * @return Response
+     */
+    protected function mapRequest($url)
+    {
+        // find urls from this host (tunnel connection for secured services)
+        $parsed   = parse_url($url);
+        $host = isset($parsed['host']) ? $parsed['host'] : $this->container->get('request')->getHttpHost();
+        $hostpath = $host . $parsed['path'];
+        $pos      = strpos($hostpath, $this->urlHostPath);
+        if ($pos === 0 && ($routeStr = substr($hostpath, strlen($this->urlHostPath))) !== false) {
+            $attributes = $this->container->get('router')->match($routeStr);
+            $gets       = array();
+            parse_str($parsed['query'], $gets);
+            $subRequest = new Request($gets, array(), $attributes, array(), array(), array(), '');
+        } else {
+            $attributes = array(
+                '_controller' => 'OwsProxy3CoreBundle:OwsProxy:entryPoint'
+            );
+            $subRequest = new Request(array('url' => $url), array(), $attributes, array(), array(), array(), '');
+        }
+        /** @var HttpKernelInterface $kernel */
+        $kernel = $this->container->get('http_kernel');
+        $response = $kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        return $response;
+    }
+
+    /**
      * Converts a http response to a GD image, respecting the mimetype.
      *
      * @param string $storagePath for temp file storage
@@ -155,7 +196,6 @@ class ImageExportService
     protected function serviceResponseToGdImage($storagePath, $response)
     {
         file_put_contents($storagePath, $response->getContent());
-        $imgResource = null;
         $contentType = trim($response->headers->get('content-type'));
         switch ($contentType) {
             case (preg_match("/image\/png/", $contentType) ? $contentType : !$contentType) :
@@ -169,7 +209,7 @@ class ImageExportService
                 break;
             default:
                 return null;
-                $this->container->get("logger")->debug("Unknown mimetype " . trim($response->headers->get('content-type')));
+                $this->getLogger()->debug("Unknown mimetype " . trim($response->headers->get('content-type')));
             //throw new \RuntimeException("Unknown mimetype " . trim($response->headers->get('content-type')));
         }
     }

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -26,6 +26,8 @@ class ImageExportService
     protected $urlHostPath;
     /** @var array */
     protected $data;
+    /** @var string[] */
+    protected $requests = array();
 
     public function __construct($container)
     {
@@ -52,8 +54,19 @@ class ImageExportService
         return $logger;
     }
 
+    /**
+     * Builds a png image and emits it directly to the browser
+     *
+     * @param string $content the job description in valid JSON
+     * @return void
+     *
+     * @todo: converting from JSON encoding is controller responsibility
+     * @todo: emitting to browser is controller responsibility
+     */
     public function export($content)
     {
+        // Clean up internally modified / collected state
+        $this->requests = array();
         $this->data = json_decode($content, true);
 
         foreach ($this->data['requests'] as $i => $layer) {

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -101,7 +101,7 @@ class PrintService
             $centery = $data['center']['y'];
 
             // switch axis for some EPSG if WMS Version 1.3.0
-            if ($layer['changeAxis']){
+            if (!empty($layer['changeAxis'])){
                 $extentWidth = $data['extent']['height'];
                 $extentHeight = $data['extent']['width'];
                 $centerx = $data['center']['y'];
@@ -569,7 +569,7 @@ class PrintService
             $centerx = $this->data['center']['x'];
             $centery = $this->data['center']['y'];
 
-            if ($layer['changeAxis']){
+            if (!empty($layer['changeAxis'])) {
                 $ovWidth = $this->conf['overview']['height'] * $layer['scale'] / 1000;
                 $ovHeight = $this->conf['overview']['width'] * $layer['scale'] / 1000;
                 $centerx = $this->data['center']['y'];
@@ -1093,6 +1093,8 @@ class PrintService
           if(isset($this->conf['legendpage_image']) && $this->conf['legendpage_image']){
              $this->addLegendPageImage();
           }
+          $xStartPosition = 0;
+          $yStartPosition = 0;
         }
 
         foreach ($this->data['legends'] as $idx => $legendArray) {
@@ -1180,7 +1182,7 @@ class PrintService
                             $height = $this->pdf->getHeight();
                             $width = $this->pdf->getWidth();
                             $legendConf = false;
-                            if(isset($this->conf['legendpage_image']) && $this->conf['legendpage_image']){
+                            if (!empty($this->conf['legendpage_image'])) {
                                $this->addLegendPageImage();
                             }
                         }
@@ -1200,7 +1202,7 @@ class PrintService
                           $this->pdf->addPage('P');
                           $x = 5;
                           $y = 10;
-                            if(isset($this->conf['legendpage_image']) && $this->conf['legendpage_image']){
+                            if (!empty($this->conf['legendpage_image'])) {
                                $this->addLegendPageImage();
                             }
                       }

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -1,11 +1,11 @@
 <?php
 namespace Mapbender\PrintBundle\Component;
 
-use Mapbender\CoreBundle\Component\SecurityContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use OwsProxy3\CoreBundle\Component\ProxyQuery;
 use OwsProxy3\CoreBundle\Component\CommonProxy;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
 /**
  * Mapbender3 Print Service.
@@ -1249,9 +1249,9 @@ class PrintService extends ImageExportService
      */
     protected function getUser()
     {
-        /** @var SecurityContext $securityContext */
-        $securityContext = $this->container->get('security.context');
-        $token           = $securityContext->getToken();
+        /** @var TokenStorage $tokenStorage */
+        $tokenStorage = $this->container->get('security.token_storage');
+        $token = $tokenStorage->getToken();
         if ($token) {
             return $token->getUser();
         } else {

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -21,7 +21,6 @@ class PrintService extends ImageExportService
     protected $resourceDir;
     protected $finalImageName;
     protected $user;
-    protected $mapRequests;
     protected $imageWidth;
     protected $imageHeight;
     protected $neededExtentWidth;


### PR DESCRIPTION
This is the ~minimal set of changes to make print jobs repeatable, so further clean ups can be (unit) tested and verified against fixed testing jobs.

This includes a new command mapbender:print:runJob which accepts a JSON or YAML. Job capturing is not included here, but JSON print jobs can, with some slight hacking and reformatting, be dumped from a Chrome inspector console or similar.

CLI support required changes to user checking (no Request object => no user) and Owsproxy interactions, where a controller action delegate from the CLI would throw a BadSignatureException. Because these parts needed to be changed anyway, they were also c&p folded.

C&P folding led to PrintService now inheriting from ImageExportService and very slight related cleanups.

This might sound scary, but the impact should be low. Almost all methods in both classes have historically been private, so customization via inheritance has never been possible to begin with.

This branch is lenient against a missing 'changeAxis' value to support jobs captured on 3.0.5.