### PR TITLE
Fix/improve legend url compatibility 305

### DIFF
--- a/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
@@ -2,14 +2,21 @@
 namespace Mapbender\CoreBundle\Component;
 
 use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\WmsBundle\Component\InstanceTunnel;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Description of SourceInstanceEntityHandler
  *
  * @author Paul Schmidt
+ *
+ * @property SourceInstance $entity
  */
 abstract class SourceInstanceEntityHandler extends EntityHandler
 {
+    /** @var InstanceTunnel */
+    protected $tunnel;
+
     /**
      * @param array $configuration
      * @return SourceInstance
@@ -48,4 +55,17 @@ abstract class SourceInstanceEntityHandler extends EntityHandler
      * Returns an array with sensitive vendor specific parameters
      */
     abstract public function getSensitiveVendorSpecific();
+
+    /**
+     * @return InstanceTunnel
+     */
+    protected function getTunnel()
+    {
+        if (!$this->tunnel) {
+            /** @var UrlGeneratorInterface $router */
+            $router = $this->container->get('router');
+            $this->tunnel = new InstanceTunnel($router, $this->entity);
+        }
+        return $this->tunnel;
+    }
 }

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -9,7 +9,7 @@ use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
 use Mapbender\CoreBundle\Entity\Application as ApplicationEntity;
 use Mapbender\CoreBundle\Utils\RequestUtil;
-use Mapbender\WmsBundle\Component\InstanceTunnel;
+use Mapbender\WmsBundle\Component\InstanceTunnelHandler;
 use Mapbender\WmsBundle\Entity\WmsSource;
 use OwsProxy3\CoreBundle\Component\CommonProxy;
 use OwsProxy3\CoreBundle\Component\ProxyQuery;
@@ -387,7 +387,7 @@ class ApplicationController extends Controller
         if (!$requestType) {
             throw new BadRequestHttpException('Missing mandatory parameter `request` in tunnelAction');
         }
-        $instanceTunnel = new InstanceTunnel($instance);
+        $instanceTunnel = new InstanceTunnelHandler($instance);
         $url = $instanceTunnel->getInternalUrl($request);
         if (!$url) {
             throw new NotFoundHttpException('Operation "' . $requestType . '" is not supported by "tunnelAction".');

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -406,7 +406,7 @@ class ApplicationController extends Controller
                     $glgMode = null;
                     $layerSource = null;
                 } else {
-                    $layerSource = WmsSourceEntityHandler::getLayerSource($source, $layerName);
+                    $layerSource = WmsSourceEntityHandler::getLayerSourceByName($source, $layerName);
                     if (!$layerSource) {
                         $glgMode = null;
                     }

--- a/src/Mapbender/CoreBundle/Utils/ArrayUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/ArrayUtil.php
@@ -62,4 +62,44 @@ class ArrayUtil
             return $value;
         }
     }
+
+    /**
+     * Extract and return the value (or $default if missing) with given $key from given array.
+     *
+     * @param array $arr
+     * @param string|integer $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function getDefault(array $arr, $key, $default=null)
+    {
+        if (array_key_exists($key, $arr)) {
+            return $arr[$key];
+        } else {
+            return $default;
+        }
+    }
+
+    /**
+     * Extract and return the value (or $default if missing) with given $key from given array. Keys are compared
+     * in case-insensitive fashion.
+     *
+     * @param array $arr
+     * @param string|integer $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function getDefaultCaseInsensitive(array $arr, $key, $default=null)
+    {
+        // make an equivalent array with all keys lower-cased, then look up $key (also lower-cased) inside it
+        // NOTE: if multiple keys exist in the input array that differ only in case, they will fold to a single mapped
+        //       value post-strtolower. Due to array_combine behaviour, the value mapped to the LAST such input key
+        //       will be used.
+        // @todo: evaluate if this is a problem / if we require first-key behavior
+        //        (solutions: A. replace getDefault delegation with loop
+        //                    B. array_reverse both keys and values before array_combine)
+        $lcKeys = array_map('strtolower', array_keys($arr));
+        $arrWithLcKeys = array_combine($lcKeys, array_values($arr));
+        return static::getDefault($arrWithLcKeys, strtolower($key), $default);
+    }
 }

--- a/src/Mapbender/CoreBundle/Utils/RequestUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/RequestUtil.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Utils;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Utility class bundling functions related to Symfony Request objects
+ * @package Mapbender\CoreBundle\Utils
+ */
+class RequestUtil
+{
+    /**
+     * Extract the value (or $default if missing) of GET parameter with given $paramName from given Request, ignoring
+     * parameter name case.
+     *
+     * @todo: Because we use similar logic a lot for WMS url processing, it would be nice to have something like a
+     *        ~CaseInsensitiveParameterBag class bound to a ~WmsRequest class where we could encapsulate both
+     *        getting and setting of values.
+     *
+     * @param Request $request
+     * @param $paramName
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function getGetParamCaseInsensitive(Request $request, $paramName, $default=null)
+    {
+        $allGetParams = $request->query->all();
+        return ArrayUtil::getDefaultCaseInsensitive($allGetParams, $paramName, $default);
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
@@ -8,6 +8,7 @@ use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\CoreBundle\Utils\RequestUtil;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class InstanceTunnel
 {
@@ -76,5 +77,49 @@ class InstanceTunnel
             case 'GetLegendGraphic':
                 return WmsInstanceLayerEntityHandler::getLegendGraphicUrl($layerSource);
         }
+    }
+
+    /**
+     * Returns the URL base the Browser / JS client should use to access the tunnel.
+     *
+     * @todo: TBD: bind Router (or entire Container) via constructor?
+     *
+     * @param UrlGeneratorInterface $router
+     * @return string
+     */
+    public function getPublicBaseUrl(UrlGeneratorInterface $router)
+    {
+        return $router->generate(
+            'mapbender_core_application_instancetunnel',
+            array(
+                'slug' => $this->instance->getLayerset()->getApplication()->getSlug(),
+                'instanceId' => $this->instance->getId()),
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+
+    /**
+     * Returns the URL the Browser / JS client should use to access a specific WMS function (by given URL) via
+     * the tunnel.
+     *
+     * @param UrlGeneratorInterface $router
+     * @param string $url NOTE: scheme/host/path completely ignored, only query string is relevant
+     * @return string
+     * @throws \RuntimeException if no REQUEST=... in given $url
+     */
+    public function generatePublicUrl(UrlGeneratorInterface $router, $url)
+    {
+        // require a "request" param, the tunnel action doesn't function without it
+        $params = array();
+        parse_str(parse_url($url, PHP_URL_QUERY), $params);
+        foreach ($params as $name => $value) {
+            if (strtolower($name) == 'request') {
+                // @todo: validate if request value is in our supported set (GetMap, GetLegendGraphic, GetFeatureInfo)?
+                $fullQueryString = strstr($url, '?', false);
+                // forward ALL GET parameters in input url
+                return $this->getPublicBaseUrl($router) . $fullQueryString;
+            }
+        }
+        throw new \RuntimeException('Failed to tunnelify url, no `request` param found: ' . var_export($url, true));
     }
 }

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Component;
+
+
+use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\CoreBundle\Utils\RequestUtil;
+use Symfony\Component\HttpFoundation\Request;
+
+class InstanceTunnel
+{
+    /** @var SourceInstance */
+    protected $instance;
+
+    /**
+     * InstanceTunnel constructor.
+     * @param SourceInstance $instance
+     */
+    public function __construct(SourceInstance $instance)
+    {
+        $this->instance = $instance;
+    }
+
+    /**
+     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getInternalUrl(Request $request)
+    {
+        $source = $this->instance->getSource();
+        $requestType = RequestUtil::getGetParamCaseInsensitive($request, 'request', null);
+
+        switch (strtolower($requestType)) {
+            case 'getmap':
+                return $source->getGetMap()->getHttpGet();
+            case 'getfeatureinfo':
+                return $source->getGetFeatureInfo()->getHttpGet();
+            case 'getlegendgraphic':
+                $glgMode = $request->query->get('_glgmode', null);
+                $layerName = $request->query->get('layer', null);
+                if (!$layerName) {
+                    $glgMode = null;
+                    $layerSource = null;
+                } else {
+                    $layerSource = WmsSourceEntityHandler::getLayerSourceByName($source, $layerName);
+                    if (!$layerSource) {
+                        $glgMode = null;
+                    }
+                }
+                switch ($glgMode) {
+                    default:
+                        return $source->getGetLegendGraphic()->getHttpGet();
+                    case 'styles':
+                        return WmsInstanceLayerEntityHandler::getLegendUrlFromStyles($layerSource);
+                    case 'GetLegendGraphic':
+                        return WmsInstanceLayerEntityHandler::getLegendGraphicUrl($layerSource);
+                }
+                break;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
@@ -3,93 +3,44 @@
 
 namespace Mapbender\WmsBundle\Component;
 
-
-use Mapbender\CoreBundle\Entity\Source;
+use Mapbender\CoreBundle\Controller\ApplicationController;
 use Mapbender\CoreBundle\Entity\SourceInstance;
-use Mapbender\CoreBundle\Utils\RequestUtil;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class InstanceTunnel
+/**
+ * Instance tunnel can both generate and evaluate requests / urls for WMS services that contain sensitive parameters
+ * (credentials, "vendorSpecifics") that need to be hidden from the browser.
+ *
+ * @see ApplicationController::instanceTunnelAction()
+ * @see WmsInstanceEntityHandler::getConfiguration()
+ * @see WmsInstanceLayerEntityHandler::getLegendConfig()
+ *
+ * @package Mapbender\WmsBundle\Component
+ */
+class InstanceTunnel extends InstanceTunnelHandler
 {
-    /** @var SourceInstance */
-    protected $instance;
-
-    /** @var Source */
-    protected $source;
+    /** @var UrlGeneratorInterface */
+    protected $router;
 
     /**
      * InstanceTunnel constructor.
+     * @param UrlGeneratorInterface $router
      * @param SourceInstance $instance
      */
-    public function __construct(SourceInstance $instance)
+    public function __construct(UrlGeneratorInterface $router, SourceInstance $instance)
     {
-        $this->instance = $instance;
-        $this->source = $instance->getSource();
-    }
-
-    /**
-     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
-     *
-     * @param Request $request
-     * @return string
-     */
-    public function getInternalUrl(Request $request)
-    {
-        $requestType = RequestUtil::getGetParamCaseInsensitive($request, 'request', null);
-
-        switch (strtolower($requestType)) {
-            case 'getmap':
-                return $this->source->getGetMap()->getHttpGet();
-            case 'getfeatureinfo':
-                return $this->source->getGetFeatureInfo()->getHttpGet();
-            case 'getlegendgraphic':
-                return $this->getInternalGetLegendGraphicUrl($request);
-            default:
-                return null;
-        }
-    }
-
-    /**
-     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
-     *
-     * @param Request $request
-     * @return string
-     */
-    public function getInternalGetLegendGraphicUrl(Request $request)
-    {
-        $glgMode = $request->query->get('_glgmode', null);
-        $layerName = RequestUtil::getGetParamCaseInsensitive($request, 'layer', null);
-        if (!$layerName) {
-            $glgMode = null;
-            $layerSource = null;
-        } else {
-            $layerSource = WmsSourceEntityHandler::getLayerSourceByName($this->source, $layerName);
-            if (!$layerSource) {
-                $glgMode = null;
-            }
-        }
-        switch ($glgMode) {
-            default:
-                return $this->source->getGetLegendGraphic()->getHttpGet();
-            case 'styles':
-                return WmsInstanceLayerEntityHandler::getLegendUrlFromStyles($layerSource);
-            case 'GetLegendGraphic':
-                return WmsInstanceLayerEntityHandler::getLegendGraphicUrl($layerSource);
-        }
+        $this->router = $router;
+        parent::__construct($instance);
     }
 
     /**
      * Returns the URL base the Browser / JS client should use to access the tunnel.
      *
-     * @todo: TBD: bind Router (or entire Container) via constructor?
-     *
-     * @param UrlGeneratorInterface $router
      * @return string
      */
-    public function getPublicBaseUrl(UrlGeneratorInterface $router)
+    public function getPublicBaseUrl()
     {
-        return $router->generate(
+        return $this->router->generate(
             'mapbender_core_application_instancetunnel',
             array(
                 'slug' => $this->instance->getLayerset()->getApplication()->getSlug(),
@@ -102,12 +53,11 @@ class InstanceTunnel
      * Returns the URL the Browser / JS client should use to access a specific WMS function (by given URL) via
      * the tunnel.
      *
-     * @param UrlGeneratorInterface $router
      * @param string $url NOTE: scheme/host/path completely ignored, only query string is relevant
      * @return string
      * @throws \RuntimeException if no REQUEST=... in given $url
      */
-    public function generatePublicUrl(UrlGeneratorInterface $router, $url)
+    public function generatePublicUrl($url)
     {
         // require a "request" param, the tunnel action doesn't function without it
         $params = array();
@@ -117,7 +67,7 @@ class InstanceTunnel
                 // @todo: validate if request value is in our supported set (GetMap, GetLegendGraphic, GetFeatureInfo)?
                 $fullQueryString = strstr($url, '?', false);
                 // forward ALL GET parameters in input url
-                return $this->getPublicBaseUrl($router) . $fullQueryString;
+                return $this->getPublicBaseUrl() . $fullQueryString;
             }
         }
         throw new \RuntimeException('Failed to tunnelify url, no `request` param found: ' . var_export($url, true));

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
@@ -58,7 +58,7 @@ class InstanceTunnel
     public function getInternalGetLegendGraphicUrl(Request $request)
     {
         $glgMode = $request->query->get('_glgmode', null);
-        $layerName = $request->query->get('layer', null);
+        $layerName = RequestUtil::getGetParamCaseInsensitive($request, 'layer', null);
         if (!$layerName) {
             $glgMode = null;
             $layerSource = null;

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnelHandler.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnelHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Component;
+
+use Mapbender\CoreBundle\Controller\ApplicationController;
+use Mapbender\CoreBundle\Entity\Source;
+use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\CoreBundle\Utils\RequestUtil;
+use Symfony\Component\HttpFoundation\Request;
+
+
+/**
+ * Base version of InstanceTunnel that can process, but not generate tunnel requests (works without access to
+ * Router).
+ *
+ * @see ApplicationController::instanceTunnelAction()
+ *
+ * @package Mapbender\WmsBundle\Component
+ */
+class InstanceTunnelHandler
+{
+    /** @var SourceInstance */
+    protected $instance;
+
+    /** @var Source */
+    protected $source;
+
+    /**
+     * InstanceTunnel constructor.
+     * @param SourceInstance $instance
+     */
+    public function __construct(SourceInstance $instance)
+    {
+        $this->instance = $instance;
+        $this->source = $instance->getSource();
+    }
+
+    /**
+     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getInternalUrl(Request $request)
+    {
+        $requestType = RequestUtil::getGetParamCaseInsensitive($request, 'request', null);
+
+        switch (strtolower($requestType)) {
+            case 'getmap':
+                return $this->source->getGetMap()->getHttpGet();
+            case 'getfeatureinfo':
+                return $this->source->getGetFeatureInfo()->getHttpGet();
+            case 'getlegendgraphic':
+                return $this->getInternalGetLegendGraphicUrl($request);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getInternalGetLegendGraphicUrl(Request $request)
+    {
+        $glgMode = $request->query->get('_glgmode', null);
+        $layerName = RequestUtil::getGetParamCaseInsensitive($request, 'layer', null);
+        if (!$layerName) {
+            $glgMode = null;
+            $layerSource = null;
+        } else {
+            $layerSource = WmsSourceEntityHandler::getLayerSourceByName($this->source, $layerName);
+            if (!$layerSource) {
+                $glgMode = null;
+            }
+        }
+        switch ($glgMode) {
+            default:
+                return $this->source->getGetLegendGraphic()->getHttpGet();
+            case 'styles':
+                return WmsInstanceLayerEntityHandler::getLegendUrlFromStyles($layerSource);
+            case 'GetLegendGraphic':
+                return WmsInstanceLayerEntityHandler::getLegendGraphicUrl($layerSource);
+        }
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -11,7 +11,6 @@ use Mapbender\WmsBundle\Entity\WmsInstance;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
 use Mapbender\WmsBundle\Entity\WmsSource;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
 /**
@@ -269,13 +268,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             }
         }
         if ($hide || $this->entity->getSource()->getUsername()) {
-            $url = $this->container->get('router')->generate(
-                'mapbender_core_application_instancetunnel',
-                array(
-                    'slug' => $this->entity->getLayerset()->getApplication()->getSlug(),
-                    'instanceId' => $this->entity->getId()),
-                UrlGeneratorInterface::ABSOLUTE_URL
-            );
+            $tunnel = new InstanceTunnel($this->entity);
+            $url = $tunnel->getPublicBaseUrl($this->container->get('router'));
             $configuration['options']['url'] = UrlUtil::validateUrl($url, $params, array());
             // remove ows proxy for a tunnel connection
             $configuration['options']['tunnel'] = true;

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -268,8 +268,7 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             }
         }
         if ($hide || $this->entity->getSource()->getUsername()) {
-            $tunnel = new InstanceTunnel($this->entity);
-            $url = $tunnel->getPublicBaseUrl($this->container->get('router'));
+            $url = $this->getTunnel()->getPublicBaseUrl();
             $configuration['options']['url'] = UrlUtil::validateUrl($url, $params, array());
             // remove ows proxy for a tunnel connection
             $configuration['options']['tunnel'] = true;

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -336,12 +336,11 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     {
         $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
         if (WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource())) {
-            $tunnel = new InstanceTunnel($this->entity->getSourceInstance());
             /** @var Router $router */
             $router = $this->container->get('router');
+            $tunnel = new InstanceTunnel($router, $entity->getSourceInstance());
         } else {
             $tunnel = null;
-            $router = null;
         }
         $layerName = $entity->getSourceItem()->getName();
         if ($styleLegendUrl) {
@@ -349,7 +348,7 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
                 // request via tunnel, see ApplicationController::instanceTunnelAction
                 // instruct the tunnel action that the legend url should be plucked from styles
                 $tunnelInputUrl = '?request=GetLegendGraphic&_glgmode=styles&layer=' . $layerName;
-                $publicLegendUrl = $tunnel->generatePublicUrl($router, $tunnelInputUrl);
+                $publicLegendUrl = $tunnel->generatePublicUrl($tunnelInputUrl);
             } else {
                 $publicLegendUrl = $styleLegendUrl;
             }
@@ -363,7 +362,7 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
                     // request via tunnel, see ApplicationController::instanceTunnelAction
                     // instruct the tunnel action that the legend url should be plucked from GetLegendGraphic
                     $tunnelInputUrl = '?request=GetLegendGraphic&_glgmode=GetLegendGraphic';
-                    $publicLegendUrl = $tunnel->generatePublicUrl($router, $tunnelInputUrl);
+                    $publicLegendUrl = $tunnel->generatePublicUrl($tunnelInputUrl);
                 } else {
                     $publicLegendUrl = $glgLegendUrl;
                 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -360,10 +360,12 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     {
         $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
         $useTunnel = WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource());
+        $layerName = $entity->getSourceItem()->getName();
         if ($styleLegendUrl) {
             if ($useTunnel) {
                 // request via tunnel, see ApplicationController::instanceTunnelAction
-                $publicLegendUrl = $this->generateTunnelUrl($styleLegendUrl);
+                // instruct the tunnel action that the legend url should be plucked from styles
+                $publicLegendUrl = $this->generateTunnelUrl('?request=GetLegendGraphic&_glgmode=styles&layer=' . $layerName);
             } else {
                 $publicLegendUrl = $styleLegendUrl;
             }
@@ -375,7 +377,8 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             if ($glgLegendUrl) {
                 if ($useTunnel) {
                     // request via tunnel, see ApplicationController::instanceTunnelAction
-                    $publicLegendUrl = $this->generateTunnelUrl($glgLegendUrl);
+                    // instruct the tunnel action that the legend url should be plucked from GetLegendGraphic
+                    $publicLegendUrl = $this->generateTunnelUrl('?request=GetLegendGraphic&_glgmode=GetLegendGraphic');
                 } else {
                     $publicLegendUrl = $glgLegendUrl;
                 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -244,13 +244,21 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         $configuration['bbox'] = $srses;
         $styles = $this->entity->getSourceItem()->getStyles();
         if ($styles) {
-            $legendurl = $styles[count($styles) - 1]->getLegendUrl(); // the last style from object's styles
-            if ($legendurl !== null) {
-                $configuration["legend"] = array(
-                    "url" => $this->generateTunnelUrl($legendurl->getOnlineResource()->getHref()),
-                    "width" => intval($legendurl->getWidth()),
-                    "height" => intval($legendurl->getHeight())
-                );
+            // scan styles for legend url entries backwards
+            // some WMS services may not populate every style with a legend, so just checking the last
+            // style for a legend is not enough
+            foreach (array_reverse($styles) as $style) {
+                /** @var Style $style */
+                $legendurl = $style->getLegendUrl();
+                if ($legendurl) {
+                    $effectiveLegendUrl = $this->generateTunnelUrl($legendurl->getOnlineResource()->getHref());
+                    $configuration["legend"] = array(
+                        "url" => $effectiveLegendUrl,
+                        "width" => intval($legendurl->getWidth()),
+                        "height" => intval($legendurl->getHeight()),
+                    );
+                    break;
+                }
             }
         } elseif ($this->entity->getSourceInstance()->getSource()->getGetLegendGraphic() !== null &&
             $this->entity->getSourceItem()->getName() !== null &&

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -242,34 +242,11 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             );
         }
         $configuration['bbox'] = $srses;
-        $styleLegendUrl = $this->getLegendUrlFromStyles($this->entity->getSourceItem());
-        $useTunnel = WmsSourceEntityHandler::useTunnel($this->entity->getSourceInstance()->getSource());
-        if ($styleLegendUrl) {
-            if ($useTunnel) {
-                // request via tunnel, see ApplicationController::instanceTunnelAction
-                $publicLegendUrl = $this->generateTunnelUrl($styleLegendUrl);
-            } else {
-                $publicLegendUrl = $styleLegendUrl;
-            }
-            $configuration["legend"] = array(
-                "url"   => $publicLegendUrl,
-            );
-        } else {
-            $glgLegendUrl = $this->getLegendGraphicUrl($this->entity->getSourceItem());
-            if ($glgLegendUrl) {
-                if ($useTunnel) {
-                    // request via tunnel, see ApplicationController::instanceTunnelAction
-                    $publicLegendUrl = $this->generateTunnelUrl($glgLegendUrl);
-                } else {
-                    $publicLegendUrl = $glgLegendUrl;
-                }
-                $configuration["legend"] = array(
-                    // this entry in the emitted config is only evaluated by the legend element if configured with
-                    // "generateLegendUrl": true
-                    "graphic"   => $publicLegendUrl,
-                );
-            }
+        $legendConfig = $this->getLegendConfig($this->entity);
+        if ($legendConfig) {
+            $configuration["legend"] = $legendConfig;
         }
+
         $configuration["treeOptions"] = array(
             "info" => $this->entity->getInfo(),
             "selected" => $this->entity->getSelected(),
@@ -371,5 +348,44 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             return Utils::getHttpUrl($url, $params);
         }
         return null;
+    }
+
+    /**
+     * Return the client-facing configuration for a layer's legend
+     *
+     * @param WmsInstanceLayer $entity
+     * @return array
+     */
+    public function getLegendConfig(WmsInstanceLayer $entity)
+    {
+        $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
+        $useTunnel = WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource());
+        if ($styleLegendUrl) {
+            if ($useTunnel) {
+                // request via tunnel, see ApplicationController::instanceTunnelAction
+                $publicLegendUrl = $this->generateTunnelUrl($styleLegendUrl);
+            } else {
+                $publicLegendUrl = $styleLegendUrl;
+            }
+            return array(
+                "url"   => $publicLegendUrl,
+            );
+        } else {
+            $glgLegendUrl = $this->getLegendGraphicUrl($entity->getSourceItem());
+            if ($glgLegendUrl) {
+                if ($useTunnel) {
+                    // request via tunnel, see ApplicationController::instanceTunnelAction
+                    $publicLegendUrl = $this->generateTunnelUrl($glgLegendUrl);
+                } else {
+                    $publicLegendUrl = $glgLegendUrl;
+                }
+                return array(
+                    // this entry in the emitted config is only evaluated by the legend element if configured with
+                    // "generateLegendUrl": true
+                    "graphic"   => $publicLegendUrl,
+                );
+            }
+        }
+        return array();
     }
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -8,7 +8,8 @@ use Mapbender\CoreBundle\Entity\SourceItem;
 use Mapbender\WmsBundle\Entity\WmsInstance;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Mapbender\WmsBundle\Entity\WmsSource;
+use Symfony\Component\Routing\Router;
 
 /**
  * Description of WmsInstanceLayerEntityHandler
@@ -278,31 +279,6 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         return null;
     }
 
-    private function generateTunnelUrl($url)
-    {
-        if ($this->entity->getSourceInstance()->getSource()->getUsername()) {
-            $tunnelBaseUrl = $this->container->get('router')->generate(
-                'mapbender_core_application_instancetunnel',
-                array(
-                    'slug' => $this->entity->getSourceInstance()->getLayerset()->getApplication()->getSlug(),
-                    'instanceId' => $this->entity->getSourceInstance()->getId()),
-                UrlGeneratorInterface::ABSOLUTE_URL
-            );
-            // forward "request" param to tunnel (lower-case matching)
-            $params = array();
-            parse_str(parse_url($url, PHP_URL_QUERY), $params);
-            foreach ($params as $name => $value) {
-                if (strtolower($name) == 'request') {
-                    $fullQueryString = strstr($url, '?', false);
-                    return $tunnelBaseUrl . $fullQueryString;
-                }
-            }
-            throw new \RuntimeException('Failed to tunnelify url, no `request` param found: ' . var_export($url, true));
-        } else {
-            return $url;
-        }
-    }
-
     /**
      * Get a legend url from the layer's styles
      *
@@ -359,13 +335,21 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     public function getLegendConfig(WmsInstanceLayer $entity)
     {
         $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
-        $useTunnel = WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource());
+        if (WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource())) {
+            $tunnel = new InstanceTunnel($this->entity->getSourceInstance());
+            /** @var Router $router */
+            $router = $this->container->get('router');
+        } else {
+            $tunnel = null;
+            $router = null;
+        }
         $layerName = $entity->getSourceItem()->getName();
         if ($styleLegendUrl) {
-            if ($useTunnel) {
+            if ($tunnel) {
                 // request via tunnel, see ApplicationController::instanceTunnelAction
                 // instruct the tunnel action that the legend url should be plucked from styles
-                $publicLegendUrl = $this->generateTunnelUrl('?request=GetLegendGraphic&_glgmode=styles&layer=' . $layerName);
+                $tunnelInputUrl = '?request=GetLegendGraphic&_glgmode=styles&layer=' . $layerName;
+                $publicLegendUrl = $tunnel->generatePublicUrl($router, $tunnelInputUrl);
             } else {
                 $publicLegendUrl = $styleLegendUrl;
             }
@@ -375,10 +359,11 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         } else {
             $glgLegendUrl = $this->getLegendGraphicUrl($entity->getSourceItem());
             if ($glgLegendUrl) {
-                if ($useTunnel) {
+                if ($tunnel) {
                     // request via tunnel, see ApplicationController::instanceTunnelAction
                     // instruct the tunnel action that the legend url should be plucked from GetLegendGraphic
-                    $publicLegendUrl = $this->generateTunnelUrl('?request=GetLegendGraphic&_glgmode=GetLegendGraphic');
+                    $tunnelInputUrl = '?request=GetLegendGraphic&_glgmode=GetLegendGraphic';
+                    $publicLegendUrl = $tunnel->generatePublicUrl($router, $tunnelInputUrl);
                 } else {
                     $publicLegendUrl = $glgLegendUrl;
                 }

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -157,13 +157,13 @@ class WmsSourceEntityHandler extends SourceEntityHandler
     }
 
     /**
-     * Find the named WmsLayerSource
+     * Find the named WmsLayerSource in the given WmsSource
      *
      * @param WmsSource $source
      * @param string $layerName
      * @return WmsLayerSource|null
      */
-    public static function getLayerSource(WmsSource $source, $layerName)
+    public static function getLayerSourceByName(WmsSource $source, $layerName)
     {
         foreach ($source->getLayers() as $layer) {
             if ($layer->getName() == $layerName) {

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -9,6 +9,7 @@ use Mapbender\CoreBundle\Entity\Layerset;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Utils\EntityUtil;
 use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsLayerSource;
 use Mapbender\WmsBundle\Entity\WmsSource;
 
 /**
@@ -153,5 +154,33 @@ class WmsSourceEntityHandler extends SourceEntityHandler
         return $query->setParameters(
             array("sid" => $this->entity->getId())
         )->getResult();
+    }
+
+    /**
+     * Find the named WmsLayerSource
+     *
+     * @param WmsSource $source
+     * @param string $layerName
+     * @return WmsLayerSource|null
+     */
+    public static function getLayerSource(WmsSource $source, $layerName)
+    {
+        foreach ($source->getLayers() as $layer) {
+            if ($layer->getName() == $layerName) {
+                return $layer;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if service has auth information that needs to be hidden from client.
+     *
+     * @param WmsSource $source
+     * @return bool
+     */
+    public static function useTunnel(WmsSource $source)
+    {
+        return !empty($source->getUsername());
     }
 }


### PR DESCRIPTION
This is a backport of pull #712 to release/3.0.5. Please check there for a detailed description of what has changed and why. Pull 712 is a regression fix. We [introduced the same regression into 3.0.5](https://github.com/mapbender/mapbender/pull/616), which is currently blocking new security releases for 3.0.5.

The backport was created with:
```
git cherry-pick d4973c3751f16027a8442883cda8642175d7fe8b..5b4f683761b89f750fb060193f7ef92ce85db51c
```
On a new branch based off the current release/3.0.5 HEAD.

Applying the commits on top of release/3.0.5 saw only a single two-line conflict in a single file, in the use statement / class header gap of WmsInstanceLayerEntityHandler.

I tested on an existing local mb305 install with user/password protected WMSes and saw working tunnel requests to both GetMap and GetLegendGraphic.