### PR TITLE
[restore BC] fix automatic element template / admin type calcs vs inheritance, noconfig edition

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -354,10 +354,10 @@ abstract class Element
      *************************************************************************/
 
     /**
-     * Get the element configuration form type.
+     * Get the element configuration form type. By default, this class needs to have the same name
+     * as the element, suffixed with "AdminType" and located in the Element\Type sub-namespace.
      *
-     * Override this method to provide a custom configuration form instead of
-     * the default YAML form.
+     * Override this method and return null to get a simple YAML entry form.
      *
      * @return string Administration type class name
      */

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -224,10 +224,7 @@ abstract class Element
      */
     public function render()
     {
-        $parts    = $this->classNameParts;
-        $template = $parts[0] . $parts[1] . ":" . $parts[2] . ":" . static::getTemplateName($parts[3]) . ".html.twig";
-
-        return $this->container->get('templating')->render($template,
+        return $this->container->get('templating')->render($this->getFrontendTemplatePath(),
             array(
                 'element'       => $this,
                 'id'            => $this->getId(),
@@ -235,6 +232,20 @@ abstract class Element
                 'title'         => $this->getTitle(),
                 'configuration' => $this->getConfiguration()
             ));
+    }
+
+    /**
+     * Return twig-style BundleName:section:file_name.engine.twig path to template file.
+     *
+     * Base implementation automatically calculates this from the class name. Override if
+     * you cannot follow naming / placement conventions.
+     *
+     * @param string $suffix defaults to '.html.twig'
+     * @return string
+     */
+    public function getFrontendTemplatePath($suffix = '.html.twig')
+    {
+        return $this->getAutomaticTemplatePath($suffix);
     }
 
     /**
@@ -343,29 +354,6 @@ abstract class Element
      *************************************************************************/
 
     /**
-     * Walk up through the class hierarchy and return the name of the first-generation child class immediately
-     * inheriting from the abstract Element
-     *
-     * @return string
-     */
-    protected static function getBaseClassName()
-    {
-        $delegateClass = get_called_class();
-        $abstractRoot = __CLASS__;      // == Mapbender\CoreBundle\Component\Element
-        while (is_subclass_of($delegateClass, $abstractRoot, true)) {
-            $parentClass = get_parent_class($delegateClass);
-            if (is_subclass_of($parentClass, $abstractRoot, true)) {
-                // parent is still not abstract, good to delegate calls to
-                $delegateClass = $parentClass;
-            } else {
-                // we're down to abstract element, stop and keep delegateClass on the first-level child class
-                break;
-            }
-        }
-        return $delegateClass;
-    }
-
-    /**
      * Get the element configuration form type.
      *
      * Override this method to provide a custom configuration form instead of
@@ -375,9 +363,7 @@ abstract class Element
      */
     public static function getType()
     {
-
-        $clsInfo = explode('\\', static::getBaseClassName());
-        return $clsInfo[0] . '\\' . $clsInfo[1] . '\\' . $clsInfo[2] . '\\Type\\' . $clsInfo[3] . 'AdminType';
+        return static::getAutomaticAdminType(true);
     }
 
     /**
@@ -387,8 +373,7 @@ abstract class Element
      */
     public static function getFormTemplate()
     {
-        $clsInfo = explode('\\', static::getBaseClassName());
-        return $clsInfo[0] .  $clsInfo[1] . ':' . $clsInfo[2] . 'Admin:' . static::getTemplateName($clsInfo[3]) . '.html.twig';
+        return static::getAutomaticTemplatePath('.html.twig', 'ElementAdmin');
     }
 
     /**
@@ -563,10 +548,17 @@ abstract class Element
     }
 
     /**
-     * Get template name by class name
+     * Converts a camel-case string to underscore-separated lower-case string
+     *
+     * E.g. "FantasticMethodNaming" => "fantastic_method_naming"
+     *
+     * Will not work with multiple consecutive upper-case letters
+     *
+     * @todo: naming, location
      *
      * @param $className
      * @return mixed
+     * @internal
      */
     protected static function getTemplateName($className)
     {
@@ -591,5 +583,102 @@ abstract class Element
     public function updateAppConfig($configIn)
     {
         return $configIn;
+    }
+
+    ##### Automagic calculation for template paths and admin type ####
+
+    /**
+     * Generates an automatic template path for the element from its class name.
+     *
+     * The generated path is twig engine style, i.e.
+     * 'BundleClassName:section:template_name.engine-name.twig'
+     *
+     * The bundle name is auto-generated from the first two namespace components, e.g. "MabenderCoreBundle".
+     *
+     * The resource section (=subfolder in Resources/views) defaults to "Element" but can be supplied.
+     *
+     * The file name is the in-namespace class name lower-cased and & decamelized, plus the given $suffix,
+     * which defaults to '.html.twig'. E.g. "html_element.html.twig".
+     *
+     * E.g. for a Mapbender\FoodBundle\Element\LemonBomb element child class this will return
+     * "MapbenderFoodBundle:Element:lemon_bomb.html.twig".
+     * This would correspond to this file path:
+     * <mapbender-root>/src/Mapbender/FoodBundle/Resources/views/Element/lemon_bomb.html.twig
+     *
+     * @param string $suffix to be appended to the generated path (default: '.html.twig', try '.json.twig' etc)
+     * @param string|null $resourceSection if null, will use third namespace component (i.e. first non-bundle component).
+     *                    For elements in any conventional Mapbender bundle, this will be "Element".
+     *                    We also use "ElementAdmin" in certain places though.
+     * @param bool $inherit (default true) allow inheriting template names from parent classes, excluding the (abstract)
+     *                    Element class itself
+     * @return string twig-style Bundle:Section:file_name.ext
+     */
+    public static function getAutomaticTemplatePath($suffix = '.html.twig', $resourceSection = null, $inherit = true)
+    {
+        if ($inherit) {
+            $cls = static::getNonAbstractBaseClassName();
+        } else {
+            $cls = get_called_class();
+        }
+        $classParts = explode('\\', $cls);
+        $nameWithoutNamespace = implode('', array_slice($classParts, -1));
+
+        $bundleName = implode('', array_slice($classParts, 0, 2));  // e.g. "Mapbender" . "CoreBundle"
+        $resourceSection = $resourceSection ?: "Element"; // $classParts[2];
+        $resourcePathParts = array_slice($classParts, 3, -1);   // subfolder under section, often empty
+        $resourcePathParts[] = static::getTemplateName($nameWithoutNamespace);
+
+        return "{$bundleName}:{$resourceSection}:" . implode('/', $resourcePathParts) . $suffix;
+    }
+
+    /**
+     * Generates an automatic "AdminType" class name from the element class name.
+     *
+     * E.g. for a Mapbender\FoodBundle\Element\LemonBomb element child class this will return the string
+     * "Mapbender\FoodBundle\Element\Type\LemonBombAdminType"
+     *
+     * @param bool $inherit (default true) allow inheriting admin type from parent classes, excluding the (abstract)
+     *                    Element class itself
+     * @return string
+     */
+    public static function getAutomaticAdminType($inherit = true)
+    {
+        if ($inherit) {
+            $cls = static::getNonAbstractBaseClassName();
+        } else {
+            $cls = get_called_class();
+        }
+        $clsInfo = explode('\\', $cls);
+        $namespaceParts = array_slice($clsInfo, 0, -1);
+        // convention: AdminType classes are placed into the "<bundle>\Element\Type" namespace
+        $namespaceParts[] = "Type";
+        $bareClassName = implode('', array_slice($clsInfo, -1));
+        // convention: AdminType class name is the same as the element class name suffixed with AdminType
+        return implode('\\', $namespaceParts) . '\\' . $bareClassName . 'AdminType';
+    }
+
+    /**
+     * Walk up through the class hierarchy and return the name of the first-generation child class immediately
+     * inheriting from the abstract Element.
+     *
+     * @todo: location
+     *
+     * @return string fully qualified class name
+     */
+    protected static function getNonAbstractBaseClassName()
+    {
+        $nonAbstractBase = get_called_class();
+        $abstractRoot = __CLASS__;      // == "Mapbender\CoreBundle\Component\Element"
+        while (is_subclass_of($nonAbstractBase, $abstractRoot, true)) {
+            $parentClass = get_parent_class($nonAbstractBase);
+            if (is_subclass_of($parentClass, $abstractRoot, true)) {
+                // parent is still not abstract, good to delegate calls to
+                $nonAbstractBase = $parentClass;
+            } else {
+                // we're down all the way, next parent is now the abstract Element
+                break;
+            }
+        }
+        return $nonAbstractBase;
     }
 }

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -343,6 +343,29 @@ abstract class Element
      *************************************************************************/
 
     /**
+     * Walk up through the class hierarchy and return the name of the first-generation child class immediately
+     * inheriting from the abstract Element
+     *
+     * @return string
+     */
+    protected static function getBaseClassName()
+    {
+        $delegateClass = get_called_class();
+        $abstractRoot = __CLASS__;      // == Mapbender\CoreBundle\Component\Element
+        while (is_subclass_of($delegateClass, $abstractRoot, true)) {
+            $parentClass = get_parent_class($delegateClass);
+            if (is_subclass_of($parentClass, $abstractRoot, true)) {
+                // parent is still not abstract, good to delegate calls to
+                $delegateClass = $parentClass;
+            } else {
+                // we're down to abstract element, stop and keep delegateClass on the first-level child class
+                break;
+            }
+        }
+        return $delegateClass;
+    }
+
+    /**
      * Get the element configuration form type.
      *
      * Override this method to provide a custom configuration form instead of
@@ -352,7 +375,8 @@ abstract class Element
      */
     public static function getType()
     {
-        $clsInfo = explode('\\', get_called_class());
+
+        $clsInfo = explode('\\', static::getBaseClassName());
         return $clsInfo[0] . '\\' . $clsInfo[1] . '\\' . $clsInfo[2] . '\\Type\\' . $clsInfo[3] . 'AdminType';
     }
 
@@ -363,7 +387,7 @@ abstract class Element
      */
     public static function getFormTemplate()
     {
-        $clsInfo = explode('\\', get_called_class());
+        $clsInfo = explode('\\', static::getBaseClassName());
         return $clsInfo[0] .  $clsInfo[1] . ':' . $clsInfo[2] . 'Admin:' . static::getTemplateName($clsInfo[3]) . '.html.twig';
     }
 

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -552,8 +552,6 @@ abstract class Element
      *
      * E.g. "FantasticMethodNaming" => "fantastic_method_naming"
      *
-     * Will not work with multiple consecutive upper-case letters
-     *
      * @todo: naming, location
      *
      * @param $className
@@ -562,15 +560,10 @@ abstract class Element
      */
     protected static function getTemplateName($className)
     {
-        $className = preg_replace_callback(
-            '/[A-Z]+[^A-Z]+/',
-            function ($match) {
-                return "_".strtolower($match[0]);
-            },
-            $className
-        );
-        $className = substr($className,1);
-        return $className;
+        // insert underscores before upper case letter following lower-case
+        $underscored = preg_replace('/([^A-Z])([A-Z])/', '\\1_\\2', $className);
+        // lower-case the whole thing
+        return strtolower($underscored);
     }
 
     /**


### PR DESCRIPTION
This replaces [Pull #649](https://github.com/mapbender/mapbender/pull/649). 649 contains a real bug / regression (calculated AdminType class name ends up in wrong namespace, misses `Type` component) and a few unfortunate choices.

This became clear after [anaylzing the existing element base](https://github.com/mapbender/mapbender/blob/enh/element-class-introspection/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php).

Differences to 649:
* auto-calculated AdminType class name is in expected namespace (`SomeBundle\Element\Type\`).
* adds previously missing `getFrontendTemplatePath` method; this was previously hard-baked into the render method
* auto-generation split out of getter logic: [getAutomaticTemplatePath](https://github.com/mapbender/mapbender/blob/eecf8e0df2bdc1b77d04e88902b9a0334057c97e/src/Mapbender/CoreBundle/Component/Element.php#L590), [getAutomaticAdminType](https://github.com/mapbender/mapbender/blob/eecf8e0df2bdc1b77d04e88902b9a0334057c97e/src/Mapbender/CoreBundle/Component/Element.php#L634) vs [getType](https://github.com/mapbender/mapbender/blob/eecf8e0df2bdc1b77d04e88902b9a0334057c97e/src/Mapbender/CoreBundle/Component/Element.php#L356), [getFormTemplate](https://github.com/mapbender/mapbender/blob/eecf8e0df2bdc1b77d04e88902b9a0334057c97e/src/Mapbender/CoreBundle/Component/Element.php#L369), (new) [getFrontendTemplatePath](https://github.com/mapbender/mapbender/blob/eecf8e0df2bdc1b77d04e88902b9a0334057c97e/src/Mapbender/CoreBundle/Component/Element.php#L237)
* configration machinery for behaviour of auto-generation vs inheritance has been removed. You can now override the getter directly, which seems more straightforward than adding a static array property; even if you do, the auto-generation is still available for delegation. The auto-generation methods have boolean params to control their awareness and handling of inheritance.




C&P from 649 start:
This addresses a BC break somewhere in the 3.0.5 timeline where Elements inheriting from each other would at some point require `getType`, `getFormTemplate`, potentially `render` re-implementations, because automagically calculated template paths and admin types would be different from the earlier (always explicit) values coded into each element.

The motivation for that refactoring was to get rid of endless c&p of the three methods mentioned above.

This pull kind of "concludes" that work. C&P is not necessary for new elements inheriting directly from Element, and no necessity exists to override methods in child classes of concrete elements either, if the (intuitive) inheritance of AdminType and templates is desired. Old-style overrides (just reimplementing any or all of the methods) still works on this branch. Only the automatically generated values are affected at all.

Because this was already a BC break, and this pull is supposed to reestablish BC, its merge target is 3.0.5.

One issue was that there has not been a method to get the template path for the frontend. This logic was so far hard-embedded into the render method(s), and I assume a lot of C&Ping of that render method has been going on for that reason alone that makes it hard to analyze.


<...>

To see exactly what's happening, the (not included) Omg639Command code from the original issue #639 may be a good starting point.

C&P end


As the original PR has been approved, the intent seems understood and accepted.
I will abuse super-cow powers and merge, assuming acceptance transfers to this (better) implementation of the same intended change.
