### PR TITLE
Fix/element config exposure

### DIFF
--- a/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
@@ -331,7 +331,11 @@ class ElementClassesInspectCommand extends ContainerAwareCommand
         );
         foreach ($detectOverrides as $methodName => $messageStyle) {
             if ($this->detectMethodOverride($rc, $methodName)) {
-                $issues[] = "<$messageStyle>own {$methodName}</$messageStyle>";
+                $message = "<$messageStyle>own {$methodName}</$messageStyle>";
+                if ($issues && !(count($issues) % 2)) {
+                    $message = "\n$message";
+                }
+                $issues[] = $message;
             }
         }
         $parentClass = get_parent_class($element);
@@ -340,7 +344,7 @@ class ElementClassesInspectCommand extends ContainerAwareCommand
         } else {
             $parentNote = "";
         }
-        return trim(implode(', ', $issues) . "\n{$parentNote}", "\n");
+        return trim(trim(implode(', ', $issues), "\n") . "\n{$parentNote}", "\n");
     }
 
     protected function detectMethodOverride(\ReflectionClass $rc, $methodName)

--- a/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
@@ -324,13 +324,14 @@ class ElementClassesInspectCommand extends ContainerAwareCommand
             $issues[] = "<comment>deprecated</comment>";
         }
         $detectOverrides = array(
-            'render',
-            'getType',
-            'getFormTemplate',
+            'getConfiguration' => 'error',
+            'render' => 'comment',
+            'getType'=> 'comment',
+            'getFormTemplate' => 'comment',
         );
-        foreach ($detectOverrides as $methodName) {
+        foreach ($detectOverrides as $methodName => $messageStyle) {
             if ($this->detectMethodOverride($rc, $methodName)) {
-                $issues[] = "<comment>own {$methodName}</comment>";
+                $issues[] = "<$messageStyle>own {$methodName}</$messageStyle>";
             }
         }
         $parentClass = get_parent_class($element);

--- a/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ElementClassesInspectCommand.php
@@ -1,0 +1,350 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Command;
+
+
+use Mapbender\CoreBundle\Component\Application;
+use Mapbender\CoreBundle\Component\Element;
+use Mapbender\CoreBundle\Mapbender;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * CLI command to inspect Mapbender element classes and perform some sanity checks.
+ *
+ * Will detect / specially highlight:
+ * * missing / empty frontend template file (based on automatic template path calulation!)
+ * * reimplemented render / getType / getFormTemplate methods
+ * * missing AdminType class
+ * * Template not in same bundle as Element (for both frontend + admin template)
+ * * Element inheriting from other concrete Element
+ * * (overridden) AdminType class != automatically calculated AdminType class (to detect inheritance issues)
+ * * (overridden) form template != automatically calculated form template (to detect inheritance / convention issues)
+ *
+ * @package Mapbender\CoreBundle\Command
+ */
+class ElementClassesInspectCommand extends ContainerAwareCommand
+{
+    /** @var  Application */
+    protected static $dummyApplication;
+
+    protected function configure()
+    {
+        $this->setName('mapbender:inspect:element:classes');
+        $this->setHelp('Summarizes information about all available Mapbender Element classes in all currently active bundles');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $noteStyle = new OutputFormatterStyle('white', 'blue');
+        $output->getFormatter()->setStyle('note', $noteStyle);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $elementNames = $this->getElementNames();
+        $headers = array(
+            'Name',
+            'Comments',
+            'Template (auto-calculated)',
+            'AdminType',
+            'AdminTemplate',
+        );
+
+        $rows = array();
+        foreach ($elementNames as $elementName) {
+            try {
+                $instance = $this->createElementInstance($elementName);
+                $rows[$elementName] = $this->formatElementInfo($instance);
+            } catch (\Exception $e) {
+                $rows[$elementName] = array(
+                    "<error>$elementName</error>",
+                    "<error>{$e->getMessage()}</error>",
+                );
+            }
+        }
+        $this->renderInfoPerNamespace($output, $headers, $rows);
+    }
+
+    protected function renderInfoPerNamespace(OutputInterface $output, $headers, $rows)
+    {
+        ksort($rows);
+        // split the information into buckets by bundle namespace
+        $namespaceBuckets = array();
+        foreach ($rows as $elementName => $cells) {
+            $classNameParts = explode('\\', $elementName);
+            $bundleNamespace = implode('\\', array_slice($classNameParts, 0, 2));
+            if (!array_key_exists($bundleNamespace, $namespaceBuckets)) {
+                $namespaceBuckets[$bundleNamespace] = array();
+            }
+            $tail = array_slice($classNameParts, 2);
+            // Highlight classes that are not immediately in namespace "<bundle>\Element\".
+            // Otherwise, omit the "Element" part of the namespace for a more compact list
+            if ($tail[0] != 'Element') {
+                $shortenedClassName = "<comment>{$tail[0]}</comment>" . implode('\\', $tail);
+            } elseif (count($tail) != 2) {
+                $shortenedClassName = "<comment>" . implode('\\', $tail) . "<comment>";
+            } else {
+                $shortenedClassName = $tail[1];
+            }
+            $cells[0] = str_replace($elementName, $shortenedClassName, $cells[0]);
+            $namespaceBuckets[$bundleNamespace][$elementName] = $cells;
+        }
+        ksort($namespaceBuckets);
+
+        foreach ($namespaceBuckets as $bundleNamespace => $rows) {
+            $output->writeln("Elements in $bundleNamespace:");
+            $this->renderTable($output, $headers, $rows);
+        }
+    }
+
+    /**
+     * @param string $className
+     * @return string
+     */
+    protected static function extractBundleNamespace($className)
+    {
+        $classNameParts = explode('\\', $className);
+        return implode('\\', array_slice($classNameParts, 0, 2));
+    }
+
+    protected static function extractBundleNameFromClassName($className)
+    {
+        $classNameParts = explode('\\', $className);
+        return implode('', array_slice($classNameParts, 0, 2));
+    }
+
+    /**
+     * @param string $templatePath twig-style (":" separators")
+     * @return string
+     */
+    protected static function extractBundleNameFromTemplatePath($templatePath)
+    {
+        return implode('', array_slice(explode(':', $templatePath), 0, 1));
+    }
+
+    /**
+     * @param Element $element
+     * @return string[]
+     */
+    protected function formatElementInfo($element)
+    {
+        $templates = array(
+            $element->getFrontendTemplatePath(),
+            $element->getFormTemplate(),
+        );
+        $autoAdminTemplate = $element->getAutomaticTemplatePath('.html.twig', 'ElementAdmin');
+        $cells = array(
+            get_class($element),
+            $this->formatElementComments($element),
+            $this->formatTemplatePath($element, $templates[0], null),
+            $this->formatAdminType($element),
+            $this->formatTemplatePath($element, $templates[1], $autoAdminTemplate),
+        );
+        return $cells;
+    }
+
+    /**
+     * @param Element $element
+     * @return string
+     */
+    protected static function formatAdminType($element)
+    {
+        $adminType = $element->getType();
+        $autoAdminType = $element->getAutomaticAdminType();
+        $elementBNS = static::extractBundleNamespace(get_class($element));
+        $adminTypeBNS = static::extractBundleNamespace($adminType);
+
+        if (!class_exists($adminType)) {
+            // mark missing class as error
+            return "<error>$adminType</error>";
+        } elseif ($elementBNS != $adminTypeBNS) {
+            // highlight admin type in different bundle
+            return str_replace($adminTypeBNS, "<comment>{$adminTypeBNS}</comment>", $adminType);
+        } elseif ($adminType != $autoAdminType) {
+            // highlight admin type override that violates convention
+            return "<comment>$adminType</comment>\n(vs {$autoAdminType})";
+        } else {
+            return $adminType;
+        }
+    }
+
+    /**
+     * Instantiate an Element from the given class name
+     *
+     * @param string $elementName
+     * @return Element
+     */
+    protected function createElementInstance($elementName)
+    {
+        $application = $this->getDummyApplication();
+        $elementEntity = new \Mapbender\CoreBundle\Entity\Element();
+        return new $elementName($application, $this->getContainer(), $elementEntity);
+    }
+
+    /**
+     * @return Application
+     */
+    protected function getDummyApplication()
+    {
+        if (!static::$dummyApplication) {
+            $applicationEntity = new \Mapbender\CoreBundle\Entity\Application();
+            static::$dummyApplication = new Application($this->getContainer(), $applicationEntity, array());
+        }
+        return static::$dummyApplication;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getElementNames()
+    {
+        # @todo: bad return type annotation in Mapbender::getElements
+        /** @var string[] $elements */
+        $elements = $this->getMapbender()->getElements();
+        return $elements;
+    }
+
+    /**
+     * Returns a bundle-qualified file path (eg "@MapbenderCoreBundle/dir/another-dir/file.ext") from a twig-style
+     * template path. Twig can performing this conversion, but it's buried in a bunch of protected / private
+     * machinery, so we have to reimplement it ourselves.
+     *
+     * @param string $twigPath
+     * @return string
+     */
+    protected static function resourcePathFromTwigPath($twigPath)
+    {
+        $parts = explode(':', ltrim($twigPath, '@'));
+        $parts[1] = "Resources/views/{$parts[1]}";
+        return '@' . implode('/', $parts);
+    }
+
+    /**
+     * Checks if the file named by $twigPath exists and is non-empty.
+     *
+     * @param string $twigPath e.g. "MapbenderCoreBundle:<view-section>:some_template.html.twig"
+     * @return bool
+     */
+    protected function templateExists($twigPath)
+    {
+        // Kernel::locateResource seems to be the best general purpose resource locator
+        /** @var Kernel $kernel */
+        $kernel = $this->getContainer()->get('kernel');
+        /** Symfony file locators throw InvalidArgumentException if files are not found... */
+        try {
+            $realPath = $kernel->locateResource($this->resourcePathFromTwigPath($twigPath));
+            return file_exists($realPath) && filesize($realPath);
+        } catch (\InvalidArgumentException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return Mapbender
+     */
+    protected function getMapbender()
+    {
+        /** @var Mapbender $mapbenderService */
+        $mapbenderService = $this->getContainer()->get('mapbender');
+        return $mapbenderService;
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param string[] $headers
+     * @param array[] $rows
+     */
+    protected function renderTable(OutputInterface $output, $headers, $rows)
+    {
+        if (class_exists('Symfony\Component\Console\Helper\TableHelper')) {
+            $th = $this->getTableHelper();
+            $th->setHeaders($headers);
+            $th->setRows($rows);
+            $th->render($output);
+        } else {
+            $symfonyVersion = Kernel::VERSION;
+            throw new \RuntimeException("Table rendering support gone in Symfony $symfonyVersion");
+        }
+    }
+
+    /**
+     * @return TableHelper
+     * @todo: this will be gone in Symfony 3.0
+     */
+    protected function getTableHelper()
+    {
+        /** @var TableHelper $table */
+        $table = $this->getHelper('table');
+        $table->setCellRowFormat('%s');
+        $table->setCellHeaderFormat('%s');
+        return $table;
+    }
+
+    /**
+     * @param Element $element
+     * @param string $path twig-style
+     * @param string|null $expected also twig-style
+     * @return string
+     */
+    protected function formatTemplatePath($element, $path, $expected)
+    {
+        if (!$this->templateExists($path)) {
+            return "<error>$path</error>";
+        }
+        $templateBundle = static::extractBundleNameFromTemplatePath($path);
+        $elementBundle = static::extractBundleNameFromClassName(get_class($element));
+        if ($templateBundle != $elementBundle) {
+            $parts = explode(':', $path);
+            $info = "<note>{$parts[0]}</note>:" . implode(':', array_slice($parts, 1));
+        } else {
+            $info = $path;
+        }
+        if ($expected && $path != $expected) {
+            $info = "<comment>{$info}</comment>\n(vs {$expected})";
+        }
+        return $info;
+    }
+
+    /**
+     * @param Element $element
+     * @return string
+     */
+    protected function formatElementComments($element)
+    {
+        $issues = array();
+        $rc = new \ReflectionClass($element);
+        $classDoc = $rc->getDocComment();
+        if (strpos($classDoc, '@deprecated') !== false) {
+            $issues[] = "<comment>deprecated</comment>";
+        }
+        $detectOverrides = array(
+            'render',
+            'getType',
+            'getFormTemplate',
+        );
+        foreach ($detectOverrides as $methodName) {
+            if ($this->detectMethodOverride($rc, $methodName)) {
+                $issues[] = "<comment>own {$methodName}</comment>";
+            }
+        }
+        $parentClass = get_parent_class($element);
+        if ($parentClass != 'Mapbender\CoreBundle\Component\Element') {
+            $parentNote = "<note>parent: $parentClass</note>";
+        } else {
+            $parentNote = "";
+        }
+        return trim(implode(', ', $issues) . "\n{$parentNote}", "\n");
+    }
+
+    protected function detectMethodOverride(\ReflectionClass $rc, $methodName)
+    {
+        $rm = $rc->getMethod($methodName);
+        return $rm && ($rc->getName() == $rm->class);
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -319,7 +319,7 @@ class Application
             foreach ($elements as $element) {
                 $configuration['elements'][ $element->getId() ] = array(
                     'init'          => $element->getWidgetName(),
-                    'configuration' => $element->getConfiguration());
+                    'configuration' => $element->getPublicConfiguration());
             }
         }
 

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -5,6 +5,7 @@ namespace Mapbender\CoreBundle\Component;
 use Mapbender\CoreBundle\Entity\Element as Entity;
 use Mapbender\ManagerBundle\Component\Mapper;
 use Mapbender\ManagerBundle\Form\Type\YAMLConfigurationType;
+use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -224,15 +225,44 @@ abstract class Element
      */
     public function render()
     {
-        return $this->container->get('templating')->render($this->getFrontendTemplatePath(),
-            array(
-                'element'       => $this,
-                'id'            => $this->getId(),
-                'entity'        => $this->entity,
-                'title'         => $this->getTitle(),
-                'application'   => $this->application,
-                'configuration' => $this->getConfiguration()
-            ));
+        $defaultTemplateVars = array(
+            'element'       => $this,
+            'id'            => $this->getId(),
+            'entity'        => $this->entity,
+            'title'         => $this->getTitle(),
+            'application'   => $this->application,
+        );
+        $templateVars = array_replace($defaultTemplateVars, $this->getFrontendTemplateVars());
+        $templatePath = $this->getFrontendTemplatePath();
+
+        /** @var TwigEngine $templatingEngine */
+        $templatingEngine = $this->container->get('templating');
+        return $templatingEngine->render($templatePath, $templateVars);
+    }
+
+    /**
+     * Should return the variables available for the frontend template. By default, this
+     * is a single "configuration" value holding the entirety of the configuration from the element entity.
+     * Override this if you want to unravel / strip / extract / otherwise prepare specific values for your
+     * element template.
+     *
+     * NOTE: the default implementation of render automatically makes the following available:
+     * * "element" (Element component instance)
+     * * "application" (Application component instance)
+     * * "entity" (Element entity instance)
+     * * "id" (Element id, string)
+     * * "title" (Element title from entity, string)
+     *
+     * You do not need to, and should not, produce them yourself again. If you do, your values will replace
+     * the defaults!
+     *
+     * @return array
+     */
+    public function getFrontendTemplateVars()
+    {
+        return array(
+            'configuration' => $this->getConfiguration(),
+        );
     }
 
     /**
@@ -247,6 +277,21 @@ abstract class Element
     public function getFrontendTemplatePath($suffix = '.html.twig')
     {
         return $this->getAutomaticTemplatePath($suffix);
+    }
+
+    /**
+     * Should return the values available to the JavaScript client code. By default, this is the entirety
+     * of the "configuration" array from the element entity, which is insecure if your element configuration
+     * stores API keys, users / passwords embedded into URLs etc.
+     *
+     * If you have sensitive data anywhere near your element entity's configuration, you should override this
+     * method and emit only the values you need for your JavaScript to work.
+     *
+     * @return array
+     */
+    public function getPublicConfiguration()
+    {
+        return $this->getConfiguration();
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -329,11 +329,15 @@ abstract class Element
     }
 
     /**
-     * Get the publicly exposed configuration, usually directly derived from
-     * the configuration field of the configuration entity. If you, for
-     * example, store passwords in your element configuration, you should
-     * override this method to return a cleaned up version of your
-     * configuration which can safely be exposed in the client.
+     * Get the configuration from the element entity.
+     *
+     * This should primarily be used for exporting / importing.
+     *
+     * You SHOULD NOT do transformations specifically for your twig template or your JavaScript here,
+     * there are now dedicated methods exactly for that (see getFrontendTemplateVars and getPublicConfiguration).
+     * Anything you do here in a method override needs to be verified against application export + reimport.
+     *
+     * The backend usually accesses the entity instance directly, so it won't be affected.
      *
      * @return array
      */

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -230,6 +230,7 @@ abstract class Element
                 'id'            => $this->getId(),
                 'entity'        => $this->entity,
                 'title'         => $this->getTitle(),
+                'application'   => $this->application,
                 'configuration' => $this->getConfiguration()
             ));
     }

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -552,8 +552,6 @@ abstract class Element
      *
      * E.g. "FantasticMethodNaming" => "fantastic_method_naming"
      *
-     * Will not work with multiple consecutive upper-case letters
-     *
      * @todo: naming, location
      *
      * @param $className
@@ -562,15 +560,10 @@ abstract class Element
      */
     protected static function getTemplateName($className)
     {
-        $className = preg_replace_callback(
-            '/[A-Z]+[^A-Z]+/',
-            function ($match) {
-                return "_".strtolower($match[0]);
-            },
-            $className
-        );
-        $className = substr($className,1);
-        return $className;
+        // insert underscores before upper case letter following lower-case
+        $underscored = preg_replace('/([^A-Z])([A-Z])/', '\\1_\\2', $className);
+        // lower-case the whole thing
+        return strtolower($underscored);
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Redlining.php
+++ b/src/Mapbender/CoreBundle/Element/Redlining.php
@@ -75,15 +75,6 @@ class Redlining extends Element
     /**
      * @inheritdoc
      */
-    public function getConfiguration()
-    {
-        $config = parent::getConfiguration();
-        return $config;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public static function getType()
     {
         return 'Mapbender\CoreBundle\Element\Type\RedliningAdminType';

--- a/src/Mapbender/PrintBundle/Element/ImageExport.php
+++ b/src/Mapbender/PrintBundle/Element/ImageExport.php
@@ -73,15 +73,6 @@ class ImageExport extends Element
     /**
      * @inheritdoc
      */
-    public function getConfiguration()
-    {
-        $config = parent::getConfiguration();
-        return $config;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public static function getType()
     {
         return 'Mapbender\PrintBundle\Element\Type\ImageExportAdminType';

--- a/src/Mapbender/WmcBundle/Element/WmcEditor.php
+++ b/src/Mapbender/WmcBundle/Element/WmcEditor.php
@@ -97,14 +97,6 @@ class WmcEditor extends Element
     /**
      * @inheritdoc
      */
-    public function getConfiguration()
-    {
-        return parent::getConfiguration();
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function render()
     {
         $config = $this->getConfiguration();


### PR DESCRIPTION
Basic mechanism to separate element template variables from client-visible configuration (for javascript widgets etc) from internally used configuration (from entity, sometimes internally extended to service httpAction needs).

This is only the mechanism. No implementation has been touched. This should be compatible with everything.

The new methods getFrontendTemplateVars and getPublicConfiguration in the Element base class do the same as before: pipe through the entire result of getConfiguration.

But with these methods in place, child classes can hook onto them and filter / transform these values without having to mess with getConfiguration (which may be risky, because it would interfere with exporting applications, and internal httpAction processing).