### PR TITLE
Fix corrupted serialization of MetadataUrl

### DIFF
--- a/src/Mapbender/WmsBundle/Component/MetadataUrl.php
+++ b/src/Mapbender/WmsBundle/Component/MetadataUrl.php
@@ -18,27 +18,6 @@ class MetadataUrl
      */
     public $type;
 
-    /** @var string */
-    protected $url;
-
-    /**
-     * Creates a MetadataUrl object from parameters
-     *
-     * @param array $parameters
-     * @return MetadataUrl
-     */
-    public static function create($parameters)
-    {
-        $metadataUrl = new MetadataUrl();
-        if (isset($parameters["type"])) {
-            $metadataUrl->type = $parameters["type"];
-        }
-        if (isset($parameters["url"])) {
-            $metadataUrl->url = $parameters["url"];
-        }
-        return $metadataUrl;
-    }
-
     /**
      * Get type
      *


### PR DESCRIPTION
Fixes #746.

Protected attribute `$url` removed, unused factory method `create` removed. Serialization result becomes valid, storage to database (when adding the WMS as a new source) works, reload works, no more exception on Postgres driver.

Previous database values remain corrupted. View / refresh / delete still not possible with fix. Manual cleanup required.

Recommend identifying the id of the affected source (it's in the backend listing and also in the URLs where you would see the exception), and running
```sql
UPDATE mb_wms_wmslayersource SET metadataurl = NULL WHERE wmssource = <your wms id here>;
```