### PR TITLE
Dimension handler: fix lost config in frontend

### DIFF
--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.dimensionshandler.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.dimensionshandler.js
@@ -28,12 +28,6 @@
             var dimension = Mapbender.Dimension(dimensionset['dimension']);
             var def = dimension.partFromValue(dimension.getDefault());// * 100;
             var valarea = $('#' + key + ' .dimensionset-value', this.element);
-            $.each(dimensionset.group, function (idx, item) {
-                var temp = self.model.findSource({origId: item.split('-')[0]});
-                if (temp.length > 0 && temp[0].configuration.options.dimensions) {
-                    temp[0].configuration.options.dimensions = [];
-                }
-            });
             valarea.text(dimension.getDefault());
             $('#' + key + ' .mb-slider', this.element).slider({
                 min: 0,


### PR DESCRIPTION
There was some "Update the code" commit that introduced a loop over the dimension configuration in layersets, and emptied it, by reference.

This pull fixes that. Dimension configration survives app initialization.