### PR TITLE
Enhancement/form validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * **v.3.0.6.4**
+    - Validate Element forms in backend
     - Fix displaying scale value in scale selector #657
     - Fix GetLegendGraphic tunnel
 

--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -7,10 +7,8 @@ use Mapbender\ManagerBundle\Component\Mapper;
 use Mapbender\ManagerBundle\Form\Type\YAMLConfigurationType;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * Base class for all Mapbender elements.

--- a/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
@@ -9,8 +9,25 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 
-class MapbenderCoreExtension extends Extension {
-    public function load(array $configs, ContainerBuilder $container) {
+class MapbenderCoreExtension extends Extension
+{
+    const CONFIG_PATH = __DIR__ . '/../Resources/config';
+
+    /**
+     * @var FileLocator
+     */
+    private $fileLocator;
+
+    /**
+     * MapbenderCoreExtension constructor.
+     */
+    public function __construct()
+    {
+        $this->fileLocator = new FileLocator(self::CONFIG_PATH);
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
@@ -30,14 +47,73 @@ class MapbenderCoreExtension extends Extension {
         $now = new \DateTime('now');
         $container->setParameter("mapbender.cache_creation", $now->format('c'));
 
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.xml');
-        
-        $loader2 = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader2->load('mapbender.yml');
+        $this
+            ->loadXmlConfigs($container)
+            ->loadYmlConfigs($container);
     }
 
     public function getAlias() {
         return 'mapbender_core';
+    }
+
+    /**
+     * @param $container
+     * @return $this
+     */
+    protected function loadXmlConfigs($container)
+    {
+        $loader = new XmlFileLoader($container, $this->fileLocator);
+        $configFiles = $this->getXmlConfigs();
+
+        $this->loadConfigs($loader, $configFiles);
+
+        return $this;
+    }
+
+    /**
+     * @param $container
+     * @return $this
+     */
+    protected function loadYmlConfigs($container)
+    {
+        $loader = new YamlFileLoader($container, $this->fileLocator);
+        $configs = $this->getYmlConfigs();
+
+        $this->loadConfigs($loader, $configs);
+
+        return $this;
+    }
+
+    /**
+     * @param $loader
+     * @param $configs
+     */
+    protected function loadConfigs($loader, $configs)
+    {
+        foreach ($configs as $config) {
+            $loader->load($config);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getYmlConfigs()
+    {
+        return [
+            'mapbender.yml',
+            'constraints.yml',
+            'formTypes.yml',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getXmlConfigs()
+    {
+        return [
+            'services.xml',
+        ];
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/HTMLElementAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/HTMLElementAdminType.php
@@ -5,11 +5,35 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+use Mapbender\CoreBundle\Validator\Constraints\HtmlConstraint;
+use Mapbender\CoreBundle\Validator\Constraints\TwigConstraint;
+
 /**
  * 
  */
 class HTMLElementAdminType extends AbstractType
 {
+    /**
+     * @var HtmlConstraint
+     */
+    private $htmlConstraint;
+
+    /**
+     * @var TwigConstraint
+     */
+    private $twigConstraint;
+
+    /**
+     * HTMLElementAdminType constructor
+     *
+     * @param HtmlConstraint $htmlConstraint
+     * @param TwigConstraint $twigConstraint
+     */
+    public function __construct(HtmlConstraint $htmlConstraint, TwigConstraint $twigConstraint)
+    {
+        $this->htmlConstraint = $htmlConstraint;
+        $this->twigConstraint = $twigConstraint;
+    }
 
     /**
      * @inheritdoc
@@ -35,9 +59,15 @@ class HTMLElementAdminType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('content', 'textarea', array(
-                'required' => false))
-            ->add('classes', 'text', array(
-                'required' => false));
+            ->add('content', 'textarea', [
+                'required' => false,
+                'constraints' => [
+                    $this->htmlConstraint,
+                    $this->twigConstraint,
+                ]
+            ])
+            ->add('classes', 'text', [
+                'required' => false,
+            ]);
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/constraints.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/constraints.yml
@@ -1,0 +1,10 @@
+services:
+
+    #
+    # Constraints
+    #
+    mapbender.constraint.html:
+        class: Mapbender\CoreBundle\Validator\Constraints\HtmlConstraint
+
+    mapbender.constraint.twig:
+        class: Mapbender\CoreBundle\Validator\Constraints\TwigConstraint

--- a/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
@@ -1,0 +1,15 @@
+services:
+
+    #
+    # Form Types
+    #
+    # Form types must be prefixed with "mapbender.form_type.element"
+    # to be accessible by initialisation in MB Core
+    #
+    mapbender.form_type.element.htmlelement:
+        class: Mapbender\CoreBundle\Element\Type\HTMLElementAdminType
+        arguments:
+            - '@mapbender.constraint.html'
+            - '@mapbender.constraint.twig'
+        tags:
+            - { name: form.type, alias: htmlelement }

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.de.yml
@@ -1,0 +1,2 @@
+html.invalid: 'HTML enthält einen Fehler!'
+twig.invalid: 'TWIG enthält einen Fehler!'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.en.yml
@@ -1,0 +1,2 @@
+html.invalid: 'HTML contains an error!'
+twig.invalid: 'TWIG contains an error!'

--- a/src/Mapbender/CoreBundle/Validator/Constraints/HtmlConstraint.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/HtmlConstraint.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class HtmlConstraint
+ *
+ * @package Mapbender\CoreBundle\Validator\Constraints
+ */
+class HtmlConstraint extends Constraint
+{
+    public $message = 'html.invalid';
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/HtmlConstraintValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/HtmlConstraintValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Class HtmlConstraintValidator
+ *
+ * @package Mapbender\CoreBundle\Validator\Constraints
+ */
+class HtmlConstraintValidator extends ConstraintValidator
+{
+    /**
+     * @param string $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        try {
+            $dom = new \DOMDocument;
+            $dom->loadHTML($value);
+        } catch (\Exception $e) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraint.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraint.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class TwigConstraint
+ *
+ * @package Mapbender\CoreBundle\Validator\Constraints
+ */
+class TwigConstraint extends Constraint
+{
+    public $message = 'twig.invalid';
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraintValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraintValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Class TwigConstraintValidator
+ *
+ * @package Mapbender\CoreBundle\Validator\Constraints
+ */
+class TwigConstraintValidator extends ConstraintValidator
+{
+    /**
+     * @param string $twigString
+     * @param Constraint $constraint
+     */
+    public function validate($twigString, Constraint $constraint)
+    {
+        try {
+            $twig = new \Twig_Environment();
+            $twig->parse($twig->tokenize($twigString));
+        } catch (\Twig_Error_Syntax $e) {
+            $this->context->addViolation($constraint->message);
+            $this->context->addViolation($e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This pull request relates to the issue https://github.com/mapbender/mapbender/issues/756 and contains:
-  declaration form types as services to be able to inject there any other necessary/desired services
- initialization of form type by taking it from the container using its service id
- declaration of constraints as services
- provided constraints and validators to validate html and twig content by HTMLElement setup

