### PR TITLE
Fix/unittest preconditions to support PHP7.3

### DIFF
--- a/src/Mapbender/CoreBundle/Tests/SeleniumPhantomJsTest.php
+++ b/src/Mapbender/CoreBundle/Tests/SeleniumPhantomJsTest.php
@@ -7,9 +7,8 @@ class SeleniumPhantomJsTest extends \PHPUnit_Extensions_Selenium2TestCase
 
     public function setUp()
     {
-        if (PHP_MINOR_VERSION == 3) {
-            $this->markTestIncomplete('This test does not run on PHP 5.3.');
-            return;
+        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
+            $this->markTestSkipped('This test requires PHP >= 5.4');
         }
         $this->setHost('localhost');
         $this->setPort(9876);

--- a/src/Mapbender/CoreBundle/Tests/SeleniumPythonTest.php
+++ b/src/Mapbender/CoreBundle/Tests/SeleniumPythonTest.php
@@ -12,6 +12,11 @@ class SeleniumPythonTest extends WebTestCase
         if (!version_compare(PHP_VERSION, '5.4', '>=')) {
             $this->markTestSkipped('This test requires PHP >= 5.4');
         }
+        $retCode = null;
+        passthru('python -c "import selenium" 2>/dev/null', $retCode);
+        if ($retCode !== 0) {
+            $this->markTestSkipped('This test requires Python and the selenium Python package');
+        }
     }
 
     public function moduleProvider()

--- a/src/Mapbender/CoreBundle/Tests/SeleniumPythonTest.php
+++ b/src/Mapbender/CoreBundle/Tests/SeleniumPythonTest.php
@@ -9,9 +9,8 @@ class SeleniumPythonTest extends WebTestCase
 {
     public function setUp()
     {
-        if (PHP_MINOR_VERSION == 3) {
-            $this->markTestIncomplete('This test does not run on PHP 5.3.');
-            return;
+        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
+            $this->markTestSkipped('This test requires PHP >= 5.4');
         }
     }
 


### PR DESCRIPTION
Unit tests in mapbender CoreBundle have [naive minor-version checks that will falsely identify PHP7.3 as PHP 5.3 and fail the tests](https://github.com/mapbender/mapbender/blob/9073dd06b57841e32c9369583b5e776f0221c8b1/src/Mapbender/CoreBundle/Tests/SeleniumPhantomJsTest.php#L10).

This pull fixes the version check to require PHP >= 5.4.

This pull also adds a check in the Python/Selenium test that skips the test if no Python or no selenium Python module can be loaded.

This pull also changes the failure mode of preconditions to use a SkippedTestError instead of (previously) IncompleteTestError, following PHPUnit's conventions and internal behaviour on what kind of error to throw when a test can't execute.