### PR TITLE
Feature/doctrine migrations

### DIFF
--- a/src/Mapbender/Component/DoctrineMigrationsHelper/MigrationFinder.php
+++ b/src/Mapbender/Component/DoctrineMigrationsHelper/MigrationFinder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Mapbender\Component\DoctrineMigrationsHelper;
+
+use Doctrine\DBAL\Migrations\Finder\AbstractFinder;
+use Doctrine\DBAL\Migrations\Finder\MigrationDeepFinderInterface;
+
+/**
+ * Class MigrationFinder
+ * Extends Doctrine\DBAL\Migrations\Finder\RecursiveRegexFinder
+ *
+ * @package Mapbender\Component
+ */
+class MigrationFinder extends AbstractFinder implements MigrationDeepFinderInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findMigrations($directory, $namespace = null)
+    {
+        $dir = $this->getRealPath($directory);
+
+        return $this->loadMigrations($this->getMatches($this->createIterator($dir)), $namespace);
+    }
+
+    /**
+     * Create a recursive iterator to find all the migrations in the subdirectories.
+     * @param $dir
+     * @return \RegexIterator
+     */
+    private function createIterator($dir)
+    {
+        return new \RegexIterator(
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            $this->getPattern(),
+            \RegexIterator::GET_MATCH
+        );
+    }
+
+    private function getPattern()
+    {
+        return sprintf('#^.+\\%sVersion[^\\%s]{1,255}\\.php$#i', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Transform the recursiveIterator result array of array into the expected array of migration file
+     * @param $iteratorFilesMatch
+     * @return array
+     */
+    private function getMatches($iteratorFilesMatch)
+    {
+        $files = [];
+        foreach ($iteratorFilesMatch as $file) {
+            $files[] = $file[0];
+        }
+
+        return $files;
+    }
+}

--- a/src/Mapbender/Component/DoctrineMigrationsHelper/MigrationsOutputWriter.php
+++ b/src/Mapbender/Component/DoctrineMigrationsHelper/MigrationsOutputWriter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mapbender\Component\DoctrineMigrationsHelper;
+
+use Doctrine\DBAL\Migrations\OutputWriter;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class MigrationsOutputWriter
+ *
+ * @package Mapbender\Component
+ */
+class MigrationsOutputWriter extends OutputWriter
+{
+    public function __construct(OutputInterface $output)
+    {
+        parent::__construct(function ($message) use ($output) {
+            return $output->writeln($message);
+        });
+    }
+}

--- a/src/Mapbender/Component/SymlinkInstaller/SymlinkInstaller.php
+++ b/src/Mapbender/Component/SymlinkInstaller/SymlinkInstaller.php
@@ -1,0 +1,225 @@
+<?php
+namespace Mapbender\Component\SymlinkInstaller;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Class SymlinkInstaller
+ *
+ * @package Mapbender\Component\SymlinkInstaller
+ */
+class SymlinkInstaller implements SymlinkInstallerInterface
+{
+    const METHOD_COPY = 'copy';
+    const METHOD_ABSOLUTE_SYMLINK = 'absolute symlink';
+    const METHOD_RELATIVE_SYMLINK = 'relative symlink';
+
+    private $filesystem = null;
+    private $originDir = null;
+    private $targetDir = null;
+    private $relativeOriginDir = null;
+
+    private $methodSymlinksAreInstalledBy;
+
+    /**
+     * SymlinkInstaller constructor.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Directory a symlink is created from
+     *
+     * @param string $originDir
+     * @return $this
+     */
+    public function setOriginDir($originDir)
+    {
+        $this->originDir = $originDir;
+
+        return $this;
+    }
+
+    /**
+     * Directory where a symlink will be created
+     *
+     * @param string $targetDir
+     * @return $this
+     */
+    public function setTargetDir($targetDir)
+    {
+        $this->targetDir = $targetDir;
+
+        return $this;
+    }
+
+    /**
+     * Install symlinks by method
+     *
+     * @param string $installationMethod
+     */
+    public function installSymlinks($installationMethod)
+    {
+        switch ($installationMethod) {
+            case self::METHOD_RELATIVE_SYMLINK:
+                $this->relativeSymlinkWithFallback();
+                break;
+            case self::METHOD_ABSOLUTE_SYMLINK:
+                $this->absoluteSymlinkWithFallback();
+                break;
+            default:
+                $this->hardCopy();
+        }
+    }
+
+    /**
+     * Try to create relative symlink
+     *
+     * Falling back to absolute symlink and finally hard copy
+     */
+    public function relativeSymlinkWithFallback()
+    {
+        try {
+            $this->setRelativeOriginDir();
+            $this->symlink();
+        } catch (IOException $e) {
+            $this->absoluteSymlinkWithFallback();
+        }
+
+        $this->methodSymlinksAreInstalledBy = self::METHOD_RELATIVE_SYMLINK;
+    }
+
+    /**
+     * Try to create absolute symlink
+     *
+     * Falling back to hard copy
+     */
+    public function absoluteSymlinkWithFallback()
+    {
+        try {
+            $this->symlink();
+        } catch (IOException $e) {
+            $this->hardCopy();
+        }
+
+        $this->methodSymlinksAreInstalledBy = self::METHOD_ABSOLUTE_SYMLINK;
+    }
+
+    /**
+     * Creates symbolic link
+     *
+     * @throws IOException If link can not be created.
+     */
+    public function symlink()
+    {
+        $this->checkSettings();
+
+        $this->filesystem->symlink($this->relativeOriginDir ?? $this->originDir, $this->targetDir);
+
+        if (!file_exists($this->targetDir)) {
+            throw new IOException(sprintf('Symbolic link "%s" was created but appears to be broken.', $this->targetDir), 0, null, $this->targetDir);
+        }
+    }
+
+    /**
+     * Copies origin to target
+     */
+    public function hardCopy()
+    {
+        $this->checkSettings();
+
+        $this
+            ->filesystem
+            ->mkdir($this->targetDir, 0777);
+
+        $this
+            ->filesystem
+            ->mirror(
+                $this->originDir,
+                $this->targetDir,
+                Finder::create()->ignoreDotFiles(false)->in($this->originDir)
+            );
+
+        $this->methodSymlinksAreInstalledBy = self::METHOD_COPY;
+    }
+
+    /**
+     * Set relative origin dir using relative path of origin folder
+     */
+    private function setRelativeOriginDir()
+    {
+        $this->relativeOriginDir = $this->filesystem->makePathRelative($this->originDir, realpath(dirname($this->targetDir)));
+    }
+
+    /**
+     * Check if all necessary settings are set
+     */
+    private function checkSettings()
+    {
+        $this
+            ->isSetFilesystem()
+            ->isSetOriginDir()
+            ->isSetTargetDir();
+    }
+
+    /**
+     * Check if a filesystem is set
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    private function isSetFilesystem()
+    {
+        if (null === $this->filesystem) {
+            throw new \Exception('File system is not set');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if an origin directory path is set
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    private function isSetOriginDir()
+    {
+        if (null === $this->originDir) {
+            throw new \Exception('Origin symlink folder is not set');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if target directory path is set
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    private function isSetTargetDir()
+    {
+        if (null === $this->targetDir) {
+            throw new \Exception('Target symlink folder is not set');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get method files are installed by
+     *
+     * @return string mixed
+     */
+    public function getMethodSymlinksAreInstalledBy()
+    {
+        return $this->methodSymlinksAreInstalledBy;
+    }
+}

--- a/src/Mapbender/Component/SymlinkInstaller/SymlinkInstallerInterface.php
+++ b/src/Mapbender/Component/SymlinkInstaller/SymlinkInstallerInterface.php
@@ -1,0 +1,70 @@
+<?php
+namespace Mapbender\Component\SymlinkInstaller;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+
+interface SymlinkInstallerInterface
+{
+    /**
+     * Directory a symlink is created from
+     *
+     * @param string $originDir
+     * @return $this
+     */
+    public function setOriginDir($originDir);
+
+    /**
+     * Directory where a symlink will be created
+     *
+     * @param string $targetDir
+     * @return $this
+     */
+    public function setTargetDir($targetDir);
+
+    /**
+     * Install symlinks by method
+     *
+     * @param string $installationMethod
+     */
+    public function installSymlinks($installationMethod);
+
+    /**
+     * Creates symbolic link.
+     *
+     * @throws IOException If link can not be created.
+     */
+    public function symlink();
+
+    /**
+     * Try to create relative symlink.
+     *
+     * Falling back to absolute symlink and finally hard copy.     *
+     *
+     * @return string
+     */
+    public function relativeSymlinkWithFallback();
+
+    /**
+     * Try to create absolute symlink.
+     *
+     * Falling back to hard copy.
+     *
+     * @return string
+     */
+    public function absoluteSymlinkWithFallback();
+
+    /**
+     * Copies origin to target.
+     *
+     * @return string
+     */
+    public function hardCopy();
+
+    /**
+    * Get method files are installed by
+    *
+    * @return string mixed
+    */
+    public function getMethodSymlinksAreInstalledBy();
+
+}

--- a/src/Mapbender/CoreBundle/Command/MigrationsInstallCommand.php
+++ b/src/Mapbender/CoreBundle/Command/MigrationsInstallCommand.php
@@ -1,0 +1,315 @@
+<?php
+namespace Mapbender\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+use Mapbender\Component\SymlinkInstaller\SymlinkInstaller;
+
+/**
+ * Class MigrationsInstallCommand
+ *
+ * @package Mapbender\CoreBundle\Command
+ */
+class MigrationsInstallCommand extends ContainerAwareCommand
+{
+    const MIGRATIONS_BUNDLE_NAME = 'DoctrineMigrationsBundle';
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $style;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string Installation Type: copy | absolute symlink | relative symlink
+     */
+    private $installationMethod;
+
+    /**
+     * @var string Path to bundles folder in default application migrations folder
+     */
+    private $bundlesDir;
+
+    /**
+     * @var int Command exit code
+     */
+    private $exitCode = 0;
+
+    /**
+     * @var array Summary table rows
+     */
+    private $outputTableRows = [];
+
+    /**
+     * @var SymlinkInstaller
+     */
+    private $symlinkInstaller;
+
+    public function __construct(SymlinkInstaller $symlinkInstaller, $name = null)
+    {
+        parent::__construct($name);
+
+        $this->symlinkInstaller = $symlinkInstaller;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('migrations:install')
+            ->setDescription('Install migrations from all delivered by Mapbender bundles')
+            ->addOption('copy', null, InputOption::VALUE_NONE, 'Copy migrations instead of symlink it')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command installs bundle migrations into your doctrine migrations folder (default is <info>app/DoctrineMigrations</info>). 
+
+The command checks if DoctrineMigrationsBundle is installed and stops if it's missing.
+
+A "bundles" directory will be created inside the target directory and the
+"DoctrineMigrations" directory of each bundle will be symlink into it. 
+It will fall back to hard copies when symbolic links aren't possible.
+
+To copy migration files to each bundle instead of create a symlink, use the <info>--copy</info> option:
+<info>php %command.full_name% --copy</info>
+
+EOT
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->style = new SymfonyStyle($this->input, $this->output);
+
+        try {
+            $this->checkDoctrineMigrationsBundleStatus();
+            $this->installMigrations();
+        } catch (\Exception $exception) {
+            $this
+                ->style
+                ->error($exception->getMessage());
+        }
+
+        return $this->exitCode;
+    }
+
+    /**
+     * Check if DoctrineMigrationsBundle is installed in an application
+     *
+     * @throws \Exception
+     */
+    protected function checkDoctrineMigrationsBundleStatus()
+    {
+        $this
+            ->output
+            ->writeln('Check if DoctrineMigrationBundle is installed in the application');
+
+        $installedBundles = $this->getContainer()->get('kernel')->getBundles();
+
+        if (!isset($installedBundles[self::MIGRATIONS_BUNDLE_NAME])) {
+            throw new \Exception('MigrationsDoctrineBundle is not installed in the application. Please install it and run the command again');
+        }
+    }
+
+    /**
+     * Create symlinks|copies of migrations in all application bundles
+     */
+    protected function installMigrations()
+    {
+        $this
+            ->output
+            ->writeln('Install migrations of bundles into application migrations folder');
+
+        $this
+            ->setFilesystem()
+            ->createBundlesMigrationsFolder()
+            ->setInstallationMethod()
+            ->installBundlesMigrations()
+            ->outputInstallationSummary();
+    }
+
+    /**
+     * Set filesystem from filesystem service
+     *
+     * @return $this
+     */
+    private function setFilesystem()
+    {
+        $this->filesystem = $this
+            ->getContainer()
+            ->get('filesystem');
+
+        return $this;
+    }
+
+    /**
+     * Create bundles folder in defult doctrine migrations application folder
+     *
+     * @return $this
+     */
+    protected function createBundlesMigrationsFolder()
+    {
+        $targetFolder = $this->getContainer()->getParameter('doctrine_migrations.dir_name');
+
+        if (!is_dir($targetFolder)) {
+            $this
+                ->filesystem
+                ->mkdir($targetFolder, 0777);
+        }
+
+        $this->bundlesDir = $targetFolder.'/bundles/';
+
+        $this->filesystem->mkdir($this->bundlesDir, 0777);
+
+        return $this;
+    }
+
+    /**
+     * Set installation method depends on input data
+     *
+     * @return $this
+     */
+    protected function setInstallationMethod()
+    {
+        if ($this->input->getOption('copy')) {
+            $this->installationMethod = SymlinkInstaller::METHOD_COPY;
+            $this
+                ->style
+                ->text('Installing migrations as <info>hard copies</info>.');
+        } else {
+            $this->installationMethod = SymlinkInstaller::METHOD_RELATIVE_SYMLINK;
+            $this
+                ->style
+                ->text('Trying to install migrations as <info>relative symbolic links</info>.');
+
+        }
+
+        $this->style->newLine();
+
+        return $this;
+    }
+
+    /**
+     * Crete symlinks|copies of migration files into corresponding folders
+     *
+     * @return $this
+     */
+    protected function installBundlesMigrations()
+    {
+        $validMigrationDirs = [];
+
+        $bundles = $this
+            ->getContainer()
+            ->get('kernel')
+            ->getBundles();
+
+        /** @var BundleInterface $bundle */
+        foreach ($bundles as $bundle) {
+            $originDir = $bundle->getPath().'/DoctrineMigrations/';
+
+            if (!is_dir($originDir)) {
+                continue;
+            }
+
+            $migrationDir = preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+            $targetDir = $this->bundlesDir . $migrationDir;
+            $validMigrationDirs[] = $migrationDir;
+
+            if (OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                $rowContent = sprintf("%s\n-> %s", $bundle->getName(), $targetDir);
+            } else {
+                $rowContent = $bundle->getName();
+            }
+
+            try {
+                $this->filesystem->remove($targetDir);
+
+                $this
+                    ->symlinkInstaller
+                    ->setOriginDir($originDir)
+                    ->setTargetDir($targetDir)
+                    ->installSymlinks($this->installationMethod);
+
+                $this->addSummaryTableRow($rowContent);
+
+            } catch (\Exception $e) {
+                $this->exitCode = 1;
+                $this->outputTableRows[] = [
+                    sprintf('<fg=red;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'ERROR' : "\xE2\x9C\x98"),
+                    $rowContent,
+                    $e->getMessage()
+                ];
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add summary info about bundle migrations installation
+     *
+     * @param $message
+     */
+    private function addSummaryTableRow($message)
+    {
+        $method = $this->symlinkInstaller->getMethodSymlinksAreInstalledBy();
+
+        if ($method === $this->installationMethod) {
+            $this->outputTableRows[] = [
+                sprintf('<fg=green;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'OK' : "\xE2\x9C\x94"),
+                $message,
+                $method,
+            ];
+        } else {
+            $this->outputTableRows[] = [
+                sprintf('<fg=yellow;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'WARNING' : '!'),
+                $message,
+                $method,
+            ];
+        }
+    }
+
+    /**
+     * Show summary of migrations installation
+     *
+     * @return $this
+     */
+    protected function outputInstallationSummary()
+    {
+        $this->style->table(array('', 'Bundle', 'Method / Error'), $this->outputTableRows);
+
+        if (0 !== $this->exitCode) {
+            $this->style->error('Some errors occurred while installing migrations.');
+        } else {
+            $this->style->success('All migrations were successfully installed.');
+        }
+
+        return $this;
+    }
+
+
+}

--- a/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
@@ -37,6 +37,7 @@ class MapbenderCoreExtension extends Extension {
         $ymlLoader->load('mapbender.yml');
         $ymlLoader->load('components.yml');
         $ymlLoader->load('commands.yml');
+        $ymlLoader->load('migrations.yml');
     }
 
     public function getAlias() {

--- a/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
@@ -30,11 +30,13 @@ class MapbenderCoreExtension extends Extension {
         $now = new \DateTime('now');
         $container->setParameter("mapbender.cache_creation", $now->format('c'));
 
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.xml');
+        $xmlLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $xmlLoader->load('services.xml');
         
-        $loader2 = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader2->load('mapbender.yml');
+        $ymlLoader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $ymlLoader->load('mapbender.yml');
+        $ymlLoader->load('components.yml');
+        $ymlLoader->load('commands.yml');
     }
 
     public function getAlias() {

--- a/src/Mapbender/CoreBundle/DoctrineMigrations/2017/11/Version20171130085139.php
+++ b/src/Mapbender/CoreBundle/DoctrineMigrations/2017/11/Version20171130085139.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Migration to modify image path
+ */
+class Version20171130085139 extends AbstractMigration
+{
+    private $configuration = [
+        'className'    => 'Mapbender\CoreBundle\Element\Map',
+        'oldImagePath' => 'bundles/mapbendercore/mapquery/lib/openlayers/img',
+        'newImagePath' => 'components/mapquery/lib/openlayers/img',
+    ];
+
+
+    /**
+     * Check if there are some map elements before migrate
+     *
+     * @param Schema $schema
+     */
+    public function preUp(Schema $schema)
+    {
+        $this->checkMapElementsQuantity();
+    }
+
+
+    /**
+     * Change the image path from the old one to the new one
+     *
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->write('Updating map elements image path values from ' . $this->configuration['oldImagePath'] . ' to ' . $this->configuration['newImagePath']);
+
+        $this
+            ->addSql(
+                "UPDATE mb_core_element SET configuration = REPLACE(configuration, :oldImagePath, :newImagePath) WHERE class = :className",
+                $this->configuration
+            );
+
+        $this->write('All image path values are successfully updated');
+    }
+
+
+    /**
+     * Check if there are some map elements before revert the migration
+     *
+     * @param Schema $schema
+     */
+    public function preDown(Schema $schema)
+    {
+        $this->checkMapElementsQuantity();
+    }
+
+
+    /**
+     * Change the image path from the new one to the old one
+     *
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->write('Revert map elements image path values from ' . $this->configuration['newImagePath'] . ' to ' . $this->configuration['oldImagePath']);
+
+        $this
+            ->addSql(
+                "UPDATE mb_core_element SET configuration = REPLACE(configuration, :newImagePath, :oldImagePath) WHERE class = :className",
+                $this->configuration
+            );
+
+        $this->write('All image path values are successfully updated');
+    }
+
+
+    /**
+     * Check if we have map elements to update
+     */
+    private function checkMapElementsQuantity()
+    {
+        $result = $this
+            ->connection
+            ->fetchAssoc(
+                "SELECT COUNT(*) as elementsQuantity FROM mb_core_element WHERE class = :className",
+                $this->configuration
+            );
+
+        $elementsQuantity = $result['elementsQuantity'];
+
+        $this->write('Found ' . $elementsQuantity . ' map elements');
+        $this->skipIf($elementsQuantity == 0, 'No rows has been found');
+    }
+}

--- a/src/Mapbender/CoreBundle/DoctrineMigrations/README.md
+++ b/src/Mapbender/CoreBundle/DoctrineMigrations/README.md
@@ -1,0 +1,45 @@
+# Doctrine Migrations
+
+## How to use 
+First of all you have to install [DoctrineMigrationsBundle](https://symfony.com/doc/master/bundles/DoctrineMigrationsBundle/index.html).
+
+### Configuration
+You can provide some custom configuration for your migrations in the app/config/config.yml file.
+
+* dir_name: a folder in you project where migrations will be stored. 
+* namespace: a namespace for migration calsses
+* table_name: a table where will be stored information about migrations executions
+* organize_migrations: the way how your migrations will be stored in the folder. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false
+
+### Create a new migration
+* Generate a migration by comparing your current database to your mapping information:
+```
+app/console doctrine:migrations:diff
+```
+* Generate a blank migration class
+```
+app/console doctrine:migrations:generate
+```
+In the current folder you can find two migrations example: with SQL code and with EntityManager.
+
+### Execute migrations
+* Execute migrations to a specified version or the latest available version
+```
+app/console doctrine:migrations:migrate
+```
+* Execute a single migration
+```
+app/console doctrine:migrations:execute [migration]
+```
+* Revert migration (only in case if the down() function is developed)
+```
+app/console doctrine:migrations:execute [migration] --down
+```
+* Execute the same migration ones again
+```
+app/console doctrine:migrations:execute [migration] --up
+```
+
+## Documentation
+* Symfony documentation: [DoctrineMigrationsBundle](https://symfony.com/doc/master/bundles/DoctrineMigrationsBundle/index.html)
+* Doctrine documentation: [Doctrine Migrations](http://docs.doctrine-project.org/projects/doctrine-migrations/en/latest/reference/introduction.html)

--- a/src/Mapbender/CoreBundle/Resources/config/commands.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/commands.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Mapbender Migrations Command
+    #
+    mapbender.command.migrations_install:
+        class: Mapbender\CoreBundle\Command\MigrationsInstallCommand
+        arguments:
+            - '@mapbender.symlink_installer'
+        tags:
+            - { name: console.command }

--- a/src/Mapbender/CoreBundle/Resources/config/components.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/components.yml
@@ -1,0 +1,4 @@
+services:
+    mapbender.symlink_installer:
+        class: Mapbender\Component\SymlinkInstaller\SymlinkInstaller
+        arguments: ['@filesystem']

--- a/src/Mapbender/CoreBundle/Resources/config/migrations.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/migrations.yml
@@ -1,0 +1,72 @@
+services:
+
+    #
+    # Doctrine Migrations Commands
+    #
+    doctrine_migrations.status_command:
+        class: Doctrine\Bundle\MigrationsBundle\Command\MigrationsStatusDoctrineCommand
+        calls:
+            - method: setMigrationConfiguration
+              arguments:
+                  - '@mapbender.migration.configuration'
+        tags:
+            - { name: console.command }
+
+    doctrine_migrations.diff_command:
+        class: Doctrine\Bundle\MigrationsBundle\Command\MigrationsDiffDoctrineCommand
+        calls:
+            - method: setMigrationConfiguration
+              arguments:
+                  - '@mapbender.migration.configuration'
+        tags:
+            - { name: console.command }
+
+    doctrine_migrations.execute_command:
+        class: Doctrine\Bundle\MigrationsBundle\Command\MigrationsExecuteDoctrineCommand
+        calls:
+            - method: setMigrationConfiguration
+              arguments:
+                  - '@mapbender.migration.configuration'
+        tags:
+            - { name: console.command }
+
+    doctrine_migrations.migrate_command:
+        class: Doctrine\Bundle\MigrationsBundle\Command\MigrationsMigrateDoctrineCommand
+        calls:
+            - method: setMigrationConfiguration
+              arguments:
+                  - '@mapbender.migration.configuration'
+        tags:
+            - { name: console.command }
+
+
+    #
+    # Migrations Configuration
+    #
+    mapbender.migration.configuration:
+        class: Doctrine\DBAL\Migrations\Configuration\Configuration
+        arguments:
+            - '@doctrine.dbal.default_connection'
+            - '@mapbender.migration.output.writer'
+        calls:
+            - method: setMigrationsFinder
+              arguments:
+                  - '@mapbender.migration.finder'
+
+
+    #
+    # Mapbender Migrations Components
+    #
+    mapbender.migration.finder:
+        class: Mapbender\Component\DoctrineMigrationsHelper\MigrationFinder
+
+    mapbender.migration.output.writer:
+        class: Mapbender\Component\DoctrineMigrationsHelper\MigrationsOutputWriter
+        arguments:
+            - '@symfony.console.output'
+
+    #
+    # Symfony console output
+    #
+    symfony.console.output:
+        class: Symfony\Component\Console\Output\ConsoleOutput


### PR DESCRIPTION
This pull request relates to the issue #719 and contains:
- command to install migrations from each bundle to an application as symlinks `app/console migrations:install`
- symlink installer component
- components to replace doctrine `RecursiveRegexFinder` and make the `DoctrineMigrationsBundle` be able to recognize migration files stored as symlinks (this logic must be removed and the doctrine migrations package must be updated to the latest version as soon, as Mapbender will be able to work with php >= 7.1)
- migration version which contains logic currently stored in the `DatabseUpgradeCommand`. This version should actually replace this command

Please review and test