### PR TITLE
Fix/wmc cleanups

### DIFF
--- a/src/Mapbender/WmcBundle/Element/WmcEditor.php
+++ b/src/Mapbender/WmcBundle/Element/WmcEditor.php
@@ -277,12 +277,17 @@ class WmcEditor extends Element
                             $wmc->getScreenshot()->move($upload_directory, $filename);
                             $wmc->setScreenshotPath($filename);
                             $format = $wmc->getScreenshot()->getClientMimeType();
-                            $logourl = $wmchandler->getWmcUrl($filename);
-                            $logoUrl = LegendUrl::create(null, null, OnlineResource::create($format, $logourl));
+                            $screenshotHref = $wmchandler->getWmcUrl($filename);
+                            if ($screenshotHref) {
+                                $legendOnlineResource = new OnlineResource($format, $screenshotHref);
+                                $logoUrl = new LegendUrl($legendOnlineResource);
+                                $wmc->setLogourl($logoUrl);
+                            } else {
+                                $wmc->setLogourl(null);
+                            }
                             $state = $wmc->getState();
                             $state->setServerurl($wmchandler->getBaseUrl());
                             $state->setSlug($this->application->getSlug());
-                            $wmc->setLogourl($logoUrl);
                         }
                     } else {
                         $wmc->setScreenshotPath(null);

--- a/src/Mapbender/WmcBundle/Entity/Wmc.php
+++ b/src/Mapbender/WmcBundle/Entity/Wmc.php
@@ -371,11 +371,11 @@ class Wmc
         $state = $state === null ? new State() : $state;
         $wmc   = new Wmc();
         $wmc->setState($state);
-        $logoUrl = $logoUrl === null ? LegendUrl::create() : $logoUrl;
+        $logoUrl = $logoUrl === null ? null : $logoUrl;
         if ($logoUrl !== null) {
             $wmc->setLogourl($logoUrl);
         }
-        $descriptionUrl = $descriptionUrl === null ? OnlineResource::create() : $descriptionUrl;
+        $descriptionUrl = $descriptionUrl === null ? null : $descriptionUrl;
         if ($descriptionUrl !== null) {
             $wmc->setDescriptionurl($descriptionUrl);
         }

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -120,7 +120,7 @@ class LegendUrl
         $legendURL      = null;
         $onlineResource = $onlineResource === null ? OnlineResource::create() : $onlineResource;
 
-        if (!$onlineResource) {
+        if ($onlineResource) {
             $legendURL = new LegendUrl();
             $legendURL->setWidth($width);
             $legendURL->setHeight($height);

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -25,11 +25,11 @@ class LegendUrl
     
     /**
      * 
-     * @param OnlineResource $onlineResource onl
+     * @param OnlineResource $onlineResource
      * @param int $width
      * @param int $height
      */
-    public function __construct($onlineResource = null, $width = null, $height = null)
+    public function __construct(OnlineResource $onlineResource = null, $width = null, $height = null)
     {
         $this->onlineResource = $onlineResource;
         $this->width = $width;
@@ -103,31 +103,6 @@ class LegendUrl
     public function getHeight()
     {
         return $this->height;
-    }
-
-    /**
-     * Create legend URL
-     *
-     * @param null $width
-     * @param null $height
-     * @param null $onlineResource
-     * @return LegendUrl|null
-     */
-    public static function create($width = null, $height = null,
-        $onlineResource = null)
-    {
-        /** @var LegendUrl $legendURL */
-        $legendURL      = null;
-        $onlineResource = $onlineResource === null ? null : $onlineResource;
-
-        if ($onlineResource) {
-            $legendURL = new LegendUrl();
-            $legendURL->setWidth($width);
-            $legendURL->setHeight($height);
-            $legendURL->setOnlineResource($onlineResource);
-        }
-
-        return $legendURL;
     }
 
 }

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -118,7 +118,7 @@ class LegendUrl
     {
         /** @var LegendUrl $legendURL */
         $legendURL      = null;
-        $onlineResource = $onlineResource === null ? OnlineResource::create() : $onlineResource;
+        $onlineResource = $onlineResource === null ? null : $onlineResource;
 
         if ($onlineResource) {
             $legendURL = new LegendUrl();

--- a/src/Mapbender/WmsBundle/Component/OnlineResource.php
+++ b/src/Mapbender/WmsBundle/Component/OnlineResource.php
@@ -75,24 +75,4 @@ class OnlineResource
         return $this->href;
     }
 
-    /**
-     * Create online resource
-     * #
-     *
-     * @param null $format
-     * @param null $href
-     * @return OnlineResource|null
-     */
-    public static function create($format = null, $href = null)
-    {
-        if ($href === null) {
-            $olr = null;
-        } else {
-            $olr = new OnlineResource();
-            $olr->setFormat($format);
-            $olr->setHref($href);
-        }
-        return $olr;
-    }
-
 }


### PR DESCRIPTION
This removes two glorified null factories. Judging by the patch line frequency, they have caused enough confusion over the years. A factory method should definitely return something, anything else is counter intuitive.
* LegendUrl::create() with no arguments returned null, and this was the only way it was ever called
* OnlineResource::create() with no arguments returned null, this was the only way it was ever called

The equivalence transformation in commit 6c4208a08d66d123ed1cf5146470f0a3b1534ff5 should demonstrate the utility of these methods in its entire glory.

