### PR TITLE
Fix/wms cleanups loading

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Exception/InvalidUrlException.php
+++ b/src/Mapbender/CoreBundle/Component/Exception/InvalidUrlException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Exception;
+
+
+class InvalidUrlException extends \InvalidArgumentException
+{
+    public function __construct($url)
+    {
+        parent::__construct("Invalid url " . var_export($url, true));
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/XmlValidator.php
+++ b/src/Mapbender/CoreBundle/Component/XmlValidator.php
@@ -93,51 +93,51 @@ class XmlValidator
 
     protected function validateDtd(\DOMDocument $doc)
     {
-            $docH = new \DOMDocument();
-            $filePath = $this->ensureLocalSchema($doc->doctype->name, $doc->doctype->systemId);
-            $docStr = str_replace($doc->doctype->systemId, $this->addFileSchema($filePath), $doc->saveXML());
-            $doc->loadXML($docStr);
-            unset($docStr);
-            if (!@$docH->loadXML($doc->saveXML(), LIBXML_DTDLOAD | LIBXML_DTDVALID)) {
-                throw new XmlParseException("mb.wms.repository.parser.couldnotparse");
-            }
-            $doc = $docH;
-            if (!@$doc->validate()) { // check with DTD
-                throw new XmlParseException("mb.wms.repository.parser.not_valid_dtd");
-            }
+        $docH = new \DOMDocument();
+        $filePath = $this->ensureLocalSchema($doc->doctype->name, $doc->doctype->systemId);
+        $docStr = str_replace($doc->doctype->systemId, $this->addFileSchema($filePath), $doc->saveXML());
+        $doc->loadXML($docStr);
+        unset($docStr);
+        if (!@$docH->loadXML($doc->saveXML(), LIBXML_DTDLOAD | LIBXML_DTDVALID)) {
+            throw new XmlParseException("mb.wms.repository.parser.couldnotparse");
+        }
+        $doc = $docH;
+        if (!@$doc->validate()) { // check with DTD
+            throw new XmlParseException("mb.wms.repository.parser.not_valid_dtd");
+        }
     }
 
     protected function validateNonDtd(\DOMDocument $doc)
     {
-            $schemaLocations = $this->addSchemas($doc);
-            $imports = "";
-            foreach ($schemaLocations as $namespace => $location) {
-                $imports .=
-                    sprintf('  <xsd:import namespace="%s" schemaLocation="%s" />' . "\n", $namespace, $location);
-            }
+        $schemaLocations = $this->addSchemas($doc);
+        $imports = "";
+        foreach ($schemaLocations as $namespace => $location) {
+            $imports .=
+                sprintf('  <xsd:import namespace="%s" schemaLocation="%s" />' . "\n", $namespace, $location);
+        }
 
-            $source = <<<EOF
+        $source = <<<EOF
 <?xml version="1.0" encoding="utf-8" ?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
 $imports
 </xsd:schema>
 EOF
-            ;
-            libxml_use_internal_errors(true);
-            libxml_clear_errors();
-            $valid = $doc->schemaValidateSource($source);
-            if (!$valid) {
-                $errors = libxml_get_errors();
-                $message = "";
-                foreach ($errors as $error) {
-                    $message .= "\n" . $error->message;
-                }
-                $this->container->get('logger')->err($message);
-                libxml_clear_errors();
-                throw new XmlParseException("mb.wms.repository.parser.not_valid_xsd");
+        ;
+        libxml_use_internal_errors(true);
+        libxml_clear_errors();
+        $valid = $doc->schemaValidateSource($source);
+        if (!$valid) {
+            $errors = libxml_get_errors();
+            $message = "";
+            foreach ($errors as $error) {
+                $message .= "\n" . $error->message;
             }
+            $this->container->get('logger')->err($message);
             libxml_clear_errors();
+            throw new XmlParseException("mb.wms.repository.parser.not_valid_xsd");
+        }
+        libxml_clear_errors();
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/XmlValidator.php
+++ b/src/Mapbender/CoreBundle/Component/XmlValidator.php
@@ -34,11 +34,6 @@ class XmlValidator
     protected $schemaDownloadDir = null;
 
     /**
-     * @var array Proxy connection parameters
-     */
-    protected $proxy_config;
-
-    /**
      *
      * @var array temp files to delete
      */
@@ -48,15 +43,12 @@ class XmlValidator
      * XmlValidator constructor.
      *
      * @param  ContainerInterface $container
-     * @param array               $proxy_config
-     * @param  null|string        $orderFromWeb Path relative to web folder
      */
-    public function __construct(ContainerInterface $container, array $proxy_config, $orderFromWeb = null)
+    public function __construct(ContainerInterface $container)
     {
         $this->container     = $container;
-        $shippingRoot = $this->container->get('kernel')->getRootDir() . '/../web/' . $orderFromWeb;
+        $shippingRoot = $this->container->get('kernel')->getRootDir() . '/../web/xmlschemas';
         $this->shippingSchemaDir = $this->ensureDirectory($this->normalizePath($shippingRoot));
-        $this->proxy_config  = $proxy_config;
         $this->schemaDownloadDir = $this->ensureDirectory(sys_get_temp_dir() . '/mapbender/xmlvalidator');
         $this->filesToDelete = array();
     }
@@ -339,7 +331,8 @@ EOF
     protected function download($url)
     {
         $proxy_query = ProxyQuery::createFromUrl($url);
-        $proxy = new CommonProxy($this->proxy_config, $proxy_query);
+        $proxy_config = $this->container->getParameter("owsproxy.proxy");
+        $proxy = new CommonProxy($proxy_config, $proxy_query);
         /** @var Response $response */
         $response = $proxy->handle();
         return $response->getContent();

--- a/src/Mapbender/CoreBundle/Component/XmlValidator.php
+++ b/src/Mapbender/CoreBundle/Component/XmlValidator.php
@@ -287,30 +287,31 @@ EOF
     }
 
     /**
-     * Normalizes a file path: repaces all strings "/ORDERNAME/.." with "".
+     * Removes parent directory traversal from a path by removing all "<parent name>/.." occurences with "".
+     * Supports both Unix and Windows style directory separators.
      *
      * @param string $path
-     * @return string a mormalized file path.
+     * @return string a mormalized file path with native directory separators
      */
     private function normalizePath($path)
     {
-        $path = preg_replace("/[\/\\\][^\/\\\]+[\/\\\][\.]{2}/", "", $path);
+        $path = preg_replace('#[/\\\\][^/\\\\]+[/\\\\][\.]{2}#', '', $path);
         if (!strpos($path, "..")) {
-            return preg_replace("/[\/\\\]/", DIRECTORY_SEPARATOR, $path);
+            return preg_replace('#[/\\\\]#', DIRECTORY_SEPARATOR, $path);
         } else {
             return $this->normalizePath($path);
         }
     }
 
     /**
-     * Adds a schema "file:///" to file path.
+     * Adds a schema "file:///" to file path, enforces Unix-style directory separators.
      *
      * @param string $filePath a file path
      * @return string a file path as url
      */
     private function addFileSchema($filePath)
     {
-        $filePath_ = preg_replace("/[\/\\\]/", "/", $filePath);
+        $filePath_ = preg_replace('#[/\\\\]#', '/', $filePath);
         if (stripos($filePath_, "file:") !== 0) {
             return "file:///" . $filePath_;
         } else {

--- a/src/Mapbender/WmcBundle/Element/WmcEditor.php
+++ b/src/Mapbender/WmcBundle/Element/WmcEditor.php
@@ -277,12 +277,17 @@ class WmcEditor extends Element
                             $wmc->getScreenshot()->move($upload_directory, $filename);
                             $wmc->setScreenshotPath($filename);
                             $format = $wmc->getScreenshot()->getClientMimeType();
-                            $logourl = $wmchandler->getWmcUrl($filename);
-                            $logoUrl = LegendUrl::create(null, null, OnlineResource::create($format, $logourl));
+                            $screenshotHref = $wmchandler->getWmcUrl($filename);
+                            if ($screenshotHref) {
+                                $legendOnlineResource = new OnlineResource($format, $screenshotHref);
+                                $logoUrl = new LegendUrl($legendOnlineResource);
+                                $wmc->setLogourl($logoUrl);
+                            } else {
+                                $wmc->setLogourl(null);
+                            }
                             $state = $wmc->getState();
                             $state->setServerurl($wmchandler->getBaseUrl());
                             $state->setSlug($this->application->getSlug());
-                            $wmc->setLogourl($logoUrl);
                         }
                     } else {
                         $wmc->setScreenshotPath(null);

--- a/src/Mapbender/WmcBundle/Entity/Wmc.php
+++ b/src/Mapbender/WmcBundle/Entity/Wmc.php
@@ -371,11 +371,11 @@ class Wmc
         $state = $state === null ? new State() : $state;
         $wmc   = new Wmc();
         $wmc->setState($state);
-        $logoUrl = $logoUrl === null ? LegendUrl::create() : $logoUrl;
+        $logoUrl = $logoUrl === null ? null : $logoUrl;
         if ($logoUrl !== null) {
             $wmc->setLogourl($logoUrl);
         }
-        $descriptionUrl = $descriptionUrl === null ? OnlineResource::create() : $descriptionUrl;
+        $descriptionUrl = $descriptionUrl === null ? null : $descriptionUrl;
         if ($descriptionUrl !== null) {
             $wmc->setDescriptionurl($descriptionUrl);
         }

--- a/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
+++ b/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
@@ -17,7 +17,7 @@ class ServiceValidateCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('mapbender:services:validate:wms')
+            ->setName('mapbender:wms:validate:url')
             ->setDescription('Replace host name in configured WMS / WFS services.')
             ->addArgument('serviceUrl', InputArgument::REQUIRED, 'URL to WMS')
             ->addOption('user', null, InputOption::VALUE_REQUIRED, 'Username (basicauth)', '')

--- a/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
+++ b/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Command;
+
+use Mapbender\WmsBundle\Entity\WmsOrigin;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Mapbender\WmsBundle\Component\Wms\Importer;
+
+
+class ServiceValidateCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('mapbender:services:validate:wms')
+            ->setDescription('Replace host name in configured WMS / WFS services.')
+            ->addArgument('serviceUrl', InputArgument::REQUIRED, 'URL to WMS')
+            ->addOption('user', null, InputOption::VALUE_REQUIRED, 'Username (basicauth)', '')
+            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'Password (basic auth)', '')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $origin = new WmsOrigin($input->getArgument('serviceUrl'), $input->getOption('user'), $input->getOption('password'));
+
+        $importer = new Importer($this->getContainer());
+        $result = $importer->evaluateServer($origin, true);
+        $wmsSource = $result->getWmsSourceEntity();
+    }
+}

--- a/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
+++ b/src/Mapbender/WmsBundle/Command/ServiceValidateCommand.php
@@ -32,5 +32,13 @@ class ServiceValidateCommand extends ContainerAwareCommand
         $importer = new Importer($this->getContainer());
         $result = $importer->evaluateServer($origin, true);
         $wmsSource = $result->getWmsSourceEntity();
+
+        $output->writeln("WMS source loaded and validated");
+        $layers = $wmsSource->getLayers();
+        $layerCount = count($layers);
+        $output->writeln("Source describes $layerCount layers:");
+        foreach ($layers as $layer) {
+            $output->writeln("* {$layer->getTitle()}");
+        }
     }
 }

--- a/src/Mapbender/WmsBundle/Command/UrlValidateCommand.php
+++ b/src/Mapbender/WmsBundle/Command/UrlValidateCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Mapbender\WmsBundle\Component\Wms\Importer;
 
 
-class ServiceValidateCommand extends ContainerAwareCommand
+class UrlValidateCommand extends ContainerAwareCommand
 {
     protected function configure()
     {

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -120,7 +120,7 @@ class LegendUrl
         $legendURL      = null;
         $onlineResource = $onlineResource === null ? OnlineResource::create() : $onlineResource;
 
-        if (!$onlineResource) {
+        if ($onlineResource) {
             $legendURL = new LegendUrl();
             $legendURL->setWidth($width);
             $legendURL->setHeight($height);

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -25,11 +25,11 @@ class LegendUrl
     
     /**
      * 
-     * @param OnlineResource $onlineResource onl
+     * @param OnlineResource $onlineResource
      * @param int $width
      * @param int $height
      */
-    public function __construct($onlineResource = null, $width = null, $height = null)
+    public function __construct(OnlineResource $onlineResource = null, $width = null, $height = null)
     {
         $this->onlineResource = $onlineResource;
         $this->width = $width;
@@ -103,31 +103,6 @@ class LegendUrl
     public function getHeight()
     {
         return $this->height;
-    }
-
-    /**
-     * Create legend URL
-     *
-     * @param null $width
-     * @param null $height
-     * @param null $onlineResource
-     * @return LegendUrl|null
-     */
-    public static function create($width = null, $height = null,
-        $onlineResource = null)
-    {
-        /** @var LegendUrl $legendURL */
-        $legendURL      = null;
-        $onlineResource = $onlineResource === null ? null : $onlineResource;
-
-        if ($onlineResource) {
-            $legendURL = new LegendUrl();
-            $legendURL->setWidth($width);
-            $legendURL->setHeight($height);
-            $legendURL->setOnlineResource($onlineResource);
-        }
-
-        return $legendURL;
     }
 
 }

--- a/src/Mapbender/WmsBundle/Component/LegendUrl.php
+++ b/src/Mapbender/WmsBundle/Component/LegendUrl.php
@@ -118,7 +118,7 @@ class LegendUrl
     {
         /** @var LegendUrl $legendURL */
         $legendURL      = null;
-        $onlineResource = $onlineResource === null ? OnlineResource::create() : $onlineResource;
+        $onlineResource = $onlineResource === null ? null : $onlineResource;
 
         if ($onlineResource) {
             $legendURL = new LegendUrl();

--- a/src/Mapbender/WmsBundle/Component/OnlineResource.php
+++ b/src/Mapbender/WmsBundle/Component/OnlineResource.php
@@ -75,24 +75,4 @@ class OnlineResource
         return $this->href;
     }
 
-    /**
-     * Create online resource
-     * #
-     *
-     * @param null $format
-     * @param null $href
-     * @return OnlineResource|null
-     */
-    public static function create($format = null, $href = null)
-    {
-        if ($href === null) {
-            $olr = null;
-        } else {
-            $olr = new OnlineResource();
-            $olr->setFormat($format);
-            $olr->setHref($href);
-        }
-        return $olr;
-    }
-
 }

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Mapbender\WmsBundle\Component\Wms;
+
+use Buzz\Message\Response;
+use Mapbender\CoreBundle\Component\Exception\InvalidUrlException;
+use Mapbender\CoreBundle\Component\Exception\XmlParseException;
+use Mapbender\CoreBundle\Component\XmlValidator;
+use Mapbender\WmsBundle\Component\WmsCapabilitiesParser;
+use Mapbender\WmsBundle\Entity\WmsOrigin;
+use Mapbender\WmsBundle\Entity\WmsSource;
+use OwsProxy3\CoreBundle\Component\CommonProxy;
+use OwsProxy3\CoreBundle\Component\ProxyQuery;
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Importer extends ContainerAware
+{
+    public function __construct(ContainerInterface $container)
+    {
+        $this->setContainer($container);
+    }
+
+    /**
+     * Performs a GetCapabilities request against WMS at $serviceUrl and returns a WmsSource instance and the
+     * (suppressed) XML validation error, if any, wrapped in a Loader\Response object.
+     *
+     * @param WmsOrigin $serviceOrigin
+     * @param bool $onlyValid
+     * @return \Mapbender\WmsBundle\Component\Wms\Importer\Response
+     * @throws XmlParseException
+     */
+    public function evaluateServer(WmsOrigin $serviceOrigin, $onlyValid=true)
+    {
+        $capsDocument = $this->loadCapabilitiesDocument($serviceOrigin);
+        $response = $this->evaluateCapabilitiesDocument($capsDocument, $onlyValid);
+        $this->updateOrigin($response->getWmsSourceEntity(), $serviceOrigin);
+        return $response;
+    }
+
+    /**
+     * Checks / evaluates a capabilities document returns a WmsSource instance and the (suppressed) XML validation error,
+     * if any, wrapped in a Loader\Response object.
+     *
+     * @param \DOMDocument $document
+     * @param boolean $onlyValid
+     * @return \Mapbender\WmsBundle\Component\Wms\Importer\Response
+     * @throws XmlParseException
+     */
+    public function evaluateCapabilitiesDocument(\DOMDocument $document, $onlyValid=true)
+    {
+        try {
+            $this->validate($document);
+            $validationError = null;
+        } catch (XmlParseException $e) {
+            if ($onlyValid) {
+                throw $e;
+            } else {
+                $validationError = $e;
+            }
+        }
+        $sourceEntity = WmsCapabilitiesParser::getParser($document)->parse();
+        $sourceEntity->setValid(!$validationError);
+        return new Importer\Response($sourceEntity, $validationError);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function requestDefaults()
+    {
+        return array(
+            'request' => 'GetCapabilities',
+            'service' => 'WMS',
+        );
+    }
+
+    /**
+     * @param WmsOrigin $serviceOrigin
+     * @return \DOMDocument
+     */
+    public function loadCapabilitiesDocument(WmsOrigin $serviceOrigin)
+    {
+        static::validateUrl($serviceOrigin->getUrl());
+        $serviceResponse = $this->capabilitiesRequest($serviceOrigin, static::requestDefaults());
+        $capsDocument = WmsCapabilitiesParser::createDocument($serviceResponse->getContent());
+        return $capsDocument;
+    }
+
+    public function validate(\DOMDocument $capsDocument)
+    {
+        $validator = new XmlValidator($this->container, $this->container->getParameter("owsproxy.proxy"), "xmlschemas/");
+        $validator->validate($capsDocument);
+    }
+
+    /**
+     * @param WmsOrigin $serviceOrigin
+     * @param array $params
+     * @return Response
+     */
+    protected function capabilitiesRequest(WmsOrigin $serviceOrigin, $params)
+    {
+        $proxy_config = $this->container->getParameter("owsproxy.proxy");
+        $proxy_query  = ProxyQuery::createFromUrl($serviceOrigin->getUrl(), $serviceOrigin->getUserName(), $serviceOrigin->getPassword());
+        /** @TODO: we REQUIRE a GetCapabilities request, so this should be a forced replacement of the "request" param */
+        /** @TODO: evaluate $params instead of hard-coding, so this thing actually becomes flexible enough for reuse */
+        if ($proxy_query->getGetPostParamValue("request", true) === null) {
+            $proxy_query->addQueryParameter("request", "GetCapabilities");
+        }
+        if ($proxy_query->getGetPostParamValue("service", true) === null) {
+            $proxy_query->addQueryParameter("service", "WMS");
+        }
+        $proxy = new CommonProxy($proxy_config, $proxy_query, $this->container->get("logger"));
+        /** @var Response $response */
+        $response = $proxy->handle();
+        return $response;
+    }
+
+    public static function validateUrl($url)
+    {
+        $parts = parse_url($url);
+        if (empty($parts['scheme']) || empty($parts['host'])) {
+            throw new InvalidUrlException($url);
+        }
+    }
+
+    public static function updateOrigin(WmsSource $wmsSource, WmsOrigin $origin)
+    {
+        $wmsSource->setOriginUrl($origin->getUrl());
+        $wmsSource->setUsername($origin->getUserName());
+        $wmsSource->setPassword($origin->getPassword());
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -16,14 +16,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Importer extends ContainerAware
 {
+    /**
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->setContainer($container);
     }
 
     /**
-     * Performs a GetCapabilities request against WMS at $serviceUrl and returns a WmsSource instance and the
-     * (suppressed) XML validation error, if any, wrapped in a Loader\Response object.
+     * Performs a GetCapabilities request against WMS at $serviceOrigin and returns a WmsSource instance and the
+     * (suppressed) XML validation error, if any, wrapped in a ImporterResponse object.
      *
      * @param WmsOrigin $serviceOrigin
      * @param bool $onlyValid
@@ -40,7 +43,7 @@ class Importer extends ContainerAware
 
     /**
      * Checks / evaluates a capabilities document returns a WmsSource instance and the (suppressed) XML validation error,
-     * if any, wrapped in a Loader\Response object.
+     * if any, wrapped in an Importer\Response object.
      *
      * @param \DOMDocument $document
      * @param boolean $onlyValid
@@ -116,6 +119,10 @@ class Importer extends ContainerAware
         return $response;
     }
 
+    /**
+     * @param string $url
+     * @throws InvalidUrlException
+     */
     public static function validateUrl($url)
     {
         $parts = parse_url($url);
@@ -124,6 +131,12 @@ class Importer extends ContainerAware
         }
     }
 
+    /**
+     * Copies origin-related attributes (url, username, password) from $origin to $wmsSource
+     *
+     * @param WmsSource $wmsSource
+     * @param WmsOrigin $origin
+     */
     public static function updateOrigin(WmsSource $wmsSource, WmsOrigin $origin)
     {
         $wmsSource->setOriginUrl($origin->getUrl());

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -89,7 +89,7 @@ class Importer extends ContainerAware
 
     public function validate(\DOMDocument $capsDocument)
     {
-        $validator = new XmlValidator($this->container, $this->container->getParameter("owsproxy.proxy"), "xmlschemas/");
+        $validator = new XmlValidator($this->container);
         $validator->validate($capsDocument);
     }
 

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer/Response.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer/Response.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Component\Wms\Importer;
+
+
+use Mapbender\CoreBundle\Component\Exception\XmlParseException;
+use Mapbender\WmsBundle\Entity\WmsSource;
+
+class Response
+{
+    protected $wmsSourceEntity;
+    protected $validationError;
+
+    public function __construct(WmsSource $wmsSourceEntity, XmlParseException $validationError = null)
+    {
+        $this->wmsSourceEntity = $wmsSourceEntity;
+        $this->validationError = $validationError;
+    }
+
+    /**
+     * @return WmsSource
+     */
+    public function getWmsSourceEntity()
+    {
+        return $this->wmsSourceEntity;
+    }
+
+    /**
+     * @return XmlParseException|null
+     */
+    public function getValidationError()
+    {
+        return $this->validationError;
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser.php
+++ b/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser.php
@@ -128,55 +128,6 @@ abstract class WmsCapabilitiesParser
         return $doc;
     }
 
-    public static function getSchemas(\DOMDocument $doc)
-    {
-        $schemaLocations = array();
-        if ($element = $dom->documentElement->getAttributeNS('http://www.w3.org/2001/XMLSchema-instance',
-            'schemaLocation')) {
-            $items = preg_split('/\s+/', $element);
-            for ($i = 0, $nb = count($items); $i < $nb; $i += 2) {
-                $schemaLocations[$items[$i - 1]] = $items[$i];
-            }
-        }
-        return $schemaLocations;
-    }
-
-    public static function validate(\DOMDocument $doc)
-    {
-//        $doc = new \DOMDocument();
-        if (!@$doc->loadXML($data, $validate && isset($doc->doctype) ? LIBXML_DTDLOAD | LIBXML_DTDVALID : 0)) {
-            throw new XmlParseException("mb.wms.repository.parser.couldnotparse");
-        }
-        // substitute xincludes
-        $doc->xinclude();
-        if ($doc->documentElement->tagName == "ServiceExceptionReport") {
-            $message = $doc->documentElement->nodeValue;
-            throw new WmsException($message);
-        }
-
-        if ($doc->documentElement->tagName !== "WMS_Capabilities"
-            && $doc->documentElement->tagName !== "WMT_MS_Capabilities") {
-            throw new NotSupportedVersionException("mb.wms.repository.parser.not_supported_document");
-        }
-
-        $version = $doc->documentElement->getAttribute("version");
-        if ($version !== "1.1.1" && $version !== "1.3.0") {
-            throw new NotSupportedVersionException('mb.wms.repository.parser.not_supported_version');
-        }
-
-        if ($validate) {
-            if (isset($doc->doctype) && !@$doc->validate()) { // check with DTD
-                throw new XmlParseException("mb.wms.repository.parser.not_valid_dtd");
-            } else if (!isset($doc->doctype)) {
-                // TODO create CREATEDSCHEMA
-                if ($version === '1.3.0' && !$doc->schemaValidate('CREATEDSCHEMA')) {
-                    throw new XmlParseException("mb.wms.repository.parser.not_valid_xsd");
-                }
-            }
-        }
-        return $doc;
-    }
-
     /**
      * Gets a capabilities parser
      *

--- a/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser.php
+++ b/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser.php
@@ -17,7 +17,7 @@ abstract class WmsCapabilitiesParser
 {
     /**
      * The XML representation of the Capabilites Document
-     * @var DOMDocument
+     * @var \DOMDocument
      */
     protected $doc;
 

--- a/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser111.php
+++ b/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser111.php
@@ -19,15 +19,6 @@ class WmsCapabilitiesParser111 extends WmsCapabilitiesParser
 {
 
     /**
-     * Creates an instance
-     * @param \DOMDocument $doc
-     */
-    public function __construct(\DOMDocument $doc)
-    {
-        parent::__construct($doc);
-    }
-
-    /**
      * Parses the GetCapabilities document
      *
      * @return \Mapbender\WmsBundle\Entity\WmsSource

--- a/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser130.php
+++ b/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser130.php
@@ -9,7 +9,6 @@ use Mapbender\WmsBundle\Entity\WmsSource;
 use Mapbender\WmsBundle\Entity\WmsSourceKeyword;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
 use Mapbender\WmsBundle\Entity\WmsLayerSourceKeyword;
-use Mapbender\WmsBundle\Component\RequestInformation;
 
 /**
  * Class that Parses WMS 1.3.0 GetCapabilies Document
@@ -182,6 +181,7 @@ class WmsCapabilitiesParser130 extends WmsCapabilitiesParser
      *
      * @param \DOMElement $contextElm the element to use as context for the
      * Operation Request Information section
+     * @return RequestInformation
      */
     private function parseOperationRequestInformation(\DOMElement $contextElm)
     {

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -218,7 +218,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * Get parent
      *
-     * @return Object
+     * @return WmsLayerSource|null
      */
     public function getParent()
     {
@@ -854,7 +854,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * Get dimension
      *
-     * @return array
+     * @return Dimension[]
      */
     public function getDimension()
     {

--- a/src/Mapbender/WmsBundle/Entity/WmsOrigin.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsOrigin.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Entity;
+
+
+class WmsOrigin
+{
+    protected $url;
+    protected $userName;
+    protected $password;
+
+    public function __construct($url, $userName, $password)
+    {
+        $this->url = trim($url); // no idea why we trim, mirrors old logic from RepositoryController
+        $this->userName = $userName;
+        $this->password = $password;
+    }
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+}

--- a/src/Mapbender/WmsBundle/Entity/WmsSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsSource.php
@@ -771,7 +771,7 @@ class WmsSource extends Source implements ContainingKeyword
     /**
      * Get username
      *
-     * 
+     * @return string
      */
     public function getUsername()
     {
@@ -793,7 +793,7 @@ class WmsSource extends Source implements ContainingKeyword
     /**
      * Get password
      *
-     * 
+     * @return string
      */
     public function getPassword()
     {


### PR DESCRIPTION
**NOTE:** This trojan-horses pull #764.

This pull moves the Wms loading machinery out of the WmsBundle RepositoryController actions into an "Importer" component that is demonstrably reusable.
It also introduces
* a new (and trivial) WmsOrigin Entity that bundles url and the optional user + password for basic auth protected services
* a new (and similarly trivial) Importer Response that carries the parsing results along with an (optional) ignored validation exception, so it can still be displayed as a warning if the user chose to ignore structural errors in the source's GetCapabilities

[Used like this:](https://github.com/mapbender/mapbender/commit/a73d3a5e28085c85d6375378e13036fede232d1a#diff-1e3841a9d0469ca05262f37ad58ac2beR176)
```php
$importer = new Importer($this->container);  // @todo: symfony service :p
$origin = new WmsOrigin($url, $userName, $password);
$importerResponse = $importer->evaluateServer($origin, false);
/** @var \Exception|null $validationError */
$validationError = $importerResponse->getValidationError();
/** @var \Mapbender\WmsBundle\Entity\WmsSource $wmsSource */
$wmsSource = $importerResponse->getWmsSourceEntity();
```

This pull also resolves some issues concerning storage of temporary schema downloads in the XmlValidator. These used to go into the web folder, which may not even be writable depending on deployment details. Worse, if web wasn't writable, an infinite loop was triggered.
The solution was to distinguish "shipping" schemas (packed in with mapbender, considered static and an optimization) from "ad-hoc" schemas that must be downloaded because the document that is currently being validated references them.

The "ad-hoc" schemas now go into `sys_get_temp_dir().'/mapbender/xmlschemas'`. Better than web. They are deleted when processing completes, either successfully or throwing.
The "shipped" schemas remain in web/xmlschemas where they have been. I have confirmed that they are still picked up and used.

### CLI / testing
As a proof of concept, there is a new mapbender:wms:validate:url CLI command that accepts an URL. It either bubbles any occuring exceptions, or trivially displays the detected layers when all went well.

I have tested both "DTD" and "non-DTD" strict parsing and evaluation, and both work.
