### PR TITLE
Fix #698 load WMS covers redlining

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -35,17 +35,14 @@
             if(this.options.auto_activate || this.options.display_type === 'element'){
                 this.activate();
             }
+
+            this.setupMapEventListeners();
+
             this._trigger('ready');
             this._ready();
-
-            //put rl layer on top of layer stack if a source is added, i.e. by wms loader
-            var self = this;
-            $(document).on('mbmapsourceadded', function(event, params) {
-                if (self.layer) {
-                    self.map.raiseLayer(self.layer, self.map.getNumLayers());
-                    self.map.resetLayersZIndex();
-                }
-            });
+        },
+        setupMapEventListeners: function() {
+            $(document).on('mbmapsourceadded', this._moveLayerToLayerStackTop.bind(this));
         },
         defaultAction: function(callback){
             this.activate(callback);
@@ -313,6 +310,16 @@
                     $('.geometry-table tr[data-id="'+this.selectedFeature.id+'"] .geometry-name', this.element).text(label);
                     this.layer.redraw();
                 }
+            }
+        },
+        /**
+         * Move redlining layer on top of layer stack if a source is added, i.e. by wms loader
+         * @private
+         */
+        _moveLayerToLayerStackTop: function(event, params) {
+            if (this.layer) {
+                this.map.raiseLayer(this.layer, this.map.getNumLayers());
+                this.map.resetLayersZIndex();
             }
         },
         /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -37,6 +37,15 @@
             }
             this._trigger('ready');
             this._ready();
+
+            //put rl layer on top of layer stack if a source is added, i.e. by wms loader
+            var self = this;
+            $(document).on('mbmapsourceadded', function(event, params) {
+                if (self.layer) {
+                    self.map.raiseLayer(self.layer, self.map.getNumLayers());
+                    self.map.resetLayersZIndex();
+                }
+            });
         },
         defaultAction: function(callback){
             this.activate(callback);


### PR DESCRIPTION
The redlining element now listens on event 'mbmapsourceadded'. If this is triggered, the redlining layer is raised by the number of current layers and the layerZIndex is reset

See ticket: https://github.com/mapbender/mapbender/issues/698