### PR TITLE
Fix/wms cleanups urlrewriting

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Transformer/CliHelperWrapper.php
+++ b/src/Mapbender/CoreBundle/Component/Transformer/CliHelperWrapper.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Transformer;
+
+/**
+ * A transformer that delegates all actual transformation work to any other transformer, but keeps track
+ * of changes and progress and can communicate them back via callbacks.
+ */
+class CliHelperWrapper extends ValueTransformerBase
+{
+    /** @var ValueTransformerBase */
+    protected $transformer;
+
+    /** @var null|callable called once with no arguments for every transform() invocation */
+    protected $changeCallback;
+
+
+    public function __construct(ValueTransformerBase $transformer, $changeCallback = null)
+    {
+        parent::__construct(true);
+        $this->transformer = $transformer;
+        $this->changeCallback = $changeCallback;
+    }
+
+    public function transformOnce($value)
+    {
+        return $this->transformer->transform($value);
+    }
+
+    public function compare($a, $b)
+    {
+        return $this->transformer->compare($a, $b);
+    }
+
+    public function transform($value)
+    {
+        $before = $value;
+        $after = $this->transformOnce($value);
+        if ($this->changeCallback && !$this->transformer->compare($before, $after)) {
+            ($this->changeCallback)($before, $after);
+        }
+        return $after;
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Transformer/RegexRewriter.php
+++ b/src/Mapbender/CoreBundle/Component/Transformer/RegexRewriter.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Transformer;
+
+
+/**
+ * A transformer that modifies strings based on regex search pattern + replacement
+ */
+class RegexRewriter extends ValueTransformerBase
+{
+    /** @var string */
+    protected $searchPattern;
+    /** @var string  */
+    protected $replacement;
+
+    /**
+     * @param string $searchPattern
+     * @param string $replacement
+     * @param bool $once see parent
+     */
+    public function __construct($searchPattern, $replacement, $once = true)
+    {
+        parent::__construct($once);
+        $this->searchPattern = $searchPattern;
+        $this->replacement = $replacement;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public function transformOnce($value)
+    {
+        return preg_replace($this->searchPattern, $this->replacement, $value);
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Transformer/UrlHostRewriter.php
+++ b/src/Mapbender/CoreBundle/Component/Transformer/UrlHostRewriter.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Transformer;
+use Mapbender\CoreBundle\Utils\UrlUtil;
+
+
+/**
+ * A Transformer that processes urls and rewrites the host
+ */
+class UrlHostRewriter extends ValueTransformerBase
+{
+    /** @var string */
+    protected $to;
+    /** @var string|null  */
+    protected $from;
+
+    /**
+     * @param string $to new host name
+     * @param string|null $from old host name (optional); if given, only replace if previous hostname equals $from
+     * @param bool $once see parent
+     */
+    public function __construct($to, $from = null, $once = true)
+    {
+        parent::__construct($once);
+        $this->to = $to;
+        $this->from = $from;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public function transformOnce($value)
+    {
+        return UrlUtil::replaceHost($value, $this->to, $this->from);
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Transformer/ValueTransformerBase.php
+++ b/src/Mapbender/CoreBundle/Component/Transformer/ValueTransformerBase.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Transformer;
+
+
+/**
+ * A thing that changes a value into a different value.
+ *
+ * Useful as a vistor.
+ */
+abstract class ValueTransformerBase
+{
+    /** @var bool */
+    protected $once;
+
+    /**
+     * @param bool $once to enable repeat runs of the transformer over the same input until it no longer changes
+     */
+    public function __construct($once = true)
+    {
+        // force to proper boolean
+        $this->once = !!$once;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    abstract public function transformOnce($value);
+
+    /**
+     * Perform change check after transformation. Base class performs PHP `===` check.
+     * Child classes should override for types with more complex comparisons.
+     *
+     * @param mixed $a
+     * @param mixed $b should be same type as $a
+     * @return bool
+     */
+    public function compare($a, $b)
+    {
+        return $a === $b;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    public function transform($value)
+    {
+        $valueOut = $this->transformOnce($value);
+        if (!$this->once) {
+            $same = $this->compare($valueOut, $value);
+            while ($same) {
+                $value = $valueOut;
+                $valueOut = $this->transformOnce($value);
+                $same = $this->compare($valueOut, $value);
+            };
+        }
+        return $valueOut;
+    }
+}

--- a/src/Mapbender/CoreBundle/Utils/UrlUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/UrlUtil.php
@@ -62,4 +62,72 @@ class UrlUtil
         }
         return $newurl;
     }
+
+    /**
+     * @param string $url input
+     * @param string $to new host name
+     * @param string|null $from old host name (optional); if given, only replace if hostname in $url equals $from
+     * @return string updated $url (or unchanged $url if mismatching $from given)
+     */
+    public static function replaceHost($url, $to, $from = null)
+    {
+        $parts = parse_url($url);
+        if (empty($parts['host'])) {
+            /**
+             * @todo: this should probably an exception; unfortunately, we have bad data in certain production dbs...
+             */
+            return $url;
+        }
+        if ($from && $from != $parts['host']) {
+            $urlOut = $url;
+        } else {
+            $parts['host'] = $to;
+            $urlOut = static::reconstruct($parts);
+        }
+        return $urlOut;
+    }
+
+    /**
+     * Inverse of parse_url.
+     * This should be a drop-in for http_build_url provided by the (rarely installed) "http" PECL extension.
+     *
+     * @param string[] $parts
+     * @return string
+     */
+    public static function reconstruct($parts)
+    {
+        $urlOut = "";
+        if (!empty($parts['scheme'])) {
+            if ($parts['scheme'] == 'file') {
+                $urlOut .= "{$parts['scheme']}:///";
+            } else {
+                $urlOut .= "{$parts['scheme']}://";
+            }
+        }
+        if (!empty($parts['user'])) {
+            $urlOut .= $parts['user'];
+        }
+        if (!empty($parts['pass'])) {
+            $urlOut .= ":{$parts['pass']}";
+        }
+        if (!empty($parts['user']) || !empty($parts['pass'])) {
+            $urlOut .= "@";
+        }
+        if (!empty($parts['host'])) {
+            $urlOut .= $parts['host'];
+        }
+        if (!empty($parts['port'])) {
+            $urlOut .= ":{$parts['port']}";
+        }
+        if (!empty($parts['path'])) {
+            $urlOut .= $parts['path'];
+        }
+        if (!empty($parts['query'])) {
+            $urlOut .= "?{$parts['query']}";
+        }
+        if (!empty($parts['fragment'])) {
+            $urlOut .= "#{$parts['fragment']}";
+        }
+        return $urlOut;
+    }
 }

--- a/src/Mapbender/WmsBundle/Command/HostRewriteCommand.php
+++ b/src/Mapbender/WmsBundle/Command/HostRewriteCommand.php
@@ -18,6 +18,26 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
+/**
+ * Rewrites host names of WMS sources
+ * $ ../app/console mapbender:wms:rewrite:host ows.terrestris.de maps.wheregroup.com --dry-run
+    Updating WMS layer sources (538)
+     *   'http://ows.terrestris.de/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
+      \=>'http://maps.wheregroup.com/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
+    Updating WMS sources (45)
+     *   'http://ows.terrestris.de/osm/service?request=GetCapabilities&service=wms'
+      \=>'http://maps.wheregroup.com/osm/service?request=GetCapabilities&service=wms'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'http://maps.wheregroup.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'http://maps.wheregroup.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'http://maps.wheregroup.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'http://maps.wheregroup.com/osm/service'
+    Updating WMS instances (169)
+
+ */
 class HostRewriteCommand extends ContainerAwareCommand
 {
     protected $progressOutput;

--- a/src/Mapbender/WmsBundle/Command/HostRewriteCommand.php
+++ b/src/Mapbender/WmsBundle/Command/HostRewriteCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Mapbender\WmsBundle\Command;
+
+use Mapbender\CoreBundle\Component\EntityHandler;
+use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
+use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsLayerSource;
+use Mapbender\WmsBundle\Entity\WmsSource;
+use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+class HostRewriteCommand extends ContainerAwareCommand
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('mapbender:wms:rewrite:host')
+            ->setDescription('Replace host name in configured WMS services.')
+            ->addArgument('from', InputArgument::REQUIRED, 'Old host name to scan for.')
+            ->addArgument('to', InputArgument::REQUIRED, 'New host name to set where old name was used.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Run through logic but skip database writeback')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dryRun = $input->getOption('dry-run');
+        $this->updateWmsLayerSources($input, $output, $dryRun);
+        $this->updateWmsSources($input, $output, $dryRun);
+        $this->updateWmsInstances($input, $output, $dryRun);
+
+        if (!$dryRun) {
+            $doctrine = $this->getContainer()->get('doctrine');
+            $doctrine->getManager()->flush();
+        }
+    }
+
+    protected function updateWmsSources(InputInterface $input, OutputInterface $output, $dryRun = false)
+    {
+        $from = $input->getArgument('from');
+        $to = $input->getArgument('to');
+
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $this->getContainer()->get('doctrine');
+        $em = $doctrine->getManager();
+
+        // Get ALL sources
+        $instanceRepository = $doctrine->getRepository('MapbenderWmsBundle:WmsSource');
+        $sources = $instanceRepository->findAll();
+
+
+        $nSources = count($sources);
+        $output->writeln("<info>Updating WMS sources</info> ($nSources)");
+        $progress = $this->createProgressBar($output, $nSources);
+
+        foreach ($sources as $source) {
+            $em->persist($source);
+            $em->persist($source->getContact());
+            $eh = EntityHandler::createHandler($this->getContainer(), $source);
+            /** @var WmsSourceEntityHandler $eh */
+            /** @var WmsSource $source */
+            $source->replaceHost($to, $from);
+
+            if (!$dryRun) {
+                $eh->update($source);
+                $em->persist($source->getContact());
+                $em->flush();
+            }
+            $progress->advance(1);
+        }
+        $progress->finish();
+    }
+
+    protected function updateWmsLayerSources(InputInterface $input, OutputInterface $output, $dryRun = false)
+    {
+        $from = $input->getArgument('from');
+        $to = $input->getArgument('to');
+
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $this->getContainer()->get('doctrine');
+
+        // Get ALL layer source entities
+        $instanceRepository = $doctrine->getRepository('MapbenderWmsBundle:WmsLayerSource');
+        $layourSources = $instanceRepository->findBy(array(), array('id' => 'ASC'));
+        /** @var \Doctrine\DBAL\Connection $connection */
+        $connection = $doctrine->getConnection();
+
+        $nLayerSources = count($layourSources);
+        $output->writeln("<info>Updating WMS layer sources</info> ($nLayerSources)");
+        $progress = $this->createProgressBar($output, $nLayerSources);
+
+        foreach ($layourSources as $layerSource) {
+            /** @var WmsLayerSource $layerSource */
+            $layerSource->replaceHost($to, $from);
+
+            // the entity handler for layer sources doesn't work. Nothing will be written to db.
+            // We have to do the updates directly
+            $sql = "UPDATE mb_wms_wmslayersource SET styles = :styles WHERE id = :id";
+            $queryParams = array(
+                ':styles' => serialize($layerSource->getStyles()),
+                ':id'     => $layerSource->getId(),
+            );
+            $stmt = $connection->prepare("$sql");
+            foreach ($queryParams as $paramName => $paramValue) {
+                $stmt->bindValue($paramName, $paramValue);
+            }
+
+            if (!$dryRun) {
+                $stmt->execute();
+            }
+            $progress->advance(1);
+        }
+        $progress->finish();
+    }
+
+    protected function updateWmsInstances(InputInterface $input, OutputInterface $output, $dryRun = false)
+    {
+        $from = $input->getArgument('from');
+        $to = $input->getArgument('to');
+
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $doctrine */
+        $doctrine = $this->getContainer()->get('doctrine');
+        $em = $doctrine->getManager();
+
+        // Get ALL WMS instances from db
+        $instanceRepository = $doctrine->getRepository('MapbenderWmsBundle:WmsInstance');
+        $iqb = $instanceRepository->createQueryBuilder('i');
+        $instances = $iqb
+            ->orderBy('i.title')
+            ->getQuery()
+            ->getResult();
+
+        $nInstances = count($instances);
+        $output->writeln("<info>Updating WMS instances</info> ($nInstances)");
+        $progress = $this->createProgressBar($output, $nInstances);
+
+        foreach ($instances as &$instance) {
+            $fqt = $instance->getTitle();
+            if (!$instance instanceof WmsInstance) {
+                $output->writeln('<error>Skipping "' . $fqt . '" – not a WMS instance.</error>');
+                continue;
+            }
+
+            $instance->getSource()->replaceHost($to, $from);
+            $instance->setSource($instance->getSource());
+
+            $handler = EntityHandler::createHandler($this->getContainer(), $instance);
+            $handler->generateConfiguration();
+
+            if (!$dryRun) {
+                $handler->save();
+                $em->flush();
+            }
+            $progress->advance(1);
+        }
+        $progress->finish();
+    }
+
+    /**
+     * Create progress bar helper
+     *
+     * @param  OutputInterface $output
+     * @param  integer $maxCount
+     * @return ProgressHelper
+     */
+    protected function createProgressBar(OutputInterface $output, $maxCount)
+    {
+        $progressBar = clone $this->getHelper('progress');
+        $progressBar->setFormat(' %current%/%max% [<info>%bar%</info>] %percent%% Elapsed: %elapsed%');
+        $progressBar->setBarCharacter('∎');
+        $progressBar->setEmptyBarCharacter(' ');
+        $progressBar->setBarWidth(20);
+        $progressBar->setProgressCharacter("·");
+        $progressBar->setRedrawFrequency(1);
+        $progressBar->start($output, $maxCount);
+        return $progressBar;
+    }
+}

--- a/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
+++ b/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
@@ -34,6 +34,7 @@ class RegexRewriteCommand extends HostRewriteCommand
     {
         parent::configure();
         $this->setName('mapbender:wms:rewrite:regex');
+        $this->setDescription('Rewrite urls in configured WMS services using regex search + replace.');
         $definition = $this->getDefinition();
         $arguments = $definition->getArguments();
         $arguments['from'] = new InputArgument('from', InputArgument::REQUIRED, 'Search pattern (regular expression)');

--- a/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
+++ b/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
@@ -35,10 +35,13 @@ class RegexRewriteCommand extends HostRewriteCommand
         parent::configure();
         $this->setName('mapbender:wms:rewrite:regex');
         $this->setDescription('Rewrite urls in configured WMS services using regex search + replace.');
+
+        // modify inherited arguments with appropriate verbiage
         $definition = $this->getDefinition();
         $arguments = $definition->getArguments();
         $arguments['from'] = new InputArgument('from', InputArgument::REQUIRED, 'Search pattern (regular expression)');
         $arguments['to'] = new InputArgument('to', InputArgument::REQUIRED, 'Replacement');
+        $definition->setArguments($arguments);
     }
 
     protected function getRewriter(InputInterface $input, OutputInterface $output)

--- a/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
+++ b/src/Mapbender/WmsBundle/Command/RegexRewriteCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Command;
+
+
+use Mapbender\CoreBundle\Component\Transformer\RegexRewriter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Rewrites WMS urls based on regex search + replace
+ * $ ../app/console mapbender:wms:rewrite:regex '^http://ows.t[er]{1,4}stris.de' 'https://wow.yeah.com' --dry-run
+    Updating WMS layer sources (538)
+     *   'http://ows.terrestris.de/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
+      \=>'https://wow.yeah.com/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
+    Updating WMS sources (45)
+     *   'http://ows.terrestris.de/osm/service?request=GetCapabilities&service=wms'
+      \=>'https://wow.yeah.com/osm/service?request=GetCapabilities&service=wms'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'https://wow.yeah.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'https://wow.yeah.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'https://wow.yeah.com/osm/service'
+     *   'http://ows.terrestris.de/osm/service'
+      \=>'https://wow.yeah.com/osm/service'
+
+ */
+class RegexRewriteCommand extends HostRewriteCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('mapbender:wms:rewrite:regex');
+        $definition = $this->getDefinition();
+        $arguments = $definition->getArguments();
+        $arguments['from'] = new InputArgument('from', InputArgument::REQUIRED, 'Search pattern (regular expression)');
+        $arguments['to'] = new InputArgument('to', InputArgument::REQUIRED, 'Replacement');
+    }
+
+    protected function getRewriter(InputInterface $input, OutputInterface $output)
+    {
+        $nativePattern = $input->getArgument('from');
+        $phpPattern = $this->nativeRegexToPhpRegex($nativePattern, 'i');
+        $replacement = $input->getArgument('to');
+
+        return new RegexRewriter($phpPattern, $replacement, true);
+    }
+
+    public static function nativeRegexToPhpRegex($pattern, $flags)
+    {
+        $potentialDelimiters = array(
+            '#',
+            '/',
+            '|',
+        );
+        foreach ($potentialDelimiters as $delim) {
+            if (strpos($pattern, $delim) === false) {
+                return "{$delim}{$pattern}{$delim}{$flags}";
+            }
+        }
+        $delim = '#';
+        return $delim . str_replace('#', '\\#', $pattern) . $delim . $flags;
+
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/Authority.php
+++ b/src/Mapbender/WmsBundle/Component/Authority.php
@@ -2,6 +2,8 @@
 
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Utils\UrlUtil;
+
 /**
  * Authority class.
  *
@@ -60,5 +62,16 @@ class Authority
     {
         $this->name = $value;
         return $this;
+    }
+
+    /**
+     * Update host in $this->url
+     *
+     * @param string $to new host name
+     * @param string|null $from old host name (optional); if given, only replace if hostname in $this->url equals $from
+     */
+    public function replaceHost($to, $from = null)
+    {
+        $this->url = UrlUtil::replaceHost($this->url, $to, $from);
     }
 }

--- a/src/Mapbender/WmsBundle/Component/Authority.php
+++ b/src/Mapbender/WmsBundle/Component/Authority.php
@@ -2,7 +2,7 @@
 
 namespace Mapbender\WmsBundle\Component;
 
-use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 
 /**
  * Authority class.
@@ -65,13 +65,12 @@ class Authority
     }
 
     /**
-     * Update host in $this->url
+     * Update $this->url
      *
-     * @param string $to new host name
-     * @param string|null $from old host name (optional); if given, only replace if hostname in $this->url equals $from
+     * @param ValueTransformerBase $rewriter
      */
-    public function replaceHost($to, $from = null)
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
-        $this->url = UrlUtil::replaceHost($this->url, $to, $from);
+        $this->url = $rewriter->transform($this->url);
     }
 }

--- a/src/Mapbender/WmsBundle/Component/OnlineResource.php
+++ b/src/Mapbender/WmsBundle/Component/OnlineResource.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Utils\UrlUtil;
+
 /**
  * OnlineResource class.
  *
@@ -95,4 +97,14 @@ class OnlineResource
         return $olr;
     }
 
+    /**
+     * Update host in $this->href
+     *
+     * @param string $to new host name
+     * @param string|null $from old host name (optional); if given, only replace if hostname in $this->href equals $from
+     */
+    public function replaceHost($to, $from = null)
+    {
+        $this->href = UrlUtil::replaceHost($this->href, $to, $from);
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/OnlineResource.php
+++ b/src/Mapbender/WmsBundle/Component/OnlineResource.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mapbender\WmsBundle\Component;
 
-use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 
 /**
  * OnlineResource class.
@@ -98,13 +98,12 @@ class OnlineResource
     }
 
     /**
-     * Update host in $this->href
+     * Update $this->href
      *
-     * @param string $to new host name
-     * @param string|null $from old host name (optional); if given, only replace if hostname in $this->href equals $from
+     * @param ValueTransformerBase $rewriter
      */
-    public function replaceHost($to, $from = null)
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
-        $this->href = UrlUtil::replaceHost($this->href, $to, $from);
+        $this->href = $rewriter->transform($this->href);
     }
 }

--- a/src/Mapbender/WmsBundle/Component/RequestInformation.php
+++ b/src/Mapbender/WmsBundle/Component/RequestInformation.php
@@ -2,7 +2,7 @@
 
 namespace Mapbender\WmsBundle\Component;
 
-use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 
 /**
  * RequestInformation class.
@@ -98,18 +98,17 @@ class RequestInformation
     }
 
     /**
-     * @param string $to new host name
-     * @param string|null $from old host name (optional); if given, only replace if hostname in $url equals $from
-     * @return $this
+     * Update $this->httpGet and $this->httpPost
+     *
+     * @param ValueTransformerBase $rewriter
      */
-    public function replaceHost($to, $from = null)
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
         if ($this->httpGet) {
-            $this->httpGet  = UrlUtil::replaceHost($this->httpGet, $to, $from);
+            $this->httpGet  = $rewriter->transform($this->httpGet);
         }
         if ($this->httpPost) {
-            $this->httpPost = UrlUtil::replaceHost($this->httpPost, $to, $from);
+            $this->httpPost = $rewriter->transform($this->httpPost);
         }
-        return $this;
     }
 }

--- a/src/Mapbender/WmsBundle/Component/RequestInformation.php
+++ b/src/Mapbender/WmsBundle/Component/RequestInformation.php
@@ -2,6 +2,8 @@
 
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Utils\UrlUtil;
+
 /**
  * RequestInformation class.
  *
@@ -95,4 +97,19 @@ class RequestInformation
         return $this;
     }
 
+    /**
+     * @param string $to new host name
+     * @param string|null $from old host name (optional); if given, only replace if hostname in $url equals $from
+     * @return $this
+     */
+    public function replaceHost($to, $from = null)
+    {
+        if ($this->httpGet) {
+            $this->httpGet  = UrlUtil::replaceHost($this->httpGet, $to, $from);
+        }
+        if ($this->httpPost) {
+            $this->httpPost = UrlUtil::replaceHost($this->httpPost, $to, $from);
+        }
+        return $this;
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/Style.php
+++ b/src/Mapbender/WmsBundle/Component/Style.php
@@ -183,4 +183,35 @@ class Style
         return $this->styleUlr;
     }
 
+    public function replaceHost($to, $from)
+    {
+        /**
+         * @todo: upstream functions getLegendUrl, getStyleUlr and getStyleSheetUrl
+         *    are marked as returning stdClass instances, but this seems to be an
+         *    error in the annotions. All setters enforce strict types, and all known
+         *    direct modifications (these are public attribs!) set instances of these
+         *    same types.
+         *
+         *    Return type annotations should be updated if possible.
+         */
+        $legendUrl = $this->getLegendUrl();
+        $styleUrl = $this->getStyleUlr();
+        $styleSheetUrl = $this->getStyleSheetUrl();
+        /** @var LegendUrl $legendUrl */
+        /** @var OnlineResource $styleSheetUrl */
+        /** @var OnlineResource $styleUrl */
+        if ($legendUrl && $legendUrl->getOnlineResource()) {
+            $legendUrl->getOnlineResource()->replaceHost($to, $from);
+            $legendUrl->setOnlineResource($legendUrl->getOnlineResource());
+        }
+        if ($styleUrl) {
+            $styleUrl->replaceHost($to, $from);
+        }
+        if ($styleSheetUrl) {
+            $styleSheetUrl->replaceHost($to, $from);
+        }
+        $this->setLegendUrl($this->getLegendUrl());
+        $this->setStyleUlr($this->getStyleUlr());
+        $this->setStyleSheetUrl($this->getStyleSheetUrl());
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/Style.php
+++ b/src/Mapbender/WmsBundle/Component/Style.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Mapbender\WmsBundle\Component;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 
 /**
  * Style class.
@@ -183,7 +184,12 @@ class Style
         return $this->styleUlr;
     }
 
-    public function replaceHost($to, $from)
+    /**
+     * Update all urls stored in $this->legendUrl, $this->styleUrl and $this->styleSheetUrl
+     *
+     * @param ValueTransformerBase $rewriter
+     */
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
         /**
          * @todo: upstream functions getLegendUrl, getStyleUlr and getStyleSheetUrl
@@ -201,14 +207,14 @@ class Style
         /** @var OnlineResource $styleSheetUrl */
         /** @var OnlineResource $styleUrl */
         if ($legendUrl && $legendUrl->getOnlineResource()) {
-            $legendUrl->getOnlineResource()->replaceHost($to, $from);
+            $legendUrl->getOnlineResource()->rewriteUrl($rewriter);
             $legendUrl->setOnlineResource($legendUrl->getOnlineResource());
         }
         if ($styleUrl) {
-            $styleUrl->replaceHost($to, $from);
+            $styleUrl->rewriteUrl($rewriter);
         }
         if ($styleSheetUrl) {
-            $styleSheetUrl->replaceHost($to, $from);
+            $styleSheetUrl->rewriteUrl($rewriter);
         }
         $this->setLegendUrl($this->getLegendUrl());
         $this->setStyleUlr($this->getStyleUlr());

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Component\ContainingKeyword;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 use Mapbender\CoreBundle\Component\Utils;
 use Mapbender\CoreBundle\Entity\Keyword;
 use Mapbender\CoreBundle\Entity\Source;
@@ -998,19 +999,24 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
         return (string)$this->id;
     }
 
-    public function replaceHost($to, $from)
+    /**
+     * Rewrite URL in all URLish attributes.
+     *
+     * @param ValueTransformerBase $rewriter
+     */
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
         $styles = array();
         foreach ($this->getStyles(false) as $style) {
-            $style->replaceHost($to, $from);
+            $style->rewriteUrl($rewriter);
             $styles[] = $style;
         }
         $this->setStyles($styles);
         foreach ($this->getMetadataUrl() as $mdu) {
-            $mdu->getOnlineResource()->replaceHost($to, $from);
+            $mdu->getOnlineResource()->rewriteUrl($rewriter);
         }
         foreach ($this->getDataUrl() as $du) {
-            $du->replaceHost($to, $from);
+            $du->rewriteUrl($rewriter);
         }
     }
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -787,7 +787,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
         if ($inherit && $this->getParent() !== null && $this->getParent()->getAuthority() !== null) {
             return array_merge($this->getParent()->getAuthority(), $this->authority);
         } else {
-            $this->authority;
+            return $this->authority;
         }
     }
 
@@ -996,5 +996,21 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     public function __toString()
     {
         return (string)$this->id;
+    }
+
+    public function replaceHost($to, $from)
+    {
+        $styles = array();
+        foreach ($this->getStyles(false) as $style) {
+            $style->replaceHost($to, $from);
+            $styles[] = $style;
+        }
+        $this->setStyles($styles);
+        foreach ($this->getMetadataUrl() as $mdu) {
+            $mdu->getOnlineResource()->replaceHost($to, $from);
+        }
+        foreach ($this->getDataUrl() as $du) {
+            $du->replaceHost($to, $from);
+        }
     }
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsSource.php
@@ -936,31 +936,24 @@ class WmsSource extends Source implements ContainingKeyword
         $this->setOriginUrl($rewriter->transform($this->getOriginUrl()));
         $this->setOnlineResource($rewriter->transform($this->getOnlineResource()));
         if ($requestInfo = $this->getGetMap()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetFeatureInfo()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetCapabilities()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getDescribeLayer()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetLegendGraphic()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetStyles()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getPutStyles()) {
-            /** @var RequestInformation $requestInfo */
             $requestInfo->rewriteUrl($rewriter);
         }
         $this->setGetMap($this->getGetMap());

--- a/src/Mapbender/WmsBundle/Entity/WmsSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsSource.php
@@ -7,7 +7,7 @@ use Mapbender\CoreBundle\Component\ContainingKeyword;
 use Mapbender\CoreBundle\Entity\Contact;
 use Mapbender\CoreBundle\Entity\Keyword;
 use Mapbender\CoreBundle\Entity\Source;
-use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\CoreBundle\Component\Transformer\ValueTransformerBase;
 use Mapbender\WmsBundle\Component\Authority;
 use Mapbender\WmsBundle\Component\LegendUrl;
 use Mapbender\WmsBundle\Component\OnlineResource;
@@ -927,43 +927,41 @@ class WmsSource extends Source implements ContainingKeyword
     }
 
     /**
-     * Replace host name in all URLish attributes.
+     * Rewrite URL in all URLish attributes.
      *
-     * @param string $to new host name
-     * @param string|null $from old host name (optional); if given, only replace if hostname in $url equals $from
-     * @return $this
+     * @param ValueTransformerBase $rewriter
      */
-    public function replaceHost($to, $from = null)
+    public function rewriteUrl(ValueTransformerBase $rewriter)
     {
-        $this->setOriginUrl(UrlUtil::replaceHost($this->getOriginUrl(), $to, $from));
-        $this->setOnlineResource(UrlUtil::replaceHost($this->getOnlineResource(), $to, $from));
+        $this->setOriginUrl($rewriter->transform($this->getOriginUrl()));
+        $this->setOnlineResource($rewriter->transform($this->getOnlineResource()));
         if ($requestInfo = $this->getGetMap()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetFeatureInfo()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetCapabilities()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getDescribeLayer()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetLegendGraphic()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getGetStyles()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         if ($requestInfo = $this->getPutStyles()) {
             /** @var RequestInformation $requestInfo */
-            $requestInfo->replaceHost($to, $from);
+            $requestInfo->rewriteUrl($rewriter);
         }
         $this->setGetMap($this->getGetMap());
         $this->setGetFeatureInfo($this->getGetFeatureInfo());
@@ -975,19 +973,17 @@ class WmsSource extends Source implements ContainingKeyword
 
         foreach ($this->getLayers() as $layer) {
             foreach ($layer->getStyles(false) as $style) {
-                $style->replaceHost($to, $from);
+                $style->rewriteUrl($rewriter);
             }
             $layer->setStyles($layer->getStyles(false));
             foreach ($layer->getAuthority(false) as $authority) {
                 /** @var Authority $authority */
                 if ($authority && $authority->getUrl()) {
-                    $authority->replaceHost($to, $from);
+                    $authority->rewriteUrl($rewriter);
                 }
             }
             $layer->setAuthority($layer->getAuthority());
         }
         $this->setLayers($this->getLayers());
-
-        return $this;
     }
 }


### PR DESCRIPTION
Rewrite hosts in configured WMS services
```sh
$ app/console mapbender:wms:rewrite:host --help
Usage:
 mapbender:wms:rewrite:host [--dry-run] from to

Arguments:
 from                  Old host name to scan for.
 to                    New host name to set where old name was used.

Options:
 --dry-run             Run through logic but skip database writeback
<...>
```
```sh
$ app/console mapbender:wms:rewrite:host ows.terrestris.de maps.wheregroup.com --dry-run
Updating WMS layer sources (538)
 *   'http://ows.terrestris.de/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
  \=>'http://maps.wheregroup.com/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
Updating WMS sources (45)
 *   'http://ows.terrestris.de/osm/service?request=GetCapabilities&service=wms'
  \=>'http://maps.wheregroup.com/osm/service?request=GetCapabilities&service=wms'
 *   'http://ows.terrestris.de/osm/service'
  \=>'http://maps.wheregroup.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'http://maps.wheregroup.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'http://maps.wheregroup.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'http://maps.wheregroup.com/osm/service'
Updating WMS instances (169)
```

Rewrite WMS urls based on regex search + replace
```sh
$ app/console mapbender:wms:rewrite:regex --help
Usage:
 mapbender:wms:rewrite:regex [--dry-run] from to

Arguments:
 from                  Search pattern (regular expression)
 to                    Replacement

Options:
 --dry-run             Run through logic but skip database writeback
<...>
```
```sh
$ app/console mapbender:wms:rewrite:regex '^http://ows.t[er]{1,4}stris.de' 'https://wow.yeah.com' --dry-run
Updating WMS layer sources (538)
 *   'http://ows.terrestris.de/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
  \=>'https://wow.yeah.com/osm/service?styles=&layer=OSM-WMS&service=WMS&format=image%2Fpng&sld_version=1.1.0&request=GetLegendGraphic&version=1.1.1'
Updating WMS sources (45)
 *   'http://ows.terrestris.de/osm/service?request=GetCapabilities&service=wms'
  \=>'https://wow.yeah.com/osm/service?request=GetCapabilities&service=wms'
 *   'http://ows.terrestris.de/osm/service'
  \=>'https://wow.yeah.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'https://wow.yeah.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'https://wow.yeah.com/osm/service'
 *   'http://ows.terrestris.de/osm/service'
  \=>'https://wow.yeah.com/osm/service'
Updating WMS instances (169)
```

This is useful to perform bulk updates of http => https, or moving services from Mapserver to Mapproxy without clicking through all configured services manually in the backend.

`--dry-run` option shows what would be done, without actually doing it.
