### PR TITLE
Fix/wms cleanups growing authorities 777

### DIFF
--- a/src/Mapbender/WmsBundle/Component/Authority.php
+++ b/src/Mapbender/WmsBundle/Component/Authority.php
@@ -61,4 +61,15 @@ class Authority
         $this->name = $value;
         return $this;
     }
+
+    /**
+     * @return string[]
+     */
+    public function toArray()
+    {
+        return array(
+            'url' => $this->url,
+            'name' => $this->name,
+        );
+    }
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -795,7 +795,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     public function getIdentifierAuthority()
     {
         $result = array();
-        $authorities = $this->getAuthority();
+        $authorities = $this->getAuthority(true);
         if (count($this->identifier) != 0 && count($authorities) != 0) {
             foreach ($this->identifier as $identifier) {
                 foreach ($authorities as $authority) {
@@ -838,9 +838,10 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * Get authority
      *
+     * @param bool $inherit to append Authrity objects inherited (recursively) from parent, if any
      * @return ArrayCollection|Authority[]
      */
-    public function getAuthority($inherit = true)
+    public function getAuthority($inherit = false)
     {
         $parent = $this->getParent();
         if ($parent) {

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -3,6 +3,7 @@
 namespace Mapbender\WmsBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Component\ContainingKeyword;
@@ -837,15 +838,69 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * Get authority
      *
-     * @return Authority
+     * @return ArrayCollection|Authority[]
      */
     public function getAuthority($inherit = true)
     {
-        if ($inherit && $this->getParent() !== null && $this->getParent()->getAuthority() !== null) {
-            return array_merge($this->getParent()->getAuthority(), $this->authority);
+        $parent = $this->getParent();
+        if ($parent) {
+            // filter artifact duplicates added by serialization / deserialization with bad default $inherit
+            // setting, see https://github.com/mapbender/mapbender/issues/777
+            // We must do this to clean up bad data potentially already accumulated in the db
+            // from previously broken logic. The data will only clean itself on next WMS Source refresh
+            // @todo / TBD: write a command that cleans up accumulated artifacts and enforce a run after the next
+            //              update to clean this up for good.
+
+            // *always* filter duplicates smeared in from parent, even with $inherit = false
+            // $inherit = false will only disable appending the parent's Authority to the returned array
+
+            // Filter *only* from own authority list, *only* if equivalent authority received from parent
+            // inheritance.
+            return $this->filterAuthorityDuplicateArtifacts($parent, $inherit);
         } else {
-            $this->authority;
+            return $this->authority;
         }
+    }
+
+    /**
+     * Filters parent-inhertiance smear artifacts from list of Authority objects.
+     * @see https://github.com/mapbender/mapbender/issues/777
+     * This must be run every time we extract the Authority list from any WmsLayerSource that has a parent, to clean
+     * up persisted artifacts.
+     *
+     * @param WmsLayerSource $parent
+     * @param boolean $inheritReturn to include parent-inherited Authority objects IN RETURN VALUE
+     * @return Authority[]
+     */
+    protected function filterAuthorityDuplicateArtifacts(WmsLayerSource $parent, $inheritReturn)
+    {
+        // ensure an array with linear keys, we need to make 1:1 key correlations
+        $ownAuthorities = $this->authority;
+        if ($ownAuthorities instanceof Collection) {
+            $ownAuthorities = iterator_to_array($ownAuthorities, false);
+        } else {
+            // copy, we're going to mutate with unset
+            $ownAuthorities = array() + array_values($ownAuthorities);
+        }
+        /** @var Authority[] $ownAuthorities */
+        $authoritiesOut = $ownAuthorities;
+        // array-converted forms of own authorities, used for duplicate checks only
+        $ownAuthorityArrays = array();
+        foreach ($ownAuthorities as $i => $ownAuthority) {
+            $ownAuthorityArrays[$i] = $ownAuthority->toArray();
+        }
+        foreach ($parent->getAuthority($inheritReturn) as $parentAuthority) {
+            if ($inheritReturn) {
+                $authoritiesOut[] = $parentAuthority;
+            }
+            $parentAuthorityArray = $parentAuthority->toArray();
+            while (false !== ($dupeIndex = array_search($parentAuthorityArray, $ownAuthorityArrays, true))) {
+                unset($ownAuthorityArrays[$dupeIndex]);
+                unset($ownAuthorities[$dupeIndex]);
+                unset($authoritiesOut[$dupeIndex]);
+            }
+        }
+        return $authoritiesOut;
     }
 
     /**


### PR DESCRIPTION
Explanation in issue #777.

Inheritance from parent has been turned off by default, still available if desired.

This should be a policy for everything that gets serialized either by Doctrine or by ourselves, that we **MUST NOT** default the getter methods to mix in relational data.

Application export magically calls getAuthority, so you may see results in exporting + importing applications repeatedly. Without the patch, the export data will grow each cycle.

With the patch, the first export might actually be smaller than before, if you already had dupes in the DB. After that first cleanup, it becomes idempotent as it should be, at least concerning Authority objects.

Otherwise, getAuthority does not seem to be used, except for getIdentifierAuthority, which itself does not seem to be used, at least not in core Mapbender.