### PR TITLE
Fix Wms Loader not using already existing backend implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * **v.3.0.6.4**
+    - Extend WmsLoader WMS service compatibility, now matches backend
     - Fix error displaying Wms metadata if no contact information available
     - Element selector (when adding to Application) is now filtered (Pull #766)
     - Fix displaying scale value in scale selector #657

--- a/src/Mapbender/WmsBundle/Element/WmsLoader.php
+++ b/src/Mapbender/WmsBundle/Element/WmsLoader.php
@@ -3,12 +3,15 @@
 namespace Mapbender\WmsBundle\Element;
 
 use Mapbender\CoreBundle\Component\Element;
-use Mapbender\CoreBundle\Component\EntityHandler;
+use Mapbender\CoreBundle\Entity\Layerset;
+use Mapbender\WmsBundle\Component\Wms\Importer;
+use Mapbender\WmsBundle\Component\WmsInstanceEntityHandler;
+use Mapbender\WmsBundle\Component\WmsInstanceLayerEntityHandler;
+use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
+use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsOrigin;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 
 /**
  * WmsLoader
@@ -159,94 +162,69 @@ class WmsLoader extends Element
     public function httpAction($action)
     {
         switch ($action) {
-            case 'getInstances':
-                return $this->getInstances();
-            case 'getCapabilities':
-                return $this->getCapabilities();
-            case 'signeUrl':
-                return $this->signeUrl();
-            case 'signeSources':
-                return $this->signeSources();
+            case 'loadWms':
+                return $this->loadWms();
             default:
                 throw new NotFoundHttpException('No such action');
         }
     }
 
-    /**
-     * Returns
-     *
-     * @return \Symfony\Component\HttpFoundation\Response a json encoded result.
-     */
-    protected function getCapabilities()
+    protected function loadWms()
     {
-        $gc_url = urldecode($this->container->get('request')->get("url", null));
+        $request = $this->container->get('request');
+        $wmsSource = $this->getWmsSource($request);
+
+        $wmsSourceEntityHandler = new WmsSourceEntityHandler($this->container, $wmsSource);
+        $layerset = new Layerset();
+        $wmsInstance = $wmsSourceEntityHandler->createInstance($layerset);
+
+        $wmsInstanceEntityHandler = new WmsInstanceEntityHandler($this->container, $wmsInstance);
         $signer = $this->container->get('signer');
-        $signedUrl = $signer->signUrl($gc_url);
-        $path = array(
-            '_controller' => 'OwsProxy3CoreBundle:OwsProxy:entryPoint',
-            'url' => urlencode($signedUrl)
-        );
-        $subRequest = $this->container->get('request')->duplicate(
-            array('url' => urlencode($signedUrl)),
-            $this->container->get('request')->request->all(),
-            $path
-        );
-        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        $layerConfiguration = array();
+        $layerConfiguration['title'] = $wmsInstance->getTitle();
+        $layerConfiguration['type'] = strtolower($wmsInstance->getType());
+        $layerConfiguration['configuration'] = $wmsInstanceEntityHandler->getConfiguration($signer);
+        $layerConfiguration['configuration']['children'] = $this->getLayersetConfig($wmsInstance);
+
+        return new JsonResponse($layerConfiguration);
     }
 
-    /**
-     * Returns
-     *
-     * @return Response
-     */
-    protected function signeUrl()
+    protected function getWmsSource($request)
     {
-        $gc_url = urldecode($this->container->get('request')->get("url", null));
-        $signer = $this->container->get('signer');
-        $signedUrl = $signer->signUrl($gc_url);
-        return new JsonResponse(array("success" => $signedUrl));
+        $requestUrl = $request->get("url");
+        $requestUserName = $request->get("username");
+        $requestPassword = $request->get("password");
+        $onlyValid = $request->get("onlyvalid");
+
+        $wmsOrigin = new WmsOrigin($requestUrl, $requestUserName, $requestPassword);
+        $importer = new Importer($this->container);
+        $importerResponse = $importer->evaluateServer($wmsOrigin, $onlyValid);
+
+        return $importerResponse->getWmsSourceEntity();
     }
 
-    /**
-     * Returns
-     *
-     * @return Response
-     */
-    protected function signeSources()
+    protected function getLayersetConfig(WmsInstance $wmsInstance)
     {
-        $sources = json_decode($this->container->get('request')->get("sources", "[]"), true);
-        $signer = $this->container->get('signer');
-        foreach ($sources as &$source) {
-            $source['configuration']['options']['url'] = $signer->signUrl($source['configuration']['options']['url']);
-        }
-        /** @todo: remove double json encoding (adjust consuming code in mapbender.element.wmsloader.js) */
-        return new JsonResponse(array("success" => json_encode($sources)));
-    }
+        $wmsInstanceLayers = $wmsInstance->getLayers();
+        $layersetConfiguration = array();
 
-    /**
-     * Creates Instances from sources.
-     * @return Response
-     */
-    protected function getInstances()
-    {
-        $instancesId = $this->container->get('request')->get("instances", null);
-        $instances = array();
-        $instancesIds = explode(',', $instancesId);
-        foreach ($instancesIds as $instanceid) {
-            $securityContext = $this->container->get('security.authorization_checker');
-            $oid = new ObjectIdentity('class', 'Mapbender\CoreBundle\Entity\Source');
-            if (false !== $securityContext->isGranted('VIEW', $oid)) {
-                $instance = $this->container->get('doctrine')
-                    ->getRepository("MapbenderWmsBundle:WmsInstance")->find($instanceid);
-                $entityHandler = EntityHandler::createHandler($this->container, $instance);
-                $entityHandler->create(false);
-                $instConfig = array(
-                    'type' => $entityHandler->getEntity()->getType(),
-                    'title' => $entityHandler->getEntity()->getTitle(),
-                    'configuration' => $entityHandler->getConfiguration($this->container->get('signer')));
-                $instances[] = $instConfig;
+        foreach ($wmsInstanceLayers as $layer) {
+            $instHandler = WmsInstanceLayerEntityHandler::createHandler($this->container, $layer);
+            $conf        = $instHandler->generateConfiguration();
+            array_push($layersetConfiguration, $conf);
+
+            if (!$conf) {
+                continue;
             }
+
+            $layerSets[] = array(
+                $layer->getId() => array(
+                    'type'          => strtolower($wmsInstance->getType()),
+                    'title'         => $layer->getTitle(),
+                    'configuration' => $conf
+                )
+            );
         }
-        return new JsonResponse(array("success" => $instances));
+        return $layersetConfiguration;
     }
 }

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -105,6 +105,10 @@ Mapbender.Geo.WmsSourceHandler = Class({'extends': Mapbender.Geo.SourceHandler }
         return reqUrl;
     },
 
+    /**
+     * @deprecated, limited compatibility, no longer used by shipping mapbender elements.
+     *              Use server-side evaluation.
+     */
     createSourceDefinitions: function(xml, options){
         if(!options.global.defFormat) {
             options.global.defFormat = "image/png";

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: URL
           wmsuser: Benutzername
           wmspass: Password
+          wmsonlyvalid: 'Nur valide?'
         btn:
           cancel: Abbrechen
           load: Laden

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'Service URL'
           wmsuser: User
           wmspass: Password
+          wmsonlyvalid: 'Only valid?'
         btn:
           cancel: Cancel
           load: Load

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.es.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.es.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'Servicio URL'
           wmsuser: User
           wmspass: Password
+          wmsonlyvalid: 'Solo válido?'
         btn:
           cancel: Cancelar
           load: Cargar

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.fr.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.fr.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'URL du service'
           wmsuser: 'Nom d''utilisateur'
           wmspass: 'Mot de passe'
+          wmsonlyvalid: 'Seulement valide?'
         btn:
           cancel: Annuler
           load: Charger

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.it.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.it.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'URL del Servizio'
           wmsuser: User
           wmspass: Password
+          wmsonlyvalid: 'Valido solo?'
         btn:
           cancel: Cancella
           load: Carica

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.nl.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.nl.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'Service URL'
           wmsuser: Gebruiker
           wmspass: Wachtwoord
+          wmsonlyvalid: 'Alleen geldig?'
         btn:
           cancel: Annuleren
           load: Laad

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.pt.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.pt.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: URL
           wmsuser: Usuário
           wmspass: Senha
+          wmsonlyvalid: 'Apenas válido?'
         btn:
           cancel: Cancelar
           load: Carregar

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.ru.yml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.ru.yml
@@ -7,6 +7,7 @@ mb:
           wmsurl: 'Сервис URL'
           wmsuser: Пользователь
           wmspass: Пароль
+          wmsonlyvalid: 'Действительно ли?'
         btn:
           cancel: Отменить
           load: Загрузить

--- a/src/Mapbender/WmsBundle/Resources/views/Element/wmsloader.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Element/wmsloader.html.twig
@@ -1,6 +1,11 @@
 <div id="{{ id }}" class="mb-element mb-element-wmsloader" title="{{ configuration.tooltip|default(title)|trans }}">
     <p class="description">{{ "mb.wms.wmsloader.dialog.label.example"|trans }}: {{ example_url }}</p>
     <br>
+    <label class="labelInput" for="loadWmsOnlyValid">{{ "mb.wms.wmsloader.dialog.label.wmsonlyvalid"|trans}}</label>
+    <div class="checkWrapper left iconCheckbox" data-icon="iconCheckbox">
+        <input name="loadWmsOnlyValid" class="checkbox" type="checkbox" />
+    </div>
+    <br>
     <label class="labelInput" for="loadWmsUrl">{{ "mb.wms.wmsloader.dialog.label.wmsurl"|trans}}:</label>
     <div class="inputWrapper">
         <input name="loadWmsUrl" class="input url" type="text" />


### PR DESCRIPTION
The Wms Loader element was restructured to use already existing
server side implementations for loading Wms. The checkbox 'only valid'
was also added, because by default, only valid Wms would be loaded.

This fixes https://github.com/mapbender/mapbender/issues/706