### PR TITLE
Enhancement/form validators

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/HTMLElementAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/HTMLElementAdminType.php
@@ -5,36 +5,12 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Mapbender\CoreBundle\Validator\Constraints\HtmlConstraint;
-use Mapbender\CoreBundle\Validator\Constraints\TwigConstraint;
-
 /**
- * 
+ * Class HTMLElementAdminType
+ * @package Mapbender\CoreBundle\Element\Type
  */
 class HTMLElementAdminType extends AbstractType
 {
-    /**
-     * @var HtmlConstraint
-     */
-    private $htmlConstraint;
-
-    /**
-     * @var TwigConstraint
-     */
-    private $twigConstraint;
-
-    /**
-     * HTMLElementAdminType constructor
-     *
-     * @param HtmlConstraint $htmlConstraint
-     * @param TwigConstraint $twigConstraint
-     */
-    public function __construct(HtmlConstraint $htmlConstraint, TwigConstraint $twigConstraint)
-    {
-        $this->htmlConstraint = $htmlConstraint;
-        $this->twigConstraint = $twigConstraint;
-    }
-
     /**
      * @inheritdoc
      */
@@ -59,12 +35,8 @@ class HTMLElementAdminType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('content', 'textarea', [
+            ->add('content', 'html', [
                 'required' => false,
-                'constraints' => [
-                    $this->htmlConstraint,
-                    $this->twigConstraint,
-                ]
             ])
             ->add('classes', 'text', [
                 'required' => false,

--- a/src/Mapbender/CoreBundle/Form/Type/HtmlFormType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/HtmlFormType.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Mapbender\CoreBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+use Mapbender\CoreBundle\Validator\Constraints\HtmlConstraint;
+use Mapbender\CoreBundle\Validator\Constraints\TwigConstraint;
+
+/**
+ * Class HtmlFormType
+ * @package Mapbender\CoreBundle\Form\Type
+ */
+class HtmlFormType extends AbstractType
+{
+    /**
+     * @var HtmlConstraint
+     */
+    private $htmlConstraint;
+
+    /**
+     * @var TwigConstraint
+     */
+    private $twigConstraint;
+
+    /**
+     * HTMLElementAdminType constructor
+     *
+     * @param HtmlConstraint $htmlConstraint
+     * @param TwigConstraint $twigConstraint
+     */
+    public function __construct(HtmlConstraint $htmlConstraint, TwigConstraint $twigConstraint)
+    {
+        $this->htmlConstraint = $htmlConstraint;
+        $this->twigConstraint = $twigConstraint;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'constraints' => array(
+                $this->htmlConstraint,
+                $this->twigConstraint,
+            )
+        ));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return 'html';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getParent()
+    {
+        return 'textarea';
+    }
+
+}
+

--- a/src/Mapbender/CoreBundle/Resources/config/constraints.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/constraints.yml
@@ -8,3 +8,13 @@ services:
 
     mapbender.constraint.twig:
         class: Mapbender\CoreBundle\Validator\Constraints\TwigConstraint
+
+    #
+    # Validators
+    #
+    mapbender.validator.twig:
+        class: Mapbender\CoreBundle\Validator\Constraints\TwigConstraintValidator
+        arguments:
+            - '@translator'
+        tags:
+            - { name: validator.constraint_validator }

--- a/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
@@ -6,10 +6,22 @@ services:
     # Form types must be prefixed with "mapbender.form_type.element"
     # to be accessible by initialisation in MB Core
     #
+
+    #
+    # Element Form Types
+    #
     mapbender.form_type.element.htmlelement:
         class: Mapbender\CoreBundle\Element\Type\HTMLElementAdminType
-        arguments:
-            - '@mapbender.constraint.html'
-            - '@mapbender.constraint.twig'
         tags:
             - { name: form.type, alias: htmlelement }
+
+    #
+    # Common Form Types
+    #
+    mapbender.form_type.html:
+            class: Mapbender\CoreBundle\Form\Type\HtmlFormType
+            arguments:
+                - '@mapbender.constraint.html'
+                - '@mapbender.constraint.twig'
+            tags:
+                - { name: form.type, alias: html }

--- a/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraintValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/TwigConstraintValidator.php
@@ -4,6 +4,8 @@ namespace Mapbender\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
 
 /**
  * Class TwigConstraintValidator
@@ -13,6 +15,19 @@ use Symfony\Component\Validator\ConstraintValidator;
 class TwigConstraintValidator extends ConstraintValidator
 {
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * TwigConstraintValidator constructor.
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator) {
+        $this->translator = $translator;
+    }
+
+    /**
      * @param string $twigString
      * @param Constraint $constraint
      */
@@ -20,6 +35,10 @@ class TwigConstraintValidator extends ConstraintValidator
     {
         try {
             $twig = new \Twig_Environment();
+            $twig->addExtension(
+                new TranslationExtension($this->translator)
+            );
+
             $twig->parse($twig->tokenize($twigString));
         } catch (\Twig_Error_Syntax $e) {
             $this->context->addViolation($constraint->message);


### PR DESCRIPTION
This new FromType could be used for all MB Elements, where it's possible to provide custom html.
The HtmlFormType includes html and twig validation.

Closes #783 and #756.