### PR TITLE
Fix layer min max scale inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Update WmsLoader example URL to https
     - Skip undefined element classes in Yaml applications, log a warning instead of crashing
     - Backport doctrine annotations to fix some broken import / export scenarios
-    - Various fixes to displaying and handling min / max scale definition from sublayers vs root layers
+    - Various fixes to displaying and handling min / max scale definition from sublayers vs root layers (see pull #787)
     - Backport fix for getting Dimension configuration with open extent
     - Fix strict SCSS warnings when compiling with ruby-sass (closes issue #761)
     - Fix possible URL signing spoof with input URLs missing query parameters (internal issue #8375)

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_input.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_input.scss
@@ -11,6 +11,9 @@
     outline:none;
     border:1px solid lighten($ciColor, 20%);
   }
+  &::placeholder {
+    color: lighten($secondColor, 20%);
+  }
 
   @extend .smallText;
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -60,18 +60,21 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             ->setTiled(ArrayUtil::hasSet($configuration, 'tiled', false))
             ->setBaseSource(ArrayUtil::hasSet($configuration, 'isBaseSource', true));
 
+        $rootMinScale = !isset($configuration["minScale"]) ? null : $configuration["minScale"];
+        $rootMaxScale =!isset($configuration["maxScale"]) ? null : $configuration["maxScale"];
+        $rootScaleObj = new MinMax($rootMinScale, $rootMaxScale);
+
         $num  = 0;
         $layersourceroot = new WmsLayerSource();
         $layersourceroot->setPriority($num)
             ->setSource($source)
             ->setTitle($this->entity->getTitle())
+            ->setScale($rootScaleObj)
             ->setId($source->getId() . '_' . $num);
         $source->addLayer($layersourceroot);
         $rootInstLayer = new WmsInstanceLayer();
         $rootInstLayer->setTitle($this->entity->getTitle())
             ->setId($this->entity->getId() . "_" . $num)
-            ->setMinScale(!isset($configuration["minScale"]) ? null : $configuration["minScale"])
-            ->setMaxScale(!isset($configuration["maxScale"]) ? null : $configuration["maxScale"])
             ->setSelected(!isset($configuration["visible"]) ? false : $configuration["visible"])
             ->setPriority($num)
             ->setSourceItem($layersourceroot)

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -39,9 +39,6 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         $instanceLayer->setSourceItem($layerSource);
         $instanceLayer->setTitle($layerSource->getTitle());
 
-        $instanceLayer->setMinScale($layerSource->getMinScale());
-        $instanceLayer->setMaxScale($layerSource->getMaxScale());
-
         $queryable = $layerSource->getQueryable();
         $instanceLayer->setInfo(Utils::getBool($queryable));
         $instanceLayer->setAllowinfo(Utils::getBool($queryable));
@@ -146,17 +143,6 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             }
         }
         $this->entity->setPriority($wmslayersource->getPriority());
-        $origMinMax = $wmslayersource->getScaleRecursive();
-        $scaleMinMax = null;
-        if ($origMinMax) {
-            $minInrange = $origMinMax->getInRange($this->entity->getMinScale());
-            $maxInrange = $origMinMax->getInRange($this->entity->getMaxScale());
-            $scaleMinMax = new MinMax($minInrange, $maxInrange);
-        } else {
-            $scaleMinMax = new MinMax($this->entity->getMinScale(), $this->entity->getMaxScale());
-        }
-        $this->entity->setMinScale($scaleMinMax ? $scaleMinMax->getMin() : null);
-        $this->entity->setMaxScale($scaleMinMax ? $scaleMinMax->getMax() : null);
         $queryable = Utils::getBool($wmslayersource->getQueryable(), true);
         if ($queryable === '0') {
             $queryable = false;

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -227,8 +227,8 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             "title" => $this->entity->getTitle(),
             "queryable" => $this->entity->getInfo(),
             "style" => $this->entity->getStyle(),
-            "minScale" => $this->entity->getMinScale() !== null ? floatval($this->entity->getMinScale()) : null,
-            "maxScale" => $this->entity->getMaxScale() !== null ? floatval($this->entity->getMaxScale()) : null
+            "minScale" => $this->entity->getMinScale(true),
+            "maxScale" => $this->entity->getMaxScale(true),
         );
         $srses = array();
         $llbbox = $this->entity->getSourceItem()->getLatlonBounds();

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstanceItem;
 use Mapbender\CoreBundle\Entity\SourceItem;
 use Mapbender\CoreBundle\Entity\SourceInstance;
-use Mapbender\WmsBundle\Entity\WmsInstance;
-use Mapbender\WmsBundle\Entity\WmsLayerSource;
 
 /**
  * WmsInstanceLayer class
@@ -428,15 +426,19 @@ class WmsInstanceLayer extends SourceInstanceItem
             $value = null;
         }
 
-        if ($recursive && $value === null && $this->getParent()) {
-            $value = $this->getParent()->getMinScale($recursive);
+        if ($recursive && $value === null) {
+            $parent = $this->getParent();
+            $parentValue = $parent ? $parent->getMinScale($recursive) : null;
+            $sourceValue = $this->getSourceItem()->getMinScale($recursive);
+            if ($parentValue !== null && $sourceValue !== null) {
+                $value = max(floatval($parentValue), floatval($sourceValue));
+            } elseif ($sourceValue !== null) {
+                $value = floatval($sourceValue);
+            } else {
+                $value = $parentValue;
+            }
         }
-
-        if ($value !== null) {
-            $value = floatval($value);
-        }
-
-        return $value;
+        return $value === null ? null : floatval($value);
     }
 
     /**
@@ -465,15 +467,19 @@ class WmsInstanceLayer extends SourceInstanceItem
             $value = null;
         }
 
-        if ($recursive && $value === null && $this->getParent()) {
-            $value = $this->getParent()->getMaxScale($recursive);
+        if ($recursive && $value === null) {
+            $parent = $this->getParent();
+            $parentValue = $parent ? $parent->getMaxScale($recursive) : null;
+            $sourceValue = $this->getSourceItem()->getMaxScale($recursive);
+            if ($parentValue !== null && $sourceValue !== null) {
+                $value = min(floatval($parentValue), floatval($sourceValue));
+            } elseif ($sourceValue !== null) {
+                $value = floatval($sourceValue);
+            } else {
+                $value = $parentValue;
+            }
         }
-
-        if ($value !== null) {
-            $value = floatval($value);
-        }
-
-        return $value;
+        return $value === null ? null : floatval($value);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -428,21 +428,26 @@ class WmsInstanceLayer extends SourceInstanceItem
         if ($value == INF) {
             $value = null;
         }
-
-        /**
-         * Logic:
-         * 1) if admin replaced scale for this exact layer instance, use that value.
-         * 2) if admin replaced scale for a parent layer instance, use that value.
-         * 3) use value from source layer (recursively scanning up)
-         */
         if ($recursive && $value === null) {
-            $parent = $this->getParent();
-            $parentValue = $parent ? $parent->getMinScale($recursive) : null;
-            if ($parentValue !== null) {
-                $value = $parentValue;
-            } else {
-                $value = $this->getSourceItem()->getMaxScale($recursive);
-            }
+            $value = $this->getInheritedMinScale();
+        }
+        return $value;
+    }
+
+    /**
+     * Get inherited effective min scale for layer instance
+     * 1) if admin replaced min scale for any parent layer instance, use that value.
+     * 2) if no parent instances have admin-set values, use value from source layer (recursively scanning up)
+     * @return float|null
+     */
+    public function getInheritedMinScale()
+    {
+        $parent = $this->getParent();
+        $parentValue = $parent ? $parent->getMinScale(true) : null;
+        if ($parentValue !== null) {
+            $value = $parentValue;
+        } else {
+            $value = $this->getSourceItem()->getMinScale(true);
         }
         return $value === null ? null : floatval($value);
     }
@@ -475,21 +480,26 @@ class WmsInstanceLayer extends SourceInstanceItem
         if ($value == INF) {
             $value = null;
         }
-
-        /**
-         * Logic:
-         * 1) if admin replaced scale for this exact layer instance, use that value.
-         * 2) if admin replaced scale for a parent layer instance, use that value.
-         * 3) use value from source layer (recursively scanning up)
-         */
         if ($recursive && $value === null) {
-            $parent = $this->getParent();
-            $parentValue = $parent ? $parent->getMaxScale($recursive) : null;
-            if ($parentValue !== null) {
-                $value = $parentValue;
-            } else {
-                $value = $this->getSourceItem()->getMaxScale($recursive);
-            }
+            $value = $this->getInheritedMaxScale();
+        }
+        return $value;
+    }
+
+    /**
+     * Get inherited effective max scale for layer instance
+     * 1) if admin replaced max scale for any parent layer instance, use that value.
+     * 2) if no parent instances have admin-set values, use value from source layer (recursively scanning up)
+     * @return float|null
+     */
+    public function getInheritedMaxScale()
+    {
+        $parent = $this->getParent();
+        $parentValue = $parent ? $parent->getMaxScale(true) : null;
+        if ($parentValue !== null) {
+            $value = $parentValue;
+        } else {
+            $value = $this->getSourceItem()->getMaxScale(true);
         }
         return $value === null ? null : floatval($value);
     }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -415,6 +415,9 @@ class WmsInstanceLayer extends SourceInstanceItem
     /**
      * Get minScale
      *
+     * Recursive path used by frontend config generation and backend instance form
+     * for placeholders only.
+     *
      * @param boolean $recursive Try to get value from parent
      * @return float
      */
@@ -426,11 +429,18 @@ class WmsInstanceLayer extends SourceInstanceItem
             $value = null;
         }
 
+        /**
+         * Logic: if admin replaced scale for this exact layer, use that value.
+         * Otherwise: if both layer source and parent instance layer(s) have
+         *            values, combine them.
+         */
         if ($recursive && $value === null) {
             $parent = $this->getParent();
             $parentValue = $parent ? $parent->getMinScale($recursive) : null;
             $sourceValue = $this->getSourceItem()->getMinScale($recursive);
             if ($parentValue !== null && $sourceValue !== null) {
+                // both parent layer instance and source layer have a value
+                // use MAXIMUM (=smaller range)
                 $value = max(floatval($parentValue), floatval($sourceValue));
             } elseif ($sourceValue !== null) {
                 $value = floatval($sourceValue);
@@ -456,6 +466,9 @@ class WmsInstanceLayer extends SourceInstanceItem
     /**
      * Get maximums scale hint
      *
+     * Recursive path used by frontend config generation and backend instance form
+     * for placeholders only.
+     *
      * @param boolean $recursive Try to get value from parent
      * @return float|null
      */
@@ -467,11 +480,18 @@ class WmsInstanceLayer extends SourceInstanceItem
             $value = null;
         }
 
+        /**
+         * Logic: if admin replaced scale for this exact layer, use that value.
+         * Otherwise: if both layer source and parent instance layer(s) have
+         *            values, combine them.
+         */
         if ($recursive && $value === null) {
             $parent = $this->getParent();
             $parentValue = $parent ? $parent->getMaxScale($recursive) : null;
             $sourceValue = $this->getSourceItem()->getMaxScale($recursive);
             if ($parentValue !== null && $sourceValue !== null) {
+                // both parent layer instance and source layer have a value
+                // use MINIMUM (=smaller range)
                 $value = min(floatval($parentValue), floatval($sourceValue));
             } elseif ($sourceValue !== null) {
                 $value = floatval($sourceValue);

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -436,18 +436,22 @@ class WmsInstanceLayer extends SourceInstanceItem
 
     /**
      * Get inherited effective min scale for layer instance
-     * 1) if admin replaced min scale for any parent layer instance, use that value.
-     * 2) if no parent instances have admin-set values, use value from source layer (recursively scanning up)
+     * 1) if admin replaced min scale for THE parent layer instance, use that value.
+     * 2) if THE parent instance has no admin-set value, use value from source layer
+     * 3) if neither is set, recurse up the tree, maintaining preference instance first, then source
      * @return float|null
      */
     public function getInheritedMinScale()
     {
         $parent = $this->getParent();
-        $parentValue = $parent ? $parent->getMinScale(true) : null;
+        $parentValue = $parent ? $parent->getMinScale(false) : null;
         if ($parentValue !== null) {
             $value = $parentValue;
         } else {
-            $value = $this->getSourceItem()->getMinScale(true);
+            $value = $this->getSourceItem()->getMinScale(false);
+            if ($value === null && $parent) {
+                $value = $parent->getInheritedMinScale();
+            }
         }
         return $value === null ? null : floatval($value);
     }
@@ -488,18 +492,22 @@ class WmsInstanceLayer extends SourceInstanceItem
 
     /**
      * Get inherited effective max scale for layer instance
-     * 1) if admin replaced max scale for any parent layer instance, use that value.
-     * 2) if no parent instances have admin-set values, use value from source layer (recursively scanning up)
+     * 1) if admin replaced max scale for THE parent layer instance, use that value.
+     * 2) if THE parent instance has no admin-set value, use value from source layer
+     * 3) if neither is set, recurse up the tree, maintaining preference instance first, then source
      * @return float|null
      */
     public function getInheritedMaxScale()
     {
         $parent = $this->getParent();
-        $parentValue = $parent ? $parent->getMaxScale(true) : null;
+        $parentValue = $parent ? $parent->getMaxScale(false) : null;
         if ($parentValue !== null) {
             $value = $parentValue;
         } else {
-            $value = $this->getSourceItem()->getMaxScale(true);
+            $value = $this->getSourceItem()->getMaxScale(false);
+            if ($value === null && $parent) {
+                $value = $parent->getInheritedMaxScale();
+            }
         }
         return $value === null ? null : floatval($value);
     }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -464,7 +464,7 @@ class WmsInstanceLayer extends SourceInstanceItem
                 $value = $parent->getInheritedMinScale();
             }
         }
-        return $value === null ? null : floatval($value);
+        return $value;
     }
 
     /**
@@ -517,7 +517,7 @@ class WmsInstanceLayer extends SourceInstanceItem
                 $value = $parent->getInheritedMaxScale();
             }
         }
-        return $value === null ? null : floatval($value);
+        return $value;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -15,6 +15,7 @@ use Mapbender\CoreBundle\Entity\SourceInstance;
  *
  * @ORM\Entity(repositoryClass="WmsInstanceLayerRepository")
  * @ORM\Table(name="mb_wms_wmsinstancelayer")
+ * @ORM\HasLifeCycleCallbacks()
  */
 class WmsInstanceLayer extends SourceInstanceItem
 {
@@ -123,6 +124,19 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         $this->sublayer = new ArrayCollection();
         $this->style = "";
+    }
+
+    /**
+     * @ORM\PostLoad()
+     */
+    public function postLoad()
+    {
+        if ($this->minScale == INF) {
+            $this->minScale = null;
+        }
+        if ($this->maxScale == INF) {
+            $this->maxScale = null;
+        }
     }
 
     /**
@@ -408,7 +422,7 @@ class WmsInstanceLayer extends SourceInstanceItem
      */
     public function setMinScale($value)
     {
-        $this->minScale = $value === null ? null : floatval($value);
+        $this->minScale = ($value === null || $value == INF) ? null : floatval($value);
         return $this;
     }
 
@@ -425,9 +439,6 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         $value = $this->minScale;
 
-        if ($value == INF) {
-            $value = null;
-        }
         if ($recursive && $value === null) {
             $value = $this->getInheritedMinScale();
         }
@@ -464,7 +475,7 @@ class WmsInstanceLayer extends SourceInstanceItem
      */
     public function setMaxScale($value)
     {
-        $this->maxScale = $value === null ? null : floatval($value);
+        $this->maxScale = ($value === null || $value == INF) ? null : floatval($value);
         return $this;
     }
 
@@ -481,9 +492,6 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         $value = $this->maxScale;
 
-        if ($value == INF) {
-            $value = null;
-        }
         if ($recursive && $value === null) {
             $value = $this->getInheritedMaxScale();
         }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -430,22 +430,18 @@ class WmsInstanceLayer extends SourceInstanceItem
         }
 
         /**
-         * Logic: if admin replaced scale for this exact layer, use that value.
-         * Otherwise: if both layer source and parent instance layer(s) have
-         *            values, combine them.
+         * Logic:
+         * 1) if admin replaced scale for this exact layer instance, use that value.
+         * 2) if admin replaced scale for a parent layer instance, use that value.
+         * 3) use value from source layer (recursively scanning up)
          */
         if ($recursive && $value === null) {
             $parent = $this->getParent();
             $parentValue = $parent ? $parent->getMinScale($recursive) : null;
-            $sourceValue = $this->getSourceItem()->getMinScale($recursive);
-            if ($parentValue !== null && $sourceValue !== null) {
-                // both parent layer instance and source layer have a value
-                // use MAXIMUM (=smaller range)
-                $value = max(floatval($parentValue), floatval($sourceValue));
-            } elseif ($sourceValue !== null) {
-                $value = floatval($sourceValue);
-            } else {
+            if ($parentValue !== null) {
                 $value = $parentValue;
+            } else {
+                $value = $this->getSourceItem()->getMaxScale($recursive);
             }
         }
         return $value === null ? null : floatval($value);
@@ -481,22 +477,18 @@ class WmsInstanceLayer extends SourceInstanceItem
         }
 
         /**
-         * Logic: if admin replaced scale for this exact layer, use that value.
-         * Otherwise: if both layer source and parent instance layer(s) have
-         *            values, combine them.
+         * Logic:
+         * 1) if admin replaced scale for this exact layer instance, use that value.
+         * 2) if admin replaced scale for a parent layer instance, use that value.
+         * 3) use value from source layer (recursively scanning up)
          */
         if ($recursive && $value === null) {
             $parent = $this->getParent();
             $parentValue = $parent ? $parent->getMaxScale($recursive) : null;
-            $sourceValue = $this->getSourceItem()->getMaxScale($recursive);
-            if ($parentValue !== null && $sourceValue !== null) {
-                // both parent layer instance and source layer have a value
-                // use MINIMUM (=smaller range)
-                $value = min(floatval($parentValue), floatval($sourceValue));
-            } elseif ($sourceValue !== null) {
-                $value = floatval($sourceValue);
-            } else {
+            if ($parentValue !== null) {
                 $value = $parentValue;
+            } else {
+                $value = $this->getSourceItem()->getMaxScale($recursive);
             }
         }
         return $value === null ? null : floatval($value);

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -628,7 +628,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
      * @param bool $recursive Try to get value from parent
      * @return float|null
      */
-    public function getMinScale($recursive = true)
+    public function getMinScale($recursive = false)
     {
         $value = null;
         $nextSource = $this;
@@ -647,7 +647,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
      * @param bool $recursive Try to get value from parent
      * @return float|null
      */
-    public function getMaxScale($recursive = true)
+    public function getMaxScale($recursive = false)
     {
         $value = null;
         $nextSource = $this;

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -641,9 +641,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
             $value = $this->getScaleRecursive() ? $this->getScaleRecursive()->getMin() : null;
         }
 
-        $value === null ? null : floatval($value);
-
-        return $value;
+        return $value === null ? null : floatval($value);
     }
 
     /**
@@ -665,9 +663,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
             $value = $this->getScaleRecursive() ? $this->getScaleRecursive()->getMax() : null;
         }
 
-        $value === null ? null : floatval($value);
-
-        return $value;
+        return $value === null ? null : floatval($value);
     }
 
     /**
@@ -690,10 +686,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
             if ((!$hasMin || !$hasMax) && $parent) {
                 $parentScale = $parent->getScaleRecursive();
                 if (!$parentScale) {
-                    return new MinMax(
-                        $hasMin ? $scale->getMin() : null,
-                        $hasMax ? $scale->getMax() : null
-                    );
+                    return $scale;
                 }
                 return new MinMax(
                     $hasMin ? $scale->getMin() : $parentScale->getMin(),
@@ -703,9 +696,6 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
                 return $scale;
             }
         }
-
-
-
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
@@ -13,8 +13,8 @@
             <td class="level{{ level }} itemType {% if type == 'node' or  type == 'root' %}iconFolderActive{% else %}iconLinkButton{% endif %} iconSmall"></td>
             <td class="titleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.layerstitle"|trans }}">{{ form_widget(form_layer.title) }}</td>
 
-            <td class="minScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.minscale"|trans }}">{{ form_widget(form_layer.minScale) }}</td>
-            <td class="maxScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.maxsclase"|trans }}">{{ form_widget(form_layer.maxScale) }}</td>
+            <td class="minScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.minscale"|trans }}">{{ form_widget(form_layer.minScale, {'attr': {'placeholder': form_layer.vars.value.getMinScale(true)}}) }}</td>
+            <td class="maxScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.maxsclase"|trans }}">{{ form_widget(form_layer.maxScale, {'attr': {'placeholder': form_layer.vars.value.getMaxScale(true)}}) }}</td>
 
             <td class="checkboxColumn" data-check-identifier="checkActive" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.active"|trans }}">{{ form_widget(form_layer.active) }}</td>
             <td class="checkboxColumn odd" data-check-identifier="checkSelectAllow" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.allowselecttoc"|trans }}">{{ form_widget(form_layer.allowselected) }}</td>

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
@@ -13,8 +13,8 @@
             <td class="level{{ level }} itemType {% if type == 'node' or  type == 'root' %}iconFolderActive{% else %}iconLinkButton{% endif %} iconSmall"></td>
             <td class="titleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.layerstitle"|trans }}">{{ form_widget(form_layer.title) }}</td>
 
-            <td class="minScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.minscale"|trans }}">{{ form_widget(form_layer.minScale, {'attr': {'placeholder': form_layer.vars.value.getMinScale(true)}}) }}</td>
-            <td class="maxScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.maxsclase"|trans }}">{{ form_widget(form_layer.maxScale, {'attr': {'placeholder': form_layer.vars.value.getMaxScale(true)}}) }}</td>
+            <td class="minScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.minscale"|trans }}">{{ form_widget(form_layer.minScale, {'attr': {'placeholder': form_layer.vars.value.getInheritedMinScale()}}) }}</td>
+            <td class="maxScaleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.maxsclase"|trans }}">{{ form_widget(form_layer.maxScale, {'attr': {'placeholder': form_layer.vars.value.getInheritedMaxScale()}}) }}</td>
 
             <td class="checkboxColumn" data-check-identifier="checkActive" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.active"|trans }}">{{ form_widget(form_layer.active) }}</td>
             <td class="checkboxColumn odd" data-check-identifier="checkSelectAllow" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.allowselecttoc"|trans }}">{{ form_widget(form_layer.allowselected) }}</td>


### PR DESCRIPTION
Remove default prepopulation of min/max scale on instance layers while creating new WMS instance or reloading existing instance. Effective initial values are still from the source, just like before, but by indirect lookup, not by copy.

Admin can now distinguish between empty, but inherited values and locally replaced values in "Layerset" backend. If no local value set, inherited value is shown as a placeholder with slightly lighter color.

Lookup logic for effective min / max scale, for each layer is now:
* use admin-set value directly on layer instance if present
* if no value set, use value from layer instance's source layer (GetCapabilities)
* if still no value, go up to parent layer instance, which, again, looks at itself first, then its source layer, recursively

This should make occurences where scale values need manual fixing after source reloads etc far less likely, and it should make it much more transparent to the admin what values are used where and why.

The admin can now simply remove the min / max scale input values from the source instance form to get the effective values from the source (even through source reloads), and only keep the few that might be needed to "fix" bad / unwanted values coming from the GetCapabilities.

Initial motivation / bigger picture:
* resolving abuse of core entities as dumping ground for precached frontend config
* removing paths that potentially modify entities in getters
* removing paths that need unintuitive resaving of entities after modifying some intuitively separate state
* removing all default relational data mixing from entity getters as it leads to
  * Data pileup / unexpected and undesired db modifications on simple load and re-persist
  * Different state of imported / cloned application and sources from original
