### PR TITLE
No entity rewrites for DimensionsHandler

### DIFF
--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -7,6 +7,7 @@ use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\WmsBundle\Element\DimensionsHandler;
 use Mapbender\WmsBundle\Entity\WmsInstance;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
@@ -433,16 +434,18 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         return $vsarr;
     }
 
+    /**
+     * Copies Extent and Default from passed DimensionInst to any DimensionInst stored
+     * in bound WmsInstance that match the same Type.
+     *
+     * @param DimensionInst $dimension
+     * @deprecated we do not modify entities for presentation or frontend purposes
+     *    This was only used by DimensionsHandler::postSave, which is now removed.
+     *    The implementation has been moved directly into DimensionsHandler.
+     */
     public function mergeDimension($dimension)
     {
-        $dimensions = $this->entity->getDimensions();
-        foreach ($dimensions as $dim) {
-            if ($dim->getType() === $dimension->getType()) {
-                $dim->setExtent($dimension->getExtent());
-                $dim->setDefault($dimension->getDefault());
-            }
-        }
-        $this->entity->setDimensions($dimensions);
+        DimensionsHandler::reconfigureDimensions($this->entity, $dimension);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -5,6 +5,7 @@ namespace Mapbender\WmsBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\WmsBundle\Component\DimensionInst;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -136,7 +137,7 @@ class WmsInstance extends SourceInstance
     /**
      * Returns dimensions
      *
-     * @return array of DimensionIst
+     * @return DimensionInst[]
      */
     public function getDimensions()
     {


### PR DESCRIPTION
DimensionsHandler used to rewrite the DimensionInst entities attached to the WmsInstance every time you saved its config in the backend. This was only done so its updated configuration could be embedded into the config generated for a loading application.

This behavior has been removed.

The equivalent replacement behavior is to use [the existing app config rewriting mechanism](https://github.com/mapbender/mapbender/commit/00d260ec192300b575d1618f7db6594c66f85675) similarly to [earlier changes in BaseSourceSwitcher](https://github.com/mapbender/mapbender/commit/5bd5681a8d5920079061392fe968b3c30450f5ad#diff-5fe99690b11d0933943310ef0080f0adR198).

Initial motivation / bigger picture:
* resolving abuse of core entities as dumping ground for precached frontend config
* removing paths that potentially modify entities in getters
* reducing interactions with *EntityHandler classes before long overdue cleanups
