### PR TITLE
Fix/wms cleanups entity behaviour

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -334,7 +334,7 @@ class Application
 
             foreach ($layerSet->layerObjects as $layer) {
                 /** @var SourceInstanceEntityHandler|WmsInstanceEntityHandler $instHandler */
-                $instHandler = EntityHandler::createHandler($this->container, $layer);
+                $instHandler = SourceInstanceEntityHandler::createHandler($this->container, $layer);
                 $conf        = $instHandler->getConfiguration($this->container->get('signer'));
 
                 if (!$conf) {

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -7,6 +7,7 @@ use Mapbender\CoreBundle\Component\Element as ElementComponent;
 use Mapbender\CoreBundle\Entity\Application as Entity;
 use Mapbender\CoreBundle\Entity\Element as ElementEntity;
 use Mapbender\CoreBundle\Entity\Layerset;
+use Mapbender\WmsBundle\Component\WmsInstanceEntityHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -332,6 +333,7 @@ class Application
             $layerSets     = array();
 
             foreach ($layerSet->layerObjects as $layer) {
+                /** @var SourceInstanceEntityHandler|WmsInstanceEntityHandler $instHandler */
                 $instHandler = EntityHandler::createHandler($this->container, $layer);
                 $conf        = $instHandler->getConfiguration($this->container->get('signer'));
 

--- a/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
+++ b/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
@@ -215,8 +215,8 @@ class ApplicationYAMLMapper
             foreach ($layerDefinitions as $id => $layerDefinition) {
                 $class = $layerDefinition['class'];
                 unset($layerDefinition['class']);
-                $entityHandler    = EntityHandler::createHandler($this->container, new $class());
-                $instance         = $entityHandler->getEntity();
+                $instance = new $class();
+                $entityHandler    = EntityHandler::createHandler($this->container, $instance);
                 $internDefinition = array(
                     'weight'   => $weight++,
                     "id"       => $id,

--- a/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
+++ b/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
@@ -8,6 +8,7 @@ use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Entity\Layerset;
 use Mapbender\CoreBundle\Entity\RegionProperties;
 use Psr\Log\LoggerInterface;
+use Mapbender\WmsBundle\Component\WmsInstanceEntityHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -221,6 +222,7 @@ class ApplicationYAMLMapper
                     "id"       => $id,
                     "layerset" => $layerset
                 );
+                /** @var WmsInstanceEntityHandler */
                 $entityHandler->setParameters(array_merge($layerDefinition, $internDefinition));
                 $layerset->addInstance($instance);
             }

--- a/src/Mapbender/CoreBundle/Component/Base/ConfigurationBase.php
+++ b/src/Mapbender/CoreBundle/Component/Base/ConfigurationBase.php
@@ -1,0 +1,105 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Base;
+
+
+/**
+ * Base class for simple "plain old data" configuration carriers that support
+ * * conversion TO array
+ * * instantiation and prepopulation FROM array
+ *
+ * Going back and forth should be idempotent. fromArray has a (by default enabled) strict mode that
+ * enforces that only known value keys can appear in the input array.
+ */
+abstract class ConfigurationBase
+{
+    protected static $classDefaults = array();
+
+    /**
+     * Convert the instance to an array representation.
+     *
+     * @return mixed[]
+     */
+    abstract public function toArray();
+
+    /**
+     * Factory method. Instantiates class and prepopulates it with values from given $options.
+     *
+     * @param mixed[] $options
+     * @param boolean $strict to throw an Exception if unrecognized options were passed
+     * @return static
+     * @throws \InvalidArgumentException if $options is not an array
+     * @throws \RuntimeException if unrecognized keys are found in $options
+     */
+    public static function fromArray($options, $strict = true)
+    {
+        if (!is_array($options)) {
+            if ($strict) {
+                throw new \InvalidArgumentException('Options must be an array, is: ' . print_r($options, true));
+            } else {
+                $options = array();
+            }
+        }
+        $instance = new static();
+        $instance->populateAttributes($options, $strict);
+        return $instance;
+    }
+
+    /**
+     * Perform mass attribute population from array via magic attribute access.
+     *
+     * @param mixed[] $options
+     * @param boolean $strict
+     * @throws \RuntimeException if unsupported value keys are found and $strict == true
+     */
+    protected function populateAttributes($options, $strict)
+    {
+        if ($strict) {
+            $validateAgainst = $this->validSet();
+            $badKeys = array_keys(array_diff_key($options, $validateAgainst));
+            if ($badKeys) {
+                $message = "Unsupported " . get_class($this) . " keys in options: " . implode(", ", $badKeys);
+                $message .= "; have: " . implode(", ", array_keys($validateAgainst));
+                throw new \RuntimeException($message);
+            }
+        }
+        $remap = $this->keyToAttributeMapping();
+        foreach ($remap as $arrayKey =>  $attributeName) {
+            if (isset($options[$arrayKey])) {
+                $options[$attributeName] = $options[$arrayKey];
+                unset($options[$arrayKey]);
+            }
+        }
+        foreach ($options as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+
+    /**
+     * Child classes should override this if attribute names diverge from keys used in array representations.
+     * Return a mapping of arrayKey => attributeName
+     *
+     * @return string[]
+     */
+    protected static function keyToAttributeMapping()
+    {
+        return array();
+    }
+
+    /**
+     * @return array
+     * Policy; no "get" prefix for non-serializible getter functions in objects that are persisted
+     * or exported or otherwise magically scanned for methods with "get" / "is" / "has" etc
+     */
+    public static function validSet()
+    {
+        $cls = get_called_class();
+        if (!array_key_exists($cls, self::$classDefaults)) {
+            /** @var static $blankInstance */
+            $blankInstance = new $cls;
+            self::$classDefaults[$cls] = $blankInstance->toArray();
+        }
+        return self::$classDefaults[$cls];
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/BoundingBox.php
+++ b/src/Mapbender/CoreBundle/Component/BoundingBox.php
@@ -197,4 +197,18 @@ class BoundingBox
         );
     }
 
+    /**
+     * The entity handlers like to call this, for database storage maybe
+     * @return float[]
+     */
+    public function toCoordsArray()
+    {
+        return array(
+            floatval($this->getMinx()),
+            floatval($this->getMiny()),
+            floatval($this->getMaxx()),
+            floatval($this->getMaxy())
+        );
+    }
+
 }

--- a/src/Mapbender/CoreBundle/Component/EntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/EntityHandler.php
@@ -85,26 +85,19 @@ class EntityHandler
     /**
      * @param ContainerInterface $container
      * @param  Source|SourceInstance|object $entity
-     * @return SourceInstanceEntityHandler|null
+     * @return static|null
+     * @todo: never return null
      */
     public static function createHandler(ContainerInterface $container, $entity)
     {
-        $bundles            = $container->get('kernel')->getBundles();
-        $reflect            = new \ReflectionClass($entity);
         $entityClass        = ClassUtils::getClass($entity);
-        $entityBundleFolder = substr($entityClass, 0, strpos($entityClass, '\\Entity\\'));
-        $entityName         = $reflect->getShortName();
-        foreach ($bundles as $type => $bundle) {
-            if (strpos( get_class($bundle), $entityBundleFolder) === 0) {
-                $handlerClass = $entityBundleFolder . '\\Component\\' . $entityName . 'EntityHandler';
-                if (class_exists($handlerClass)) {
-                    return new $handlerClass($container, $entity);
-                } else {
-                    return null;
-                }
-            }
+        $handlerClass = str_replace('\\Entity\\', '\\Component\\', $entityClass) . 'EntityHandler';
+
+        if (class_exists($handlerClass)) {
+            return new $handlerClass($container, $entity);
+        } else {
+            return null;
         }
-        return null;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
+++ b/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
 
+use Mapbender\CoreBundle\Component\Base\ConfigurationBase;
 use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
 
 /**
@@ -8,7 +9,7 @@ use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
  *
  * @author Paul Schmidt
  */
-abstract class InstanceConfiguration
+abstract class InstanceConfiguration extends ConfigurationBase
 {
     /**
      * ORM\Column(type="string", nullable=true)
@@ -24,7 +25,7 @@ abstract class InstanceConfiguration
 
     /**
      * ORM\Column(type="text", nullable=true)
-     * @var InstanceConfigurationOptions
+     * @var InstanceConfigurationOptions|array
      */
     public $options;
 
@@ -143,29 +144,5 @@ abstract class InstanceConfiguration
      */
     public abstract function getChildren();
     
-    /**
-     * Returns InstanceConfiguration as array
-     * 
-     * @return array
-     */
-    public abstract function toArray();
-    
-    /**
-     * Creates an InstanceConfiguration from options
-     * 
-     * @param array $options array with options
-     * @return InstanceConfiguration
-     */
-    public static function fromArray($options)
-    {
-        if($options && is_array($options))
-        {
-            if(isset($options['type']) && $options['type'] === 'wms'){
-                return WmsInstanceConfiguration::fromArray($options);
-            }
-        }
-        return null;
-    }
-
 }
 

--- a/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
+++ b/src/Mapbender/CoreBundle/Component/InstanceConfiguration.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
 
+use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
+
 /**
  * Description of SourceConfiguration
  *
@@ -22,7 +24,7 @@ abstract class InstanceConfiguration
 
     /**
      * ORM\Column(type="text", nullable=true)
-     * @var string
+     * @var InstanceConfigurationOptions
      */
     public $options;
 
@@ -159,7 +161,7 @@ abstract class InstanceConfiguration
         if($options && is_array($options))
         {
             if(isset($options['type']) && $options['type'] === 'wms'){
-                return \Mapbender\WmsBundle\Component\WmsInstanceConfiguration::fromArray($options);
+                return WmsInstanceConfiguration::fromArray($options);
             }
         }
         return null;

--- a/src/Mapbender/CoreBundle/Component/InstanceConfigurationOptions.php
+++ b/src/Mapbender/CoreBundle/Component/InstanceConfigurationOptions.php
@@ -1,12 +1,13 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
+use Mapbender\CoreBundle\Component\Base\ConfigurationBase;
 
 /**
  * Description of SourceConfigurationOptions
  *
  * @author Paul Schmidt
  */
-abstract class InstanceConfigurationOptions
+abstract class InstanceConfigurationOptions extends ConfigurationBase
 {
     /**
      * ORM\Column(type="string", nullable=true)
@@ -16,17 +17,17 @@ abstract class InstanceConfigurationOptions
     /**
      * ORM\Column(type="float", nullable=true)
      */
-    public $opacity;
+    public $opacity = 1;
 
     /**
      * ORM\Column(type="boolean", nullable=true)
      */
-    public $proxy;
+    public $proxy = false;
 
     /**
      * ORM\Column(type="boolean", nullable=true)
      */
-    public $visible;
+    public $visible = true;
 
     /**
      * Sets an url
@@ -115,8 +116,10 @@ abstract class InstanceConfigurationOptions
      * @param Signer $signer
      * @return bool transparency
      *
-     * @deprecated this should be a getter, not a mutator
+     * @deprecated this should be a getter, not a mutator, if it should exist at all here. URL signing is presentation
+     * layer.
      * @internal
+     * @todo: find callers
      */
     public function signUrl(Signer $signer = null)
     {
@@ -137,55 +140,5 @@ abstract class InstanceConfigurationOptions
             "proxy" => $this->proxy,
             "visible" => $this->visible,
         );
-    }
-
-    /**
-     * @return array
-     * Policy; no "get" prefix for non-serializible getter functions in objects that are persisted or exported
-     */
-    public static function defaults()
-    {
-        // all properties uninitialized
-        return array(
-            "url" => null,
-            "opacity" => null,
-            "proxy" => null,
-            "visible" => null,
-        );
-    }
-
-    /**
-     * Creates an InstanceConfigurationOptions from options
-     * @param array $options array with options
-     * @param bool $strict to throw if unknown options have been passed
-     * @return static
-     */
-    public static function fromArray($options, $strict = true)
-    {
-        if (!is_array($options)) {
-            if ($strict) {
-                throw new \InvalidArgumentException('Options must be an array, is: ' . print_r($options, true));
-            } else {
-                $options = array();
-            }
-        }
-        $instance = new static();
-        $instance->populateAttributes($options, static::defaults(), $strict);
-        return $instance;
-    }
-
-    protected function populateAttributes($options, $defaults, $strict)
-    {
-        $mergedOptions = array_replace($defaults, $options);
-        if ($strict) {
-            $validateAgainst = $defaults ?: $this->defaults();
-            $badKeys = array_keys(array_diff_key($validateAgainst, $options));
-            if ($badKeys) {
-                throw new \RuntimeException("Unsupported keys in options: " . implode(", ", $badKeys));
-            }
-        }
-        foreach ($mergedOptions as $key => $value) {
-            $this->{$key} = $value;
-        }
     }
 }

--- a/src/Mapbender/CoreBundle/Component/SourceEntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/SourceEntityHandler.php
@@ -19,8 +19,7 @@ abstract class SourceEntityHandler extends EntityHandler
         
     /**
      * Creates a SourceInstance
-     * @param Layerset $layerset layerset
-     * @param boolean $persist a flag to save the entity
+     * @param Layerset|null $layerset layerset
      */
     abstract public function createInstance(Layerset $layerset = null);
     

--- a/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
@@ -2,6 +2,7 @@
 namespace Mapbender\CoreBundle\Component;
 
 use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\WmsBundle\Component\Dimension;
 use Mapbender\WmsBundle\Component\InstanceTunnel;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -25,7 +26,9 @@ abstract class SourceInstanceEntityHandler extends EntityHandler
     abstract public function setParameters(array $configuration = array());
 
     /**
-     * Creates a SourceInstance
+     * Copies attributes from bound instance's source to the bound instance
+     * @deprecated
+     * If the source is already bound to the instance....
      */
     abstract public function create();
     

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -5,8 +5,8 @@ namespace Mapbender\CoreBundle\Controller;
 use Mapbender\CoreBundle\Asset\ApplicationAssetCache;
 use Mapbender\CoreBundle\Asset\AssetFactory;
 use Mapbender\CoreBundle\Component\Application;
-use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
+use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
 use Mapbender\CoreBundle\Entity\Application as ApplicationEntity;
 use Mapbender\CoreBundle\Utils\RequestUtil;
 use Mapbender\WmsBundle\Component\InstanceTunnelHandler;
@@ -372,7 +372,7 @@ class ApplicationController extends Controller
         $getParams   = $request->query->all();
         $user        = $source->getUsername() ? $source->getUsername() : null;
         $password    = $source->getUsername() ? $source->getPassword() : null;
-        $instHandler = EntityHandler::createHandler($this->container, $instance);
+        $instHandler = SourceInstanceEntityHandler::createHandler($this->container, $instance);
         $vendorspec  = $instHandler->getSensitiveVendorSpecific();
         /* overwrite vendorspecific parameters from handler with get/post parameters */
         if (count($getParams)) {

--- a/src/Mapbender/CoreBundle/Utils/ArrayUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/ArrayUtil.php
@@ -49,6 +49,9 @@ class ArrayUtil
     /**
      * Check if array has a key and return the value, other way set new one and return it.
      *
+     * @deprecated THIS MODIFIES THE ARRAY BY WRITING THE KEY INTO THE KEY NOT THE VALUE YOU HAVE BEEN WARNED
+     * @internal
+     *
      * @param array $arr array
      * @param string $key array key to check for existens
      * @param null  $value default value if key doesn't exists

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -7,6 +7,7 @@ use FOM\ManagerBundle\Configuration\Route as ManagerRoute;
 use Mapbender\CoreBundle\Component\Application as AppComponent;
 use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
+use Mapbender\CoreBundle\Component\SourceEntityHandler;
 use Mapbender\CoreBundle\Controller\WelcomeController;
 use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Element;
@@ -18,6 +19,7 @@ use Mapbender\ManagerBundle\Component\ImportHandler;
 use Mapbender\ManagerBundle\Component\UploadScreenshot;
 use Mapbender\ManagerBundle\Form\Type\ApplicationCopyType;
 use Mapbender\ManagerBundle\Form\Type\ApplicationType;
+use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Form;
@@ -733,6 +735,7 @@ class ApplicationController extends WelcomeController
         $container     = $this->container;
         $source        = $entityManager->getRepository("MapbenderCoreBundle:Source")->find($sourceId);
         $layerSet      = $entityManager->getRepository("MapbenderCoreBundle:Layerset")->find($layersetId);
+        /** @var SourceEntityHandler|WmsSourceEntityHandler $eHandler */
         $eHandler      = EntityHandler::createHandler($container, $source);
         $connection->beginTransaction();
         $sourceInstance = $eHandler->createInstance($layerSet);

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -8,6 +8,7 @@ use Mapbender\CoreBundle\Component\Application as AppComponent;
 use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
 use Mapbender\CoreBundle\Component\SourceEntityHandler;
+use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
 use Mapbender\CoreBundle\Controller\WelcomeController;
 use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Element;
@@ -735,11 +736,11 @@ class ApplicationController extends WelcomeController
         $container     = $this->container;
         $source        = $entityManager->getRepository("MapbenderCoreBundle:Source")->find($sourceId);
         $layerSet      = $entityManager->getRepository("MapbenderCoreBundle:Layerset")->find($layersetId);
-        /** @var SourceEntityHandler|WmsSourceEntityHandler $eHandler */
-        $eHandler      = EntityHandler::createHandler($container, $source);
+        $eHandler      = SourceEntityHandler::createHandler($container, $source);
         $connection->beginTransaction();
         $sourceInstance = $eHandler->createInstance($layerSet);
-        EntityHandler::createHandler($container, $sourceInstance)->save();
+        $instanceSaveHandler = SourceInstanceEntityHandler::createHandler($container, $sourceInstance);
+        $instanceSaveHandler->save();
         $entityManager->flush();
         $connection->commit();
         $this->get("logger")

--- a/src/Mapbender/WmcBundle/Component/WmcParser110.php
+++ b/src/Mapbender/WmcBundle/Component/WmcParser110.php
@@ -15,6 +15,7 @@ use Mapbender\WmsBundle\Component\RequestInformation;
 use Mapbender\WmsBundle\Component\Style;
 use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
 use Mapbender\WmsBundle\Component\WmsInstanceConfigurationOptions;
+use Mapbender\WmsBundle\Component\WmsInstanceLayerEntityHandler;
 use Mapbender\WmsBundle\Entity\WmsInstance;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
@@ -324,7 +325,7 @@ class WmcParser110 extends WmcParser
                 $rootInst->addSublayer($newLayerInstance);
                 $wmsinst->addLayer($newLayerInstance);
             }
-            $rootLayHandler = EntityHandler::createHandler($this->container, $rootInst);
+            $rootLayHandler = new WmsInstanceLayerEntityHandler($this->container, $rootInst);
             $children = array($rootLayHandler->generateConfiguration());
             $wmsconf->setChildren($children);
             return array(

--- a/src/Mapbender/WmsBundle/Component/Dimension.php
+++ b/src/Mapbender/WmsBundle/Component/Dimension.php
@@ -126,6 +126,8 @@ class Dimension
 
     /**
      * Get default
+     *
+     * @return string|null
      */
     public function getDefault()
     {

--- a/src/Mapbender/WmsBundle/Component/DimensionInst.php
+++ b/src/Mapbender/WmsBundle/Component/DimensionInst.php
@@ -147,4 +147,30 @@ class DimensionInst extends Dimension
             'type' => $this->getType(),
         );
     }
+
+    /**
+     * Factory method, copies attributes from given Dimension object.
+     * Adds Origextent initially equal to Dimension Extent
+     * Adds Active initially false
+     * Adds Type found from Dimension Extent via @see findType
+     *
+     * @param Dimension $dim
+     * @return static
+     */
+    public static function fromDimension(Dimension $dim)
+    {
+        $diminst = new static();
+        $diminst->setCurrent($dim->getCurrent());
+        $diminst->setDefault($dim->getDefault());
+        $diminst->setMultipleValues($dim->getMultipleValues());
+        $diminst->setName($dim->getName());
+        $diminst->setNearestValue($dim->getNearestValue());
+        $diminst->setUnitSymbol($dim->getUnitSymbol());
+        $diminst->setUnits($dim->getUnits());
+        $diminst->setActive(false);
+        $diminst->setOrigextent($dim->getExtent());
+        $diminst->setExtent($dim->getExtent());
+        $diminst->setType(static::findType($dim->getExtent()));
+        return $diminst;
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/VendorSpecificHandler.php
+++ b/src/Mapbender/WmsBundle/Component/VendorSpecificHandler.php
@@ -10,6 +10,10 @@ use Mapbender\CoreBundle\Utils\EntityUtil;
  * VendorSpecificHandler class for handling of VendorSpecific.
  *
  * @author Paul Schmidt
+ * @deprecated
+ * @internal
+ *
+ * Only used by WmsInstanceEntityHandler
  */
 class VendorSpecificHandler
 {
@@ -27,7 +31,7 @@ class VendorSpecificHandler
 
     /**
      * Sets a vendor specific
-     * @param type $vendorspecific
+     * @param VendorSpecific $vendorspecific
      * @return \Mapbender\WmsBundle\Component\VendorSpecificHandler
      */
     public function setVendorspecific(VendorSpecific $vendorspecific)
@@ -62,7 +66,7 @@ class VendorSpecificHandler
     /**
      * Reterns a vendor specific value
      * @param mixed $object
-     * @return type
+     * @return string|null
      */
     public function getVendorSpecificValue($object)
     {

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -4,13 +4,22 @@ namespace Mapbender\WmsBundle\Component;
 
 use Mapbender\CoreBundle\Component\InstanceConfiguration;
 use Mapbender\CoreBundle\Component\InstanceConfigurationOptions;
+use Mapbender\WmsBundle\Entity\WmsInstance;
 
 /**
  * Description of WmsInstanceConfiguration
  *
  * @author Paul Schmidt
  *
- * @property WmsInstanceConfigurationOptions $options
+ * @deprecated this entire class is only used transiently to capture values via its setters, then converted to
+ *     array and discared. The sanitization performed along the way is minimal.
+ *
+ * @see WmcParser110::parseLayer()
+ * @see WmsInstance::updateConfiguration()
+ * @internal
+ *
+ * @property WmsInstanceConfigurationOptions|array $options
+ *
  */
 class WmsInstanceConfiguration extends InstanceConfiguration
 {
@@ -62,37 +71,33 @@ class WmsInstanceConfiguration extends InstanceConfiguration
      */
     public function toArray()
     {
+        if (is_array($this->options)) {
+            $optionsArray = $this->options;
+        } else {
+            $optionsArray = $this->options->toArray();
+        }
         return array(
             "type" => $this->type,
             "title" => $this->title,
             "isBaseSource" => $this->isBaseSource,
-            "options" => $this->options->toArray(),
+            "options" => $optionsArray,
             "children" => $this->children
         );
     }
 
     /**
-     * @inheritdoc
+     * @param WmsInstance $instance
+     * @param bool $strict
+     * @return null|static
      */
-    public static function fromArray($options)
+    public static function fromEntity(WmsInstance $instance, $strict = true)
     {
-        $ic = null;
-        if ($options && is_array($options)) {
-            $ic = new WmsInstanceConfiguration();
-            if (isset($options['type'])) {
-                $ic->type = $options['type'];
-            }
-            if (isset($options['title'])) {
-                $ic->title = $options['title'];
-            }
-            if (isset($options['isBaseSource'])) {
-                $ic->isBaseSource = $options['isBaseSource'];
-            }
-            if (isset($options['options'])) {
-                $ic->options = WmsInstanceConfigurationOptions::fromArray($options['options']);
-            }
-        }
-        return $ic;
+        $options = array(
+            'type' => strtolower($instance->getType()),
+            'title' => $instance->getTitle(),
+            'isBaseSource' => $instance->isBaseSource(),
+            'options' => WmsInstanceConfigurationOptions::fromEntity($instance),
+        );
+        return static::fromArray($options, $strict);
     }
-
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -15,7 +15,7 @@ use Mapbender\WmsBundle\Entity\WmsInstance;
  *     array and discared. The sanitization performed along the way is minimal.
  *
  * @see WmcParser110::parseLayer()
- * @see WmsInstance::updateConfiguration()
+ * @see WmsInstanceEntityHandler::getConfiguration()
  * @internal
  *
  * @property WmsInstanceConfigurationOptions|array $options
@@ -103,7 +103,7 @@ class WmsInstanceConfiguration extends InstanceConfiguration
 
     /**
      * Helper method that converts an entity to its array representation
-     * @todo: this probably belongs directly in the entity
+     * @todo: this probably belongs directly in a frontend config generating service
      *
      * @param WmsInstance $entity
      * @return array

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -9,6 +9,8 @@ use Mapbender\CoreBundle\Component\InstanceConfigurationOptions;
  * Description of WmsInstanceConfiguration
  *
  * @author Paul Schmidt
+ *
+ * @property WmsInstanceConfigurationOptions $options
  */
 class WmsInstanceConfiguration extends InstanceConfiguration
 {
@@ -28,7 +30,7 @@ class WmsInstanceConfiguration extends InstanceConfiguration
     /**
      * Returns options
      * 
-     * @return InstanceConfigurationOptions
+     * @return WmsInstanceConfigurationOptions
      */
     public function getOptions()
     {

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfiguration.php
@@ -100,4 +100,16 @@ class WmsInstanceConfiguration extends InstanceConfiguration
         );
         return static::fromArray($options, $strict);
     }
+
+    /**
+     * Helper method that converts an entity to its array representation
+     * @todo: this probably belongs directly in the entity
+     *
+     * @param WmsInstance $entity
+     * @return array
+     */
+    public static function entityToArray($entity)
+    {
+        return static::fromEntity($entity)->toArray();
+    }
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
@@ -356,7 +356,7 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             'visible' => $instance->getVisible(),
             'format' => $instance->getFormat(),
             'info_format' => $instance->getInfoformat(),
-            'transparency' => $instance->getTransparency(),
+            'transparent' => $instance->getTransparency(),
             'opacity' => ($instance->getOpacity() / 100),
             'tiled' => $instance->getTiled(),
             'buffer' => $instance->getBuffer(),
@@ -367,21 +367,13 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
         ));
     }
 
-    public static function defaults()
+    protected static function keyToAttributeMapping()
     {
-        return parent::defaults() + array(
-            'buffer' => 0,
-            'ratio' => 1.25,
-            // everything else is uninitialized
-            'version' => null,
-            'exception_format' => null,     // danger zone: attribute name is exceptionformat, with no underscore
-            'format' => null,
-            'info_format' => null,          // danger zone: attribute name is infoformat, with no underscore
-            'transparency' => null,
-            'vendorspecifics' => null,
-            'tiled' => null,
-            'bbox' => null,
-            'dimensions' => null,
+        // remap our three "danger zone" keys
+        return array(
+            'exception_format' => 'exceptionformat',
+            'info_format' => 'infoformat',
+            'transparent' => 'transparency',
         );
     }
 }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
@@ -3,16 +3,24 @@ namespace Mapbender\WmsBundle\Component;
 
 use Mapbender\CoreBundle\Component\InstanceConfigurationOptions;
 use Mapbender\CoreBundle\Utils\UrlUtil;
+use Mapbender\WmcBundle\Component\WmcParser110;
 use Mapbender\WmsBundle\Entity\WmsInstance;
 
 /**
  * Description of WmsInstanceConfiguration
  *
  * @author Paul Schmidt
+ *
+ * @deprecated this entire class is only used transiently to capture values via its setters, then converted to
+ *     array and discared. The sanitization performed along the way is minimal.
+ *
+ * @see WmcParser110::parseLayer()
+ * @see WmsInstanceEntityHandler::getConfiguration()
+ * @see WmsInstanceConfiguration::fromEntity()
+ * @internal
  */
 class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
 {
-
     /**
      * ORM\Column(type="string", nullable=true)
      */

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php
@@ -356,6 +356,10 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
         foreach ($rootLayer->getSourceItem()->getMergedBoundingBoxes() as $bbox) {
             $boundingBoxMap[$bbox->getSrs()] = $bbox->toCoordsArray();
         }
+        $ratio = $instance->getRatio();
+        if ($ratio !== null) {
+            $ratio = floatval($ratio);
+        }
         return static::fromArray(array(
             'url' => $effectiveUrl,
             'dimensions' => $dimensions,
@@ -368,7 +372,7 @@ class WmsInstanceConfigurationOptions extends InstanceConfigurationOptions
             'opacity' => ($instance->getOpacity() / 100),
             'tiled' => $instance->getTiled(),
             'buffer' => $instance->getBuffer(),
-            'ratio' => $instance->getRatio(),
+            'ratio' => $ratio,
             'version' => $instance->getSource()->getVersion(),
             'exception_format' => $instance->getExceptionformat(),
             'bbox' => $boundingBoxMap,

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -310,15 +310,10 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
      */
     public function generateConfiguration()
     {
-        $wmsconf = new WmsInstanceConfiguration();
-        $wmsconf->setType(strtolower($this->entity->getType()));
-        $wmsconf->setTitle($this->entity->getTitle());
-        $wmsconf->setIsBaseSource($this->entity->isBasesource());
+        $wmsconf = WmsInstanceConfiguration::fromEntity($this->entity);
 
-        $options    = WmsInstanceConfigurationOptions::fromEntity($this->entity);
-
-        $wmsconf->setOptions($options);
         $persistableConfig = $wmsconf->toArray();
+
         $this->entity->setConfiguration($persistableConfig);
     }
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -179,9 +179,6 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
          *     doctrine:schema:update --force
          *     before it can be removed
          */
-        $layerHandler = new WmsInstanceLayerEntityHandler($this->container, $this->entity->getRootlayer());
-        $layerHandler->remove();
-
         $this->container->get('doctrine')->getManager()->persist(
             $this->entity->getLayerset()->getApplication()->setUpdated(new \DateTime('now')));
         $this->container->get('doctrine')->getManager()->remove($this->entity);

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -179,7 +179,7 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
          *     doctrine:schema:update --force
          *     before it can be removed
          */
-        $layerHandler = self::createHandler($this->container, $this->entity->getRootlayer());
+        $layerHandler = new WmsInstanceLayerEntityHandler($this->container, $this->entity->getRootlayer());
         $layerHandler->remove();
 
         $this->container->get('doctrine')->getManager()->persist(

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -307,8 +307,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
     protected function getRootLayerConfig()
     {
         $rootlayer = $this->entity->getRootlayer();
-        $entityHandler = new WmsInstanceLayerEntityHandler($this->container, $rootlayer);
-        $rootLayerConfig = $entityHandler->generateConfiguration();
+        $entityHandler = new WmsInstanceLayerEntityHandler($this->container, null);
+        $rootLayerConfig = $entityHandler->generateConfiguration($rootlayer);
         return $rootLayerConfig;
     }
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -156,7 +156,6 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         foreach ($layerSet->getInstances() as $instance) {
             /** @var WmsInstance $instance */
             $instance->setWeight($num);
-            $instance->updateConfiguration();
             $this->container->get('doctrine')->getManager()->persist($instance);
             $num++;
         }
@@ -212,7 +211,6 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         $rootUpdateHandler = new WmsInstanceLayerEntityHandler($this->container, $this->entity->getRootlayer());
         $rootUpdateHandler->update($this->entity, $this->entity->getSource()->getRootlayer());
 
-        $this->entity->updateConfiguration();
         $this->container->get('doctrine')->getManager()->persist(
             $this->entity->getLayerset()->getApplication()->setUpdated(new \DateTime('now')));
         $this->container->get('doctrine')->getManager()->persist($this->entity);
@@ -234,10 +232,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
      */
     public function getConfiguration(Signer $signer = null)
     {
-        if ($this->entity->getConfiguration() === null) {
-            $this->entity->updateConfiguration();
-        }
-        $configuration = $this->entity->getConfiguration();
+        $configuration = WmsInstanceConfiguration::entityToArray($this->entity);
+
         $layerConfig = $this->getRootLayerConfig();
         if ($layerConfig) {
             $configuration['children'] = array($layerConfig);
@@ -277,12 +273,11 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
     }
 
     /**
-     * Modifies the bound entity, populates `configuration` attribute, returns nothing
-     * @deprecated, call the entity method directly; you don't need a container to do so
+     * Does nothing, returns nothing
+     * @deprecated
      */
     public function generateConfiguration()
     {
-        $this->entity->updateConfiguration();
     }
 
     protected function getRootLayerConfig()

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -126,6 +126,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
     }
 
     /**
+     * Copies attributes from bound instance's source to the bound instance
+     * @deprecated
      * @inheritdoc
      */
     public function create()
@@ -308,57 +310,12 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
      */
     public function generateConfiguration()
     {
-        $rootlayer = $this->entity->getRootlayer();
-        $srses = array();
-        foreach ($this->extractBoundingBoxes($rootlayer) as $bbox) {
-            $srses[$bbox->getSrs()] = array(
-                floatval($bbox->getMinx()),
-                floatval($bbox->getMiny()),
-                floatval($bbox->getMaxx()),
-                floatval($bbox->getMaxy()),
-            );
-        }
         $wmsconf = new WmsInstanceConfiguration();
         $wmsconf->setType(strtolower($this->entity->getType()));
         $wmsconf->setTitle($this->entity->getTitle());
         $wmsconf->setIsBaseSource($this->entity->isBasesource());
 
-        $options    = new WmsInstanceConfigurationOptions();
-        $options->setUrl($this->entity->getSource()->getGetMap()->getHttpGet());
-        $dimensions = array();
-        foreach ($this->entity->getDimensions() as $dimension) {
-            if ($dimension->getActive()) {
-                $dimensions[] = $dimension->getConfiguration();
-                if ($dimension->getDefault()) {
-                    $help = array($dimension->getParameterName() => $dimension->getDefault());
-                    $options->setUrl(UrlUtil::validateUrl($options->getUrl(), $help, array()));
-                }
-            }
-        }
-        $vendorsecifics = array();
-        foreach ($this->entity->getVendorspecifics() as $key => $vendorspec) {
-            $handler = new VendorSpecificHandler($vendorspec);
-            /* add to url only simple vendor specific with valid default value */
-            if ($vendorspec->getVstype() === VendorSpecific::TYPE_VS_SIMPLE && $handler->isVendorSpecificValueValid()) {
-                $vendorsecifics[] = $handler->getConfiguration();
-                $help             = $handler->getKvpConfiguration(null);
-                $options->setUrl(UrlUtil::validateUrl($options->getUrl(), $help, array()));
-            }
-        }
-        $options->setProxy($this->entity->getProxy())
-            ->setVisible($this->entity->getVisible())
-            ->setFormat($this->entity->getFormat())
-            ->setInfoformat($this->entity->getInfoformat())
-            ->setTransparency($this->entity->getTransparency())
-            ->setOpacity($this->entity->getOpacity() / 100)
-            ->setTiled($this->entity->getTiled())
-            ->setBbox($srses)
-            ->setDimensions($dimensions)
-            ->setBuffer($this->entity->getBuffer())
-            ->setRatio($this->entity->getRatio())
-            ->setVendorspecifics($vendorsecifics)
-            ->setVersion($this->entity->getSource()->getVersion())
-            ->setExceptionformat($this->entity->getExceptionformat());
+        $options    = WmsInstanceConfigurationOptions::fromEntity($this->entity);
 
         $wmsconf->setOptions($options);
         $persistableConfig = $wmsconf->toArray();

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\WmsBundle\Component;
 
+use Doctrine\ORM\EntityManager;
 use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Component\Signer;
 use Mapbender\CoreBundle\Component\SourceInstanceEntityHandler;
@@ -162,8 +163,9 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         if ($this->entity->getRootlayer()) {
             self::createHandler($this->container, $this->entity->getRootlayer())->save();
         }
+        $layerSet = $this->entity->getLayerset();
         $num = 0;
-        foreach ($this->entity->getLayerset()->getInstances() as $instance) {
+        foreach ($layerSet->getInstances() as $instance) {
             /** @var WmsInstanceEntityHandler $instHandler */
             $instHandler = self::createHandler($this->container, $instance);
             $instHandler->getEntity()->setWeight($num);
@@ -171,9 +173,12 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             $this->container->get('doctrine')->getManager()->persist($instHandler->getEntity());
             $num++;
         }
-        $this->container->get('doctrine')->getManager()->persist(
-            $this->entity->getLayerset()->getApplication()->setUpdated(new \DateTime('now')));
-        $this->container->get('doctrine')->getManager()->persist($this->entity);
+        $application = $layerSet->getApplication();
+        $application->setUpdated(new \DateTime('now'));
+        /** @var EntityManager $entityManager */
+        $entityManager = $this->container->get('doctrine')->getManager();
+        $entityManager->persist($application);
+        $entityManager->persist($this->entity);
     }
     
 
@@ -212,8 +217,9 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         $this->entity->setDimensions($dimensions);
 
         # TODO vendorspecific for layer specific parameters
-        self::createHandler($this->container, $this->entity->getRootlayer())
-            ->update($this->entity, $this->entity->getSource()->getRootlayer());
+        /** @var WmsInstanceLayerEntityHandler $rootUpdateHandler */
+        $rootUpdateHandler = new WmsInstanceLayerEntityHandler($this->container, $this->entity->getRootlayer());
+        $rootUpdateHandler->update($this->entity, $this->entity->getSource()->getRootlayer());
 
         $this->generateConfiguration();
         $this->container->get('doctrine')->getManager()->persist(
@@ -288,21 +294,6 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         $status = $this->entity->getSource()->getStatus();
         $configuration['status'] = $status && $status === Source::STATUS_UNREACHABLE ? 'error' : 'ok';
         return $configuration;
-    }
-
-    /**
-     * @param WmsInstanceLayer $rootLayer
-     * @return BoundingBox[]
-     */
-    private function extractBoundingBoxes(WmsInstanceLayer $rootLayer)
-    {
-        $sourceItem = $rootLayer->getSourceItem();
-        $bboxes = array();
-        $latLonBounds = $sourceItem->getLatlonBounds();
-        if ($latLonBounds) {
-            $bboxes[] = $latLonBounds;
-        }
-        return array_merge($bboxes, $sourceItem->getBoundingBoxes());
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -150,8 +150,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
         $this->entity->setWeight(-1);
         $wmslayer_root = $this->entity->getSource()->getRootlayer();
 
-        $newInstanceLayerHandler = new WmsInstanceLayerEntityHandler($this->container, new WmsInstanceLayer());
-        $newInstanceLayerHandler->create($this->entity, $wmslayer_root);
+        // ??? @todo: return value is not used, does this implicitly modify one of the passed entities...?
+        WmsInstanceLayerEntityHandler::entityFactory($this->entity, $wmslayer_root);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -145,12 +145,14 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         }
         foreach ($toRemove as $rem) {
             $this->entity->getSublayer()->removeElement($rem);
-            self::createHandler($this->container, $rem)->remove();
+            $removeHandler = new WmsInstanceLayerEntityHandler($this->container, $rem);
+            $removeHandler->remove();
         }
         foreach ($wmslayersource->getSublayer() as $wmslayersourceSub) {
             $layer = $this->findLayer($wmslayersourceSub, $this->entity->getSublayer());
             if ($layer) {
-                self::createHandler($this->container, $layer)->update($instance, $wmslayersourceSub);
+                $layerInstanceHandler = new WmsInstanceLayerEntityHandler($this->container, $layer);
+                $layerInstanceHandler->update($instance, $wmslayersourceSub);
             } else {
                 $sublayerInstance = WmsInstanceLayerEntityHandler::entityFactory($instance, $wmslayersourceSub, $wmslayersourceSub->getPriority());
                 $sublayerInstance->setParent($this->entity);

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -186,27 +186,31 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     }
 
     /**
-     * Generates a configuration for layers
+     * Generates layerset configuration for frontend consumption, recursively.
+     *
+     * @param WmsInstanceLayer|null $entity uses bound entity if omitted
+     *    HACK alert: this function cannot currently be unbound / made static because
+     *                deep down, the URL generation via tunnel might require access
+     *                to the container. The bound entity OTOH is used for nothing
+     *                outside the (optional) initial substitution for an empty argument
      *
      * @return array
      */
-    public function generateConfiguration()
+    public function generateConfiguration(WmsInstanceLayer $entity = null)
     {
-        $configuration = array();
-        if ($this->entity->getActive() === true) {
-            $children = null;
-            if ($this->entity->getSublayer()->count() > 0) {
-                $children = array();
-                foreach ($this->entity->getSublayer() as $sublayer) {
-                    /** @var WmsInstanceLayer $sublayer */
-                    $instLayHandler = new WmsInstanceLayerEntityHandler($this->container, $sublayer);
-                    $configurationTemp = $instLayHandler->generateConfiguration();
-                    if (count($configurationTemp) > 0) {
-                        $children[] = $configurationTemp;
-                    }
+        $entity = $entity ?: $this->entity;
+        if (!$entity->getActive()) {
+            return array();
+        } else {
+            $children = array();
+            foreach ($entity->getSublayer() as $sublayer) {
+                /** @var WmsInstanceLayer $sublayer */
+                $configurationTemp = $this->generateConfiguration($sublayer);
+                if (count($configurationTemp) > 0) {
+                    $children[] = $configurationTemp;
                 }
             }
-            $layerConf = $this->getConfiguration();
+            $layerConf = $this->getConfiguration($entity);
             $configuration = array(
                 "options" => $layerConf,
                 "state" => array(
@@ -216,49 +220,55 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
                     "outOfBounds" => null
                 ),
             );
-            if ($children !== null) {
+            if ($children) {
                 $configuration["children"] = $children;
             }
+            return $configuration;
         }
-        return $configuration;
     }
 
     /**
+     * @param WmsInstanceLayer|null $entity uses bound entity if omitted
+     *    HACK alert: this function cannot currently be unbound / made static because
+     *                deep down, the URL generation via tunnel might require access
+     *                to the container. The bound entity OTOH is used for nothing
+     *                outside the (optional) initial substitution for an empty argument
      * @inheritdoc
      */
-    public function getConfiguration()
+    public function getConfiguration(WmsInstanceLayer $entity = null)
     {
-        $sourceItem = $this->entity->getSourceItem();
+        $entity = $entity ?: $this->entity;
+        $sourceItem = $entity->getSourceItem();
         $configuration = array(
-            "id" => strval($this->entity->getId()),
-            "priority" => $this->entity->getPriority(),
+            "id" => strval($entity->getId()),
+            "priority" => $entity->getPriority(),
             "name" => $sourceItem->getName() !== null ?
                 $sourceItem->getName() : "",
-            "title" => $this->entity->getTitle(),
-            "queryable" => $this->entity->getInfo(),
-            "style" => $this->entity->getStyle(),
-            "minScale" => $this->entity->getMinScale(true),
-            "maxScale" => $this->entity->getMaxScale(true),
+            "title" => $entity->getTitle(),
+            "queryable" => $entity->getInfo(),
+            "style" => $entity->getStyle(),
+            "minScale" => $entity->getMinScale(true),
+            "maxScale" => $entity->getMaxScale(true),
         );
         $srses = array();
         foreach ($sourceItem->getMergedBoundingBoxes() as $bbox) {
             $srses[$bbox->getSrs()] = $bbox->toCoordsArray();
         }
         $configuration['bbox'] = $srses;
-        $legendConfig = $this->getLegendConfig($this->entity);
+        $legendConfig = $this->getLegendConfig($entity);
         if ($legendConfig) {
             $configuration["legend"] = $legendConfig;
         }
 
         $configuration["treeOptions"] = array(
-            "info" => $this->entity->getInfo(),
-            "selected" => $this->entity->getSelected(),
-            "toggle" => $this->entity->getSublayer()->count() > 0 ? $this->entity->getToggle() : null,
+            "info" => $entity->getInfo(),
+            "selected" => $entity->getSelected(),
+            "toggle" => $entity->getSublayer()->count() > 0 ? $entity->getToggle() : null,
             "allow" => array(
-                "info" => $this->entity->getAllowinfo(),
-                "selected" => $this->entity->getAllowselected(),
-                "toggle" => $this->entity->getSublayer()->count() > 0 ? $this->entity->getAllowtoggle() : null,
-                "reorder" => $this->entity->getAllowreorder(),
+                "info" => $entity->getAllowinfo(),
+                "selected" => $entity->getAllowselected(),
+                "toggle" => $entity->getSublayer()->count() > 0 ? $entity->getAllowtoggle() : null,
+                "reorder" => $entity->getAllowreorder(),
             )
         );
         return $configuration;

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -68,16 +68,6 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
      */
     public function remove()
     {
-        /**
-         * @todo: sublayer remove is redundant now, but it may require an automatic
-         *     doctrine:schema:update --force
-         *     before it can be removed
-         */
-        foreach ($this->entity->getSublayer() as $sublayer) {
-            $sublayerRemoveHandler = new WmsInstanceLayerEntityHandler($this->container, $sublayer);
-            $sublayerRemoveHandler->remove();
-        }
-
         $this->container->get('doctrine')->getManager()->remove($this->entity);
     }
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -198,7 +198,8 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             if ($this->entity->getSublayer()->count() > 0) {
                 $children = array();
                 foreach ($this->entity->getSublayer() as $sublayer) {
-                    $instLayHandler = self::createHandler($this->container, $sublayer);
+                    /** @var WmsInstanceLayer $sublayer */
+                    $instLayHandler = new WmsInstanceLayerEntityHandler($this->container, $sublayer);
                     $configurationTemp = $instLayHandler->generateConfiguration();
                     if (count($configurationTemp) > 0) {
                         $children[] = $configurationTemp;

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -32,9 +32,22 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
      */
     public function create(SourceInstance $instance, SourceItem $layerSource, $num = 0)
     {
-        /** @var WmsLayerSource $instanceLayer */
         $instanceLayer = $this->entity;
+        $this->populateFromSource($instanceLayer, $instance, $layerSource, $num);
+        return $this->entity;
+    }
 
+    /**
+     * @internal
+     * @todo: this belongs into a WmsInstanceLayer::fromWmsInstance factory method
+     * @param WmsInstanceLayer $instanceLayer target
+     * @param WmsInstance $instance source
+     * @param WmsLayerSource $layerSource also the source, purpose unknown
+     * @param int $num
+     * @return WmsInstanceLayer
+     */
+    public static function populateFromSource(WmsInstanceLayer $instanceLayer, WmsInstance $instance, WmsLayerSource $layerSource, $num = 0)
+    {
         $instanceLayer->setSourceInstance($instance);
         $instanceLayer->setSourceItem($layerSource);
         $instanceLayer->setTitle($layerSource->getTitle());
@@ -53,10 +66,9 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
         }
         foreach ($layerSource->getSublayer() as $wmslayersourceSub) {
             $subLayerInstance = new WmsInstanceLayer();
-            $entityHandler = new WmsInstanceLayerEntityHandler($this->container, $subLayerInstance);
-            $entityHandler->create($instance, $wmslayersourceSub, $num + 1);
-            $entityHandler->getEntity()->setParent($instanceLayer);
-            $instanceLayer->addSublayer($entityHandler->getEntity());
+            static::populateFromSource($subLayerInstance, $instance, $wmslayersourceSub, $num + 1);
+            $subLayerInstance->setParent($instanceLayer);
+            $instanceLayer->addSublayer($subLayerInstance);
         }
         return $instanceLayer;
     }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -217,11 +217,12 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
      */
     public function getConfiguration()
     {
+        $sourceItem = $this->entity->getSourceItem();
         $configuration = array(
             "id" => strval($this->entity->getId()),
             "priority" => $this->entity->getPriority(),
-            "name" => $this->entity->getSourceItem()->getName() !== null ?
-                $this->entity->getSourceItem()->getName() : "",
+            "name" => $sourceItem->getName() !== null ?
+                $sourceItem->getName() : "",
             "title" => $this->entity->getTitle(),
             "queryable" => $this->entity->getInfo(),
             "style" => $this->entity->getStyle(),
@@ -229,22 +230,8 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             "maxScale" => $this->entity->getMaxScale(true),
         );
         $srses = array();
-        $llbbox = $this->entity->getSourceItem()->getLatlonBounds();
-        if ($llbbox !== null) {
-            $srses[$llbbox->getSrs()] = array(
-                floatval($llbbox->getMinx()),
-                floatval($llbbox->getMiny()),
-                floatval($llbbox->getMaxx()),
-                floatval($llbbox->getMaxy())
-            );
-        }
-        foreach ($this->entity->getSourceItem()->getBoundingBoxes() as $bbox) {
-            $srses[$bbox->getSrs()] = array(
-                floatval($bbox->getMinx()),
-                floatval($bbox->getMiny()),
-                floatval($bbox->getMaxx()),
-                floatval($bbox->getMaxy())
-            );
+        foreach ($sourceItem->getMergedBoundingBoxes() as $bbox) {
+            $srses[$bbox->getSrs()] = $bbox->toCoordsArray();
         }
         $configuration['bbox'] = $srses;
         $legendConfig = $this->getLegendConfig($this->entity);

--- a/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
@@ -75,15 +75,11 @@ class WmsLayerSourceEntityHandler extends SourceItemEntityHandler
     private function removeRecursively(WmsLayerSource $wmslayer)
     {
         /**
-         * @todo: recursive remove is redundant now, but it may require an automatic
-         *     doctrine:schema:update --force
-         *     before it can be removed
+         * @todo: recursive remove is redundant wrt entity manager, but detaching from the relational collections
+         *        may be necessary for update to work
          */
         foreach ($wmslayer->getSublayer() as $sublayer) {
             $this->removeRecursively($sublayer);
-        }
-        foreach ($wmslayer->getKeywords() as $kwd) {
-            $this->container->get('doctrine')->getManager()->remove($kwd);
         }
         if ($wmslayer->getParent()) {
             $wmslayer->getParent()->getSublayer()->removeElement($wmslayer);

--- a/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
@@ -60,6 +60,11 @@ class WmsLayerSourceEntityHandler extends SourceItemEntityHandler
      */
     private function removeRecursively(WmsLayerSource $wmslayer)
     {
+        /**
+         * @todo: recursive remove is redundant now, but it may require an automatic
+         *     doctrine:schema:update --force
+         *     before it can be removed
+         */
         foreach ($wmslayer->getSublayer() as $sublayer) {
             $this->removeRecursively($sublayer);
         }

--- a/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsLayerSourceEntityHandler.php
@@ -79,7 +79,7 @@ class WmsLayerSourceEntityHandler extends SourceItemEntityHandler
      * @inheritdoc
      */
     public function update(SourceItem $itemNew)
-    {# set priority
+    {
         $prio = $this->entity->getPriority();
         $manager = $this->container->get('doctrine')->getManager();
         $classMeta = $manager->getClassMetadata(EntityUtil::getRealClass($this->entity));
@@ -93,6 +93,8 @@ class WmsLayerSourceEntityHandler extends SourceItemEntityHandler
             }
             // ignore not identifier fields
         }
+        /** @var WmsLayerSource $itemNew */
+
         $this->entity->setPriority($prio);
         KeywordUpdater::updateKeywords(
             $this->entity,
@@ -156,9 +158,9 @@ class WmsLayerSourceEntityHandler extends SourceItemEntityHandler
 
     /**
      * Finds a layers at the layerlist.
-     * @param type $layer
-     * @param type $layerList
-     * @return array true
+     * @param WmsLayerSource $layer
+     * @param WmsLayerSource[] $layerList
+     * @return WmsLayerSource[]
      */
     private function findLayer($layer, $layerList)
     {

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -96,18 +96,6 @@ class WmsSourceEntityHandler extends SourceEntityHandler
      */
     public function remove()
     {
-        /**
-         * @todo: rootLayer and contact remove is redundant now, but it may require an automatic
-         *     doctrine:schema:update --force
-         *     before it can be removed
-         */
-        if ($this->entity->getRootlayer()) {
-            $rootLayerHandler = new WmsLayerSourceEntityHandler($this->container, $this->entity->getRootlayer());
-            $rootLayerHandler->remove();
-        }
-        if ($this->entity->getContact()) {
-            $this->container->get('doctrine')->getManager()->remove($this->entity->getContact());
-        }
         $this->container->get('doctrine')->getManager()->remove($this->entity);
     }
 

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -53,15 +53,18 @@ class WmsSourceEntityHandler extends SourceEntityHandler
     }
 
     /**
-     * @inheritdoc
+     * Creates a new WmsInstance, optionally attaches it to a layerset, then updates
+     * the ordering of the layers.
+     *
+     * @param Layerset|null $layerSet new instance will be attached to layerset if given
+     * @return WmsInstance
      */
     public function createInstance(Layerset $layerSet = NULL)
     {
         $instance        = new WmsInstance();
         $instance->setSource($this->entity);
         $instance->setLayerset($layerSet);
-        $instanceHandler = new WmsInstanceEntityHandler($this->container, $instance);
-        $instanceHandler->create();
+        $instance->populateFromSource($this->entity);
         if ($layerSet) {
             $num = 0;
             foreach ($layerSet->getInstances() as $instanceAtLayerset) {
@@ -80,6 +83,11 @@ class WmsSourceEntityHandler extends SourceEntityHandler
      */
     public function remove()
     {
+        /**
+         * @todo: rootLayer and contact remove is redundant now, but it may require an automatic
+         *     doctrine:schema:update --force
+         *     before it can be removed
+         */
         if ($this->entity->getRootlayer()) {
             self::createHandler($this->container, $this->entity->getRootlayer())->remove();
         }

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -9,6 +9,7 @@ use Mapbender\CoreBundle\Entity\Layerset;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Utils\EntityUtil;
 use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
 use Mapbender\WmsBundle\Entity\WmsSource;
 
@@ -59,13 +60,13 @@ class WmsSourceEntityHandler extends SourceEntityHandler
         $instance        = new WmsInstance();
         $instance->setSource($this->entity);
         $instance->setLayerset($layerSet);
-        $instanceHandler = self::createHandler($this->container, $instance);
+        $instanceHandler = new WmsInstanceEntityHandler($this->container, $instance);
         $instanceHandler->create();
-        if ($instanceHandler->getEntity()->getLayerset()) {
+        if ($instance->getLayerset()) {
             $num = 0;
-            foreach ($instanceHandler->getEntity()->getLayerset()->getInstances() as $instanceAtLayerset) {
-                $instHandler = self::createHandler($this->container, $instanceAtLayerset);
-                $instHandler->getEntity()->setWeight($num);
+            foreach ($instance->getLayerset()->getInstances() as $instanceAtLayerset) {
+                $instanceAtLayerset->setWeight($num);
+                $instHandler = new WmsInstanceEntityHandler($this->container, $instanceAtLayerset);
                 $instHandler->generateConfiguration();
                 $num++;
             }

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -83,11 +83,9 @@ class WmsSourceEntityHandler extends SourceEntityHandler
             foreach ($layerSet->getInstances() as $instanceAtLayerset) {
                 /** @var WmsInstance $instanceAtLayerset */
                 $instanceAtLayerset->setWeight($num);
-                $instanceAtLayerset->updateConfiguration();
                 $num++;
             }
         }
-        $instance->updateConfiguration();
         return $instance;
     }
 

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -62,17 +62,17 @@ class WmsSourceEntityHandler extends SourceEntityHandler
         $instance->setLayerset($layerSet);
         $instanceHandler = new WmsInstanceEntityHandler($this->container, $instance);
         $instanceHandler->create();
-        if ($instance->getLayerset()) {
+        if ($layerSet) {
             $num = 0;
-            foreach ($instance->getLayerset()->getInstances() as $instanceAtLayerset) {
+            foreach ($layerSet->getInstances() as $instanceAtLayerset) {
+                /** @var WmsInstance $instanceAtLayerset */
                 $instanceAtLayerset->setWeight($num);
-                $instHandler = new WmsInstanceEntityHandler($this->container, $instanceAtLayerset);
-                $instHandler->generateConfiguration();
+                $instanceAtLayerset->updateConfiguration();
                 $num++;
             }
         }
-        $instanceHandler->generateConfiguration();
-        return $instanceHandler->getEntity();
+        $instance->updateConfiguration();
+        return $instance;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsSourceEntityHandler.php
@@ -126,7 +126,8 @@ class WmsSourceEntityHandler extends SourceEntityHandler
         }
         $this->entity->setContact($contact);
 
-        self::createHandler($this->container, $this->entity->getRootlayer())->update($sourceNew->getRootlayer());
+        $rootUpdateHandler = new WmsLayerSourceEntityHandler($this->container, $this->entity->getRootlayer());
+        $rootUpdateHandler->update($sourceNew->getRootlayer());
 
         KeywordUpdater::updateKeywords(
             $this->entity,
@@ -136,7 +137,8 @@ class WmsSourceEntityHandler extends SourceEntityHandler
         );
 
         foreach ($this->getInstances() as $instance) {
-            self::createHandler($this->container, $instance)->update();
+            $instanceUpdateHandler = new WmsInstanceEntityHandler($this->container, $instance);
+            $instanceUpdateHandler->update();
         }
 
         if (!$transaction) {
@@ -145,7 +147,7 @@ class WmsSourceEntityHandler extends SourceEntityHandler
     }
 
     /**
-     * @inheritdoc
+     * @return WmsInstance[]
      */
     public function getInstances()
     {

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -327,7 +327,6 @@ class RepositoryController extends Controller
                 // reload instance after saving ... why?
                 /** @var WmsInstance $wmsinstance */
                 $wmsinstance = $this->loadEntityByPk($repositoryName, $wmsinstance->getId());
-                $wmsinstance->updateConfiguration();
                 $entityHandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
                 $entityHandler->save();
                 $em->flush();
@@ -417,7 +416,6 @@ class RepositoryController extends Controller
         $em->flush();
         /** @var WmsInstance $wmsinstance */
         $wmsinstance = $this->loadEntityByPk("MapbenderCoreBundle:SourceInstance", $instanceId);
-        $wmsinstance->updateConfiguration();
         $wmsinsthandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
         $wmsinsthandler->save();
         $em->flush();

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -2,20 +2,22 @@
 
 namespace Mapbender\WmsBundle\Controller;
 
+use Doctrine\ORM\EntityRepository;
 use FOM\ManagerBundle\Configuration\Route as ManagerRoute;
-use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SourceMetadata;
 use Mapbender\WmsBundle\Component\Wms\Importer;
 use Mapbender\WmsBundle\Component\WmsInstanceEntityHandler;
 use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
 use Mapbender\WmsBundle\Entity\WmsOrigin;
+use Mapbender\CoreBundle\Entity\SourceInstance;
+use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsSource;
 use Mapbender\WmsBundle\Form\Type\WmsInstanceInstanceLayersType;
 use Mapbender\WmsBundle\Form\Type\WmsSourceSimpleType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
@@ -38,7 +40,7 @@ class RepositoryController extends Controller
      */
     public function newAction()
     {
-        $form = $this->get("form.factory")->create(new WmsSourceSimpleType(), new WmsSource());
+        $form = $this->createForm(new WmsSourceSimpleType(), new WmsSource());
         return array(
             "form" => $form->createView()
         );
@@ -51,7 +53,7 @@ class RepositoryController extends Controller
      */
     public function startAction()
     {
-        $form = $this->get("form.factory")->create(new WmsSourceSimpleType(), new WmsSource());
+        $form = $this->createForm(new WmsSourceSimpleType(), new WmsSource());
         return array(
             "form" => $form->createView()
         );
@@ -88,8 +90,7 @@ class RepositoryController extends Controller
             throw new AccessDeniedException();
         }
 
-        /** @var FormInterface $form */
-        $form      = $this->get("form.factory")->create(new WmsSourceSimpleType(), $wmssource_req);
+        $form      = $this->createForm(new WmsSourceSimpleType(), $wmssource_req);
         $form->submit($request);
         $onlyvalid = $form->get('onlyvalid')->getData();
         if ($form->isValid()) {
@@ -120,6 +121,7 @@ class RepositoryController extends Controller
                 return $this->redirect($this->generateUrl("mapbender_manager_repository_new", array(), true));
             }
             $this->setAliasForDuplicate($wmssource);
+
             $this->getDoctrine()->getManager()->getConnection()->beginTransaction();
 
             $sourceHandler = new WmsSourceEntityHandler($this->container, $wmssource);
@@ -144,14 +146,14 @@ class RepositoryController extends Controller
      */
     public function updateformAction($sourceId)
     {
-        $source          = $this->getDoctrine()->getRepository("MapbenderCoreBundle:Source")->find($sourceId);
+        $source          = $this->loadEntityByPk("MapbenderCoreBundle:Source", $sourceId);
         $securityContext = $this->get('security.context');
         $oid             = new ObjectIdentity('class', 'Mapbender\CoreBundle\Entity\Source');
         if (!$securityContext->isGranted('VIEW', $oid) && !$securityContext->isGranted('EDIT', $source)) {
             throw new AccessDeniedException();
         }
 
-        $form = $this->get("form.factory")->create(new WmsSourceSimpleType(), $source);
+        $form = $this->createForm(new WmsSourceSimpleType(), $source);
         return array(
             "form" => $form->createView()
         );
@@ -166,7 +168,7 @@ class RepositoryController extends Controller
     {
         $request         = $this->get('request');
         /** @var WmsSource|null $wmsOrig */
-        $wmsOrig         = $this->getDoctrine()->getRepository("MapbenderCoreBundle:Source")->find($sourceId);
+        $wmsOrig         = $this->loadEntityByPk("MapbenderCoreBundle:Source", $sourceId);
         $securityContext = $this->get('security.context');
         $oid             = new ObjectIdentity('class', 'Mapbender\CoreBundle\Entity\Source');
         if (!$securityContext->isGranted('VIEW', $oid) && !$securityContext->isGranted('EDIT', $wmsOrig)) {
@@ -174,8 +176,7 @@ class RepositoryController extends Controller
         }
         if ($this->getRequest()->getMethod() === 'POST') { // check form and redirect to update
             $wmssource_req = new WmsSource();
-            /** @var FormInterface $form */
-            $form          = $this->get("form.factory")->create(new WmsSourceSimpleType(), $wmssource_req);
+            $form          = $this->createForm(new WmsSourceSimpleType(), $wmssource_req);
             $form->submit($request);
             if ($form->isValid()) {
                 $importer = new Importer($this->container);
@@ -239,7 +240,7 @@ class RepositoryController extends Controller
                 );
             }
         } else { // create form for update
-            $form = $this->get("form.factory")->create(new WmsSourceSimpleType(), $wmsOrig);
+            $form = $this->createForm(new WmsSourceSimpleType(), $wmsOrig);
             return array(
                 "form" => $form->createView()
             );
@@ -254,12 +255,9 @@ class RepositoryController extends Controller
      */
     public function deleteAction($sourceId)
     {
-        $wmssource    = $this->getDoctrine()
-            ->getRepository("MapbenderWmsBundle:WmsSource")
-            ->find($sourceId);
-        $wmsinstances = $this->getDoctrine()
-            ->getRepository("MapbenderWmsBundle:WmsInstance")
-            ->findBySource($sourceId);
+        $wmssource    = $this->loadEntityByPk("MapbenderWmsBundle:WmsSource", $sourceId);
+        $wmsinstances = $this->getRepository("MapbenderWmsBundle:WmsInstance")
+            ->findBy(array('source' => $sourceId));
         $em           = $this->getDoctrine()->getManager();
         $em->getConnection()->beginTransaction();
 
@@ -289,9 +287,7 @@ class RepositoryController extends Controller
      */
     public function deleteInstanceAction($slug, $instanceId)
     {
-        $instance    = $this->getDoctrine()
-            ->getRepository("MapbenderCoreBundle:SourceInstance")
-            ->find($instanceId);
+        $instance    = $this->loadEntityByPk("MapbenderCoreBundle:SourceInstance", $instanceId);
         $em          = $this->getDoctrine()->getManager();
         $em->getConnection()->beginTransaction();
         $insthandler = new WmsInstanceEntityHandler($this->container, $instance);
@@ -310,9 +306,9 @@ class RepositoryController extends Controller
      */
     public function instanceAction($slug, $instanceId)
     {
-        $wmsinstance = $this->getDoctrine()
-            ->getRepository("MapbenderWmsBundle:WmsInstance")
-            ->find($instanceId);
+        $repositoryName = "MapbenderWmsBundle:WmsInstance";
+        /** @var WmsInstance|null $wmsinstance */
+        $wmsinstance = $this->loadEntityByPk($repositoryName, $instanceId);
 
         if ($this->getRequest()->getMethod() == 'POST') { //save
             $form = $this->createForm(new WmsInstanceInstanceLayersType(), $wmsinstance);
@@ -328,9 +324,9 @@ class RepositoryController extends Controller
                 $em->persist($wmsinstance);
                 $em->flush();
                 $em->getConnection()->commit();
-                $wmsinstance   = $this->getDoctrine()
-                    ->getRepository("MapbenderWmsBundle:WmsInstance")
-                    ->find($wmsinstance->getId());
+                // reload instance after saving ... why?
+                /** @var WmsInstance $wmsinstance */
+                $wmsinstance = $this->loadEntityByPk($repositoryName, $wmsinstance->getId());
                 $entityHandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
                 $entityHandler->generateConfiguration();
                 $entityHandler->save();
@@ -372,9 +368,8 @@ class RepositoryController extends Controller
     public function instanceLayerPriorityAction($slug, $instanceId, $instLayerId)
     {
         $number  = $this->get("request")->get("number");
-        $instLay = $this->getDoctrine()
-            ->getRepository('MapbenderWmsBundle:WmsInstanceLayer')
-            ->findOneById($instLayerId);
+        /** @var WmsInstanceLayer|null $instLay */
+        $instLay = $this->loadEntityByPk('MapbenderWmsBundle:WmsInstanceLayer', $instLayerId);
 
         if (!$instLay) {
             return new Response(json_encode(array(
@@ -395,6 +390,7 @@ class RepositoryController extends Controller
             "SELECT il FROM MapbenderWmsBundle:WmsInstanceLayer il  WHERE il.wmsinstance=:wmsi ORDER BY il.priority ASC"
         );
         $query->setParameters(array("wmsi" => $instanceId));
+        /** @var WmsInstanceLayer[] $instList */
         $instList = $query->getResult();
 
         $num = 0;
@@ -419,9 +415,7 @@ class RepositoryController extends Controller
             $em->persist($inst);
         }
         $em->flush();
-        $wmsinstance = $this->getDoctrine()
-            ->getRepository("MapbenderCoreBundle:SourceInstance")
-            ->find($instanceId);
+        $wmsinstance = $this->loadEntityByPk("MapbenderCoreBundle:SourceInstance", $instanceId);
         $wmsinsthandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
         $wmsinsthandler->generateConfiguration();
         $wmsinsthandler->save();
@@ -442,9 +436,7 @@ class RepositoryController extends Controller
     public function instanceEnabledAction($slug, $instanceId)
     {
         $enabled     = $this->get("request")->get("enabled");
-        $wmsinstance = $this->getDoctrine()
-            ->getRepository("MapbenderWmsBundle:WmsInstance")
-            ->find($instanceId);
+        $wmsinstance = $this->loadEntityByPk("MapbenderWmsBundle:WmsInstance", $instanceId);
         if (!$wmsinstance) {
             return new Response(
                 json_encode(array('error' => 'The wms instance with the id "'.$instanceId.'" does not exist.')),
@@ -453,7 +445,7 @@ class RepositoryController extends Controller
             );
         } else {
             $enabled_before = $wmsinstance->getEnabled();
-            $enabled        = $enabled === "true" ? true : false;
+            $enabled        = $enabled === "true";
             $wmsinstance->setEnabled($enabled);
             $this->getDoctrine()->getManager()->persist(
                 $wmsinstance->getLayerSet()->getApplication()->setUpdated(new \DateTime('now')));
@@ -478,8 +470,8 @@ class RepositoryController extends Controller
     public function metadataAction()
     {
         $sourceId        = $this->container->get('request')->get("sourceId", null);
-        $instance        = $this->container->get("doctrine")
-                ->getRepository('Mapbender\CoreBundle\Entity\SourceInstance')->find($sourceId);
+        /** @var SourceInstance|null $instance */
+        $instance        = $this->loadEntityByPk('Mapbender\CoreBundle\Entity\SourceInstance', $sourceId);
         $securityContext = $this->get('security.context');
         $oid             = new ObjectIdentity('class', 'Mapbender\CoreBundle\Entity\Application');
         if (!$securityContext->isGranted('VIEW', $oid)
@@ -502,7 +494,7 @@ class RepositoryController extends Controller
         $wmsWithSameTitle = $this->getDoctrine()
             ->getManager()
             ->getRepository("MapbenderWmsBundle:WmsSource")
-            ->findByTitle($wmsSource->getTitle());
+            ->findBy(array('title' => $wmsSource->getTitle()));
 
         if (count($wmsWithSameTitle) > 0) {
             $wmsSource->setAlias(count($wmsWithSameTitle));
@@ -525,5 +517,25 @@ class RepositoryController extends Controller
 
         $acl->insertObjectAce($securityIdentity, MaskBuilder::MASK_OWNER);
         $aclProvider->updateAcl($acl);
+    }
+
+    /**
+     * @param string $repositoryName
+     * @param mixed $id
+     * @return object|null
+     */
+    protected function loadEntityByPk($repositoryName, $id)
+    {
+        return $this->getDoctrine()->getRepository($repositoryName)->find($id);
+    }
+
+    /**
+     * @param string $repositoryName
+     * @param string $persistentManagerName object manager name (leave as null for default manager)
+     * @return EntityRepository
+     */
+    protected function getRepository($repositoryName, $persistentManagerName = null)
+    {
+        return $this->getDoctrine()->getRepository($repositoryName, $persistentManagerName);
     }
 }

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -327,8 +327,8 @@ class RepositoryController extends Controller
                 // reload instance after saving ... why?
                 /** @var WmsInstance $wmsinstance */
                 $wmsinstance = $this->loadEntityByPk($repositoryName, $wmsinstance->getId());
+                $wmsinstance->updateConfiguration();
                 $entityHandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
-                $entityHandler->generateConfiguration();
                 $entityHandler->save();
                 $em->flush();
 
@@ -415,9 +415,10 @@ class RepositoryController extends Controller
             $em->persist($inst);
         }
         $em->flush();
+        /** @var WmsInstance $wmsinstance */
         $wmsinstance = $this->loadEntityByPk("MapbenderCoreBundle:SourceInstance", $instanceId);
+        $wmsinstance->updateConfiguration();
         $wmsinsthandler = new WmsInstanceEntityHandler($this->container, $wmsinstance);
-        $wmsinsthandler->generateConfiguration();
         $wmsinsthandler->save();
         $em->flush();
         $em->getConnection()->commit();

--- a/src/Mapbender/WmsBundle/Element/WmsLoader.php
+++ b/src/Mapbender/WmsBundle/Element/WmsLoader.php
@@ -209,7 +209,7 @@ class WmsLoader extends Element
         $layersetConfiguration = array();
 
         foreach ($wmsInstanceLayers as $layer) {
-            $instHandler = WmsInstanceLayerEntityHandler::createHandler($this->container, $layer);
+            $instHandler = new WmsInstanceLayerEntityHandler($this->container, $layer);
             $conf        = $instHandler->generateConfiguration();
             array_push($layersetConfiguration, $conf);
 

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -580,33 +580,6 @@ class WmsInstance extends SourceInstance
     }
 
     /**
-     * Recalculates the "configuration" array attribute
-     */
-    public function updateConfiguration()
-    {
-        $this->configuration = WmsInstanceConfiguration::entityToArray($this);
-    }
-
-    /**
-     * Copies Extent and Default from passed DimensionInst to any DimensionInst stored
-     * in $this->dimensions if they match the same Type.
-     *
-     * @param DimensionInst $referenceDimension
-     * @deprecated only used by DimensionsHandler::postSave, which is also deprecated
-     */
-    public function reconfigureDimensions(DimensionInst $referenceDimension)
-    {
-        $dimensions = $this->getDimensions();
-        foreach ($dimensions as $dim) {
-            if ($dim->getType() === $referenceDimension->getType()) {
-                $dim->setExtent($referenceDimension->getExtent());
-                $dim->setDefault($referenceDimension->getDefault());
-            }
-        }
-        $this->setDimensions($dimensions);
-    }
-
-    /**
      * @param WmsSource $source
      */
     public function populateFromSource(WmsSource $source)

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -148,7 +148,7 @@ class WmsInstance extends SourceInstance
     /**
      * Sets dimensions
      *
-     * @param array $dimensions array of DimensionIst
+     * @param DimensionInst[] $dimensions
      * @return \Mapbender\WmsBundle\Entity\WmsInstance
      */
     public function setDimensions(array $dimensions)
@@ -158,7 +158,7 @@ class WmsInstance extends SourceInstance
     }
 
     /**
-     * @return VendorSpecific[]|DimensionInst[]
+     * @return VendorSpecific[]
      */
     public function getVendorspecifics()
     {

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\WmsBundle\Component\DimensionInst;
 use Mapbender\WmsBundle\Component\VendorSpecific;
+use Mapbender\WmsBundle\Component\WmsInstanceConfiguration;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -576,4 +577,13 @@ class WmsInstance extends SourceInstance
     {
         return new WmsMetadata($this);
     }
+
+    /**
+     * Recalculates the "configuration" array attribute
+     */
+    public function updateConfiguration()
+    {
+        $this->configuration = WmsInstanceConfiguration::entityToArray($this);
+    }
+
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\WmsBundle\Component\DimensionInst;
+use Mapbender\WmsBundle\Component\VendorSpecific;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -170,7 +171,7 @@ class WmsInstance extends SourceInstance
 
     /**
      * Sets vendorspecifics
-     * @param ArrayCollection $vendorspecifics array of DimensionIst
+     * @param ArrayCollection|DimensionInst[]|VendorSpecific[] $vendorspecifics
      * @return \Mapbender\WmsBundle\Entity\WmsInstance
      */
     public function setVendorspecifics(array $vendorspecifics)
@@ -528,7 +529,7 @@ class WmsInstance extends SourceInstance
     /**
      * Add layers
      *
-     * @param WmsInstanceLayer $layers
+     * @param WmsInstanceLayer $layer
      * @return WmsInstance
      */
     public function addLayer(WmsInstanceLayer $layer)

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -5,6 +5,7 @@ namespace Mapbender\WmsBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Mapbender\CoreBundle\Component\BoundingBox;
+use Mapbender\CoreBundle\Component\Utils;
 use Mapbender\CoreBundle\Entity\SourceInstanceItem;
 use Mapbender\CoreBundle\Entity\SourceItem;
 use Mapbender\CoreBundle\Entity\SourceInstance;
@@ -612,4 +613,38 @@ class WmsInstanceLayer extends SourceInstanceItem
         return (string) $this->getId();
     }
 
+    /**
+     * @internal
+     * @param WmsInstance $instance source
+     * @param WmsLayerSource $layerSource also the source, purpose unknown
+     * @param int $priority
+     */
+    public function populateFromSource(WmsInstance $instance, WmsLayerSource $layerSource, $priority = 0)
+    {
+        $this->setSourceInstance($instance);
+        $this->setSourceItem($layerSource);
+        $this->setTitle($layerSource->getTitle());
+
+        $this->setMinScale($layerSource->getMinScale());
+        $this->setMaxScale($layerSource->getMaxScale());
+
+        $queryable = $layerSource->getQueryable();
+        $this->setInfo(Utils::getBool($queryable));
+        $this->setAllowinfo(Utils::getBool($queryable));
+        $this->setPriority($priority);
+        $instance->addLayer($this);
+        if ($layerSource->getSublayer()->count() > 0) {
+            $this->setToggle(false);
+            $this->setAllowtoggle(true);
+        } else {
+            $this->setToggle(null);
+            $this->setAllowtoggle(null);
+        }
+        foreach ($layerSource->getSublayer() as $wmslayersourceSub) {
+            $subLayerInstance = new static();
+            $subLayerInstance->populateFromSource($instance, $wmslayersourceSub, $priority);
+            $subLayerInstance->setParent($this);
+            $this->addSublayer($subLayerInstance);
+        }
+    }
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -4,6 +4,7 @@ namespace Mapbender\WmsBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Mapbender\CoreBundle\Component\BoundingBox;
 use Mapbender\CoreBundle\Entity\SourceInstanceItem;
 use Mapbender\CoreBundle\Entity\SourceItem;
 use Mapbender\CoreBundle\Entity\SourceInstance;
@@ -610,4 +611,5 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         return (string) $this->getId();
     }
+
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -227,7 +227,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
 
     /**
      *
-     * @return ArrayCollection
+     * @return ArrayCollection|WmsLayerSource[]
      */
     public function getSublayer()
     {

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -469,7 +469,7 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     /**
      * Get latlonBounds
      *
-     * @return Object
+     * @return BoundingBox
      */
     public function getLatlonBounds($inherit = true)
     {

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -1020,4 +1020,20 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword
     {
         return (string)$this->id;
     }
+
+    /**
+     * Returns a merged array of the latlon bounds (if set) and other bounding boxes.
+     * This is used by the *EntityHandler machinery frontend config generation.
+     *
+     * @return BoundingBox[]
+     */
+    public function getMergedBoundingBoxes()
+    {
+        $bboxes = array();
+        $latLonBounds = $this->getLatlonBounds();
+        if ($latLonBounds) {
+            $bboxes[] = $latLonBounds;
+        }
+        return array_merge($bboxes, $this->getBoundingBoxes());
+    }
 }

--- a/src/Mapbender/WmsBundle/Entity/WmsSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsSource.php
@@ -7,6 +7,7 @@ use Mapbender\CoreBundle\Component\ContainingKeyword;
 use Mapbender\CoreBundle\Entity\Contact;
 use Mapbender\CoreBundle\Entity\Keyword;
 use Mapbender\CoreBundle\Entity\Source;
+use Mapbender\WmsBundle\Component\DimensionInst;
 use Mapbender\WmsBundle\Component\RequestInformation;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -920,5 +921,23 @@ class WmsSource extends Source implements ContainingKeyword
     {
         $this->identifier = $identifier;
         return $this;
+    }
+
+    /**
+     * @return DimensionInst[]
+     */
+    public function dimensionInstancesFactory()
+    {
+        $dimensions = array();
+        foreach ($this->getLayers() as $layer) {
+            /** @var WmsLayerSource $layer */
+            foreach ($layer->getDimension() as $dimension) {
+                $dim = DimensionInst::fromDimension($dimension);
+                if (!in_array($dim, $dimensions)) {
+                    $dimensions[] = $dim;
+                }
+            }
+        }
+        return $dimensions;
     }
 }

--- a/src/Mapbender/WmsBundle/Tests/Entities/WmsInstanceOptionsTest.php
+++ b/src/Mapbender/WmsBundle/Tests/Entities/WmsInstanceOptionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace Mapbender\WmsBundle\Tests\Entities;
+
+
+use Mapbender\WmsBundle\Component\RequestInformation;
+use Mapbender\WmsBundle\Component\WmsInstanceConfigurationOptions;
+use Mapbender\WmsBundle\Entity\WmsInstance;
+use Mapbender\WmsBundle\Entity\WmsLayerSource;
+use Mapbender\WmsBundle\Entity\WmsSource;
+
+/**
+ * @group unit
+ */
+class WmsInstanceOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return WmsInstance
+     */
+    public static function makeBlankWmsInstance()
+    {
+        // this is the MINIMAL initialization of a WmsInstance so the options can
+        // be generated...
+        // @todo: WmsSource ctor should ensure GetMap is prepopulated
+        // @todo: WmsInstance factory should ensure source is preset to given WmsSource
+        // @todo: WmsInstance factory should ensure root layer instance points to source root layer
+        $blankGetMap = new RequestInformation();
+        $blankWmsSource = new WmsSource();
+        $blankWmsSource->setGetMap($blankGetMap);
+        $blankRootLayer = new WmsLayerSource();
+
+        $blankWmsSource->addLayer($blankRootLayer);
+        $blankWmsInstance = new WmsInstance();
+        $blankWmsInstance->populateFromSource($blankWmsSource);
+        $blankWmsInstance->setSource($blankWmsSource);
+
+        $blankWmsInstance->getRootlayer()->setSourceItem($blankRootLayer);
+        return $blankWmsInstance;
+    }
+
+    public function testInstanceConfigurationDefaultsMatchEntityDefaults()
+    {
+        $blankWmsInstance = $this->makeBlankWmsInstance();
+
+        $blankInstanceOptions = new WmsInstanceConfigurationOptions();
+        $generatedInstanceOptions = WmsInstanceConfigurationOptions::fromEntity($blankWmsInstance);
+
+        $instanceDefaultArray = $generatedInstanceOptions->toArray();
+        $instanceConfigurationDefaultsArray = $blankInstanceOptions->toArray();
+
+        // if you want to dump ... this will end the phpunit run
+        // while (ob_get_level()) { ob_end_clean();}
+        // die(var_export($instanceDefaultArray, true) . "\n");
+        // die(var_export($instanceConfigurationDefaultsArray, true) . "\n");
+
+        $this->assertSame($instanceDefaultArray, $instanceConfigurationDefaultsArray);
+    }
+}


### PR DESCRIPTION
This is a backwards-compatible change dissolving dependencies on EntityHandler while interacting with sources, source instances, their layers, and related objects.

The public APIs of all EntityHandler child classes has been maintained including all quirks. Old-style instantiation and usage is fully supported, many repository-internal usages have been updated though.

### Motivation
The EntityHandler hierarchy is an embodiment of three anti-patterns that make maintaining and extending the behaviors incredibly complex
* explicitly runtime-instantiated service
* non-reusable service prebound to single task
* intransparent string name concatenation of concrete class

### Instantiation, IDE introspection
EntityHandler instantiation has been simplified and clarified, replacing instances of `EntityHandler::createHandler` with a plain old `new` whenever the resulting class is deterministic, and a move to a more concrete e.g. `SourceInstanceEntityHandler::createHandler` wherever some polymorphism is possible. This greatly improves IDE type knowledge, making the using code easier to understand and maintain.

Superfluous instantiations of EntityHandler have also been removed wherever possible. E.g. [internal cases of EntityHandler classes creating, basically, themselves again have been reduced to simple recursive calls](https://github.com/mapbender/mapbender/pull/790/files#diff-df3c2648c88e6cc0566723726ad7a60fL173)

## Recursive relational object deletion without EntityHandler interaction
[EntityHandler-driven recursive remove has been cut back](https://github.com/mapbender/mapbender/pull/790/commits/d13a4c73729dabe4ca5b49b6898cebb6f39fa699). This is already ensured by cascade=remove declarations in the entities. This change has been verified against services with populated `contact` and `keyword` relations.
* Tables have been counted
* complex WMS source has been added, instance has been attached to application
* Source has been deleted.
* I observed that the instance vanished, all attached layers and all attached keywords and contacts vanished. The table counts matched exactly the state before adding the source.

## Freeing up WmsInstance::configuration
The [last important change](https://github.com/mapbender/mapbender/commit/a44a91aa62100215ab0bc6bc6f8d7604766b5a32) is stopping frontend config being smeared into WmsInstance::configuration, previously requiring, again, creation of a WmsInstanceEntityHandler and a call to generateConfiguration whenever something relating to frontend config had changed.

This was effectively a caching layer built into a core entity, which was a horrenduous anti-pattern. The [payload we had been caching](https://github.com/mapbender/mapbender/blob/fbb9e44f0a3344b3d07e6d8525f9ec29bab49bce/src/Mapbender/WmsBundle/Component/WmsInstanceConfigurationOptions.php#L328) was the result of
* calling ~20 getters on the WmsInstance
* serializing Bounding Boxes, Dimensions and Vendorspecifics to arrays
* converting ratio and opacity to float

This payload is ~constant time, it does not grow with the layer count, only slightly with Dimensions. It's not worth breaking entity semantics to cache it, and if we still need to cache it, that needs to happen in the presentation layer, perhaps in the scope of caching the entire application config (TBD).

Generated configuration is the same as before. For demonstration, I baked a few monster WMS services into an application and diffed the config 1) with the code right before this branch and 2) at the (current) end of this branch with the added extra of **never** returning the persisted configuration from before from WmsInstance::getConfiguration. I'm using json_pp with `canonical` option to ensure JSON keys are sorted and don't appear in random order, so the configs are comparable.
```
## release/3.0.5, parent commit of this branch
ron@flake:~/proj/mb305/application/mapbender$ git checkout -q ef7e083e39d82324cd04281beda06188e168c6e2
ron@flake:~/proj/mb305/application/mapbender$ rm -rf `find ../app/cache/{dev,prod} -mindepth 1 -maxdepth 1 -not -name 'sessions'`
ron@flake:~/proj/mb305/application/mapbender$ curl -s 'http://305.mapbender.local/app_dev.php/application/teh-grids/config' | json_pp -json_opt=pretty,ascii,canonical > teh-grids.config.ef7e083e39d82324cd04281beda06188e168c6e2.json

## last config-significant commit on this branch
ron@flake:~/proj/mb305/application/mapbender$ git checkout -q fbb9e44f0a3344b3d07e6d8525f9ec29bab49bce

## manually disable WmsInstance::getConfiguration (not committed) ..., then
ron@flake:~/proj/mb305/application/mapbender$ git diff src/
diff --git a/src/Mapbender/WmsBundle/Entity/WmsInstance.php b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
index daf58bd..26b0d14 100644
--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -201,6 +201,7 @@ class WmsInstance extends SourceInstance
      */
     public function getConfiguration()
     {
+        return array();
         return $this->configuration;
     }

ron@flake:~/proj/mb305/application/mapbender$ rm -rf `find ../app/cache/{dev,prod} -mindepth 1 -maxdepth 1 -not -name 'sessions'`
ron@flake:~/proj/mb305/application/mapbender$ curl -s 'http://305.mapbender.local/app_dev.php/application/teh-grids/config' | json_pp -json_opt=pretty,ascii,canonical > teh-grids.config.fbb9e44f0a3344b3d07e6d8525f9ec29bab49bce.json

## now finally compare the configs
ron@flake:~/proj/mb305/application/mapbender$ diff -uw teh-grids.config.a44a91aa62100215ab0bc6bc6f8d7604766b5a32.json teh-grids.config.fbb9e44f0a3344b3d07e6d8525f9ec29bab49bce.json
ron@flake:~/proj/mb305/application/mapbender$
```
The diff is empty => the configs delivered to the client are 100% unchanged.

The pretty-printed json configuration is ~780kB (8 active WMS instances). The local WmsInstance configurations made up 2.5% of the data volume and 12% of the total generation time. The practical impact of no longer caching these portions is smaller, because the instance is now more compact and loads faster.

### Strategy
The ultimate goal (beyond the scope of this pull) is to no longer depend on the EntityManager hierarchy at all. Recursive persistence, removal, attaching related objects can and should be performed entirely by Doctrine EntityManager. What the EM cannot do should move into compartmentalized services (proper services). Namely:
* reformatting entity data into a configuration array fit for the frontend (presentation layer)
* merging a new entity into an old entity, e.g. refresh WmsSource in backend updates related WmsInstances (Repository layer)
