### PR TITLE
Fix/form types as services

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Element.php
+++ b/src/Mapbender/CoreBundle/Component/Element.php
@@ -536,7 +536,7 @@ abstract class Element
                 'css' => array(
                     'components/codemirror/lib/codemirror.css'));
         } else {
-            $type = self::getAdminFormType($configurationFormType, $container);
+            $type = self::getAdminFormType($configurationFormType, $container, $class);
 
             $options = array('application' => $application);
             if ($type instanceof ExtendedCollection && $element !== null && $element->getId() !== null) {
@@ -559,11 +559,13 @@ abstract class Element
      *
      * @param string $configurationFormType
      * @param ContainerInterface $container
+     * @param string $class
+     *
      * @return $type
      */
-    protected static function getAdminFormType($configurationFormType, ContainerInterface $container)
+    protected static function getAdminFormType($configurationFormType, ContainerInterface $container, $class)
     {
-        $formTypeId = 'mapbender.form_type.element.' . $configurationFormType::getName();
+        $formTypeId = 'mapbender.form_type.element.' . self::getElementName($class);
         $serviceExists = $container->has($formTypeId);
 
         if (false !== $serviceExists) {
@@ -573,6 +575,19 @@ abstract class Element
         }
 
         return $adminFormType;
+    }
+
+    /**
+     * Get lowercase element name from full class namespace
+     *
+     * @param string $class
+     * @return string
+     */
+    protected static function getElementName($class)
+    {
+        $namespaceParts = explode('\\', $class);
+
+        return strtolower(array_pop($namespaceParts));
     }
 
     /**

--- a/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/MapbenderCoreExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class MapbenderCoreExtension extends Extension
 {
-    const CONFIG_PATH = __DIR__ . '/../Resources/config';
+    const CONFIG_PATH = '/../Resources/config';
 
     /**
      * @var FileLocator
@@ -23,7 +23,7 @@ class MapbenderCoreExtension extends Extension
      */
     public function __construct()
     {
-        $this->fileLocator = new FileLocator(self::CONFIG_PATH);
+        $this->fileLocator = new FileLocator(__DIR__ . self::CONFIG_PATH);
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/formTypes.yml
@@ -4,7 +4,10 @@ services:
     # Form Types
     #
     # Form types must be prefixed with "mapbender.form_type.element"
+    # and named using lowercase element class name
     # to be accessible by initialisation in MB Core
+    #
+    # Example: for HTMLElementAdminType it must be mapbender.form_type.element.htmlelement
     #
 
     #


### PR DESCRIPTION
There are two issues has been found:

- php version lower 5.6 doesn't allow using scalar expressions by constant definition
- it's a bad practice to call not static functions in a static way

Closes #792 