### PR TITLE
Add config hook to expose DimensionsHandler as a technical preview

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/LayerTreeMenuType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayerTreeMenuType.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element\Type;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class LayerTreeMenuType extends AbstractType
+{
+    protected $exposedChoices = array();
+
+    /**
+     * @param boolean $showDimensions see services.xml, controlled via parameter `mapbender.preview.element.dimensionshandler`
+     */
+    public function __construct($showDimensions)
+    {
+        $this->exposedChoices = array(
+            "layerremove" => "Remove layer",
+            "opacity" => "Opacity",
+            "zoomtolayer" => "Zoom to layer",
+            "metadata" => "Metadata",
+        );
+        if ($showDimensions) {
+            $this->exposedChoices += array(
+                "dimension" => "Dimension",
+            );
+        }
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'choices' => $this->exposedChoices,
+            'multiple' => true,
+        ));
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'layertree_menu';
+    }
+
+    /**
+     * @return null|string|\Symfony\Component\Form\FormTypeInterface
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
@@ -37,15 +37,6 @@ class LayertreeAdminType extends AbstractType
     {
         $subscriber = new LayertreeSubscriber($builder->getFormFactory(), $options['application']);
         $builder->addEventSubscriber($subscriber);
-        $menuComponents = array(
-            "layerremove" => "Remove layer",
-            "opacity" => "Opacity",
-            "zoomtolayer" => "Zoom to layer",
-            "metadata" => "Metadata",
-//            "legend" => "Legend",
-//            "kmlexport" => "KML export",
-//            "dimension" => "Dimension",
-        );
         $builder->add('target', 'target_element', array(
                 'element_class' => 'Mapbender\\CoreBundle\\Element\\Map',
                 'application' => $options['application'],
@@ -75,9 +66,10 @@ class LayertreeAdminType extends AbstractType
                 'required' => false))
             ->add('hideSelect', 'checkbox', array(
                 'required' => false))
-            ->add('menu', 'choice', array(
+            // see LayerTreeMenuType.php
+            ->add('menu', 'layertree_menu', array(
                 'required' => false,
-                "multiple" => true,
-                'choices' => $menuComponents));
+            ))
+        ;
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="signer.class">Mapbender\CoreBundle\Component\Signer</parameter>
         <parameter key="assetic.filter.scss.class">Eslider\Filter\ScssFilter</parameter>
         <parameter key="mapbender.owsproxy.httpclient.legacy.class">Mapbender\CoreBundle\Component\OwsProxy\LegacyService</parameter>
+        <parameter key="mapbender.form_type.element.layertree.menu.class">Mapbender\CoreBundle\Element\Type\LayerTreeMenuType</parameter>
     </parameters>
 
     <services>
@@ -90,6 +91,12 @@
 
         <service id="owsproxy.httpclient" class="%mapbender.owsproxy.httpclient.legacy.class%">
             <argument type="service" id="service_container" />
+        </service>
+
+        <!-- layertree "menu" choices; servicy because of DimensionsHandler interaction -->
+        <service id="mapbender.form_type.element.layertree.menuChoices" class="%mapbender.form_type.element.layertree.menu.class%">
+            <argument>%mapbender.preview.element.dimensionshandler%</argument>
+            <tag name="form.type" alias="layertree_menu" />
         </service>
     </services>
 </container>

--- a/src/Mapbender/WmsBundle/MapbenderWmsBundle.php
+++ b/src/Mapbender/WmsBundle/MapbenderWmsBundle.php
@@ -15,9 +15,13 @@ class MapbenderWmsBundle extends MapbenderBundle
      */
     public function getElements()
     {
-        return array(
-            'Mapbender\WmsBundle\Element\WmsLoader'
+        $elements = array(
+            'Mapbender\WmsBundle\Element\WmsLoader',
         );
+        if ($this->container->getParameter('mapbender.preview.element.dimensionshandler')) {
+            $elements[] = 'Mapbender\WmsBundle\Element\DimensionsHandler';
+        }
+        return $elements;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -4,6 +4,8 @@
 	xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="wmsloader.example_url">https://wms.wheregroup.com/cgi-bin/mapbender_user.xml?VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;SERVICE=WMS</parameter>
+        <!-- set this to true in your parameters.yml to expose DimensionsHandler element -->
+        <parameter key="mapbender.preview.element.dimensionshandler">false</parameter>
     </parameters>
 </container>
 


### PR DESCRIPTION
This is a better, cleaner version of [pull 610](https://github.com/mapbender/mapbender/pull/610/files#diff-005c46c7584cee49cf60354ae9ad5ac0L47), exploring a new "technical preview" delivery for not-quite-ready features that are already in the main code base.

DimensionsHandler has been sleeping in the code base for a while, but it's not ready yet for public consumption. Some projects do use it though, even on older 3.0.5 versions, so we can't just remove it or break it out into its own repository without risking upgrade continuity.

This pull does not enable anything new by default. DimensionsHandler is still kept "hidden". Meaning:
* doesn't show up in the list of addable elements when you edit your application layout
* doesn't show up in LayerTree "menu" choices

This simply changes the method of exposure. Before:
* Projects would have to hack their MapbenderWmsBundle::getElements
* Projects would have to hack their Element\Type\LayerTreeAdminType

This may actually have led to forks.

After:
* Projects can at their own risk enable DimensionsHandler it with a single parameters.yml entry
```yml
parameters:
    <...>
    mapbender.preview.element.dimensionshandler: true
```