### PR TITLE
Fix/importer and tunnel are services

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
@@ -1,39 +1,56 @@
 <?php
 
-
-namespace Mapbender\WmsBundle\Component;
-
-use Mapbender\CoreBundle\Controller\ApplicationController;
+namespace Mapbender\CoreBundle\Component\Source\Tunnel;
+use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\CoreBundle\Utils\RequestUtil;
+use Mapbender\WmsBundle\Component\InstanceTunnel;
+use Mapbender\WmsBundle\Component\WmsInstanceLayerEntityHandler;
+use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
 use Symfony\Component\HttpFoundation\Request;
 
-
 /**
- * Base version of InstanceTunnel that can process, but not generate tunnel requests (works without access to
- * Router).
- *
- * @see ApplicationController::instanceTunnelAction()
- *
- * @package Mapbender\WmsBundle\Component
+ * Tunnel base endpoint pre-bound to a particular SourceInstance
  */
-class InstanceTunnelHandler
+class Endpoint
 {
+    /** @var InstanceTunnel */
+    protected $service;
+
     /** @var SourceInstance */
     protected $instance;
 
     /** @var Source */
     protected $source;
 
+
     /**
      * InstanceTunnel constructor.
+     * @param InstanceTunnel
      * @param SourceInstance $instance
      */
-    public function __construct(SourceInstance $instance)
+    public function __construct($service, SourceInstance $instance)
     {
+        $this->service = $service;
         $this->instance = $instance;
         $this->source = $instance->getSource();
+    }
+
+    /**
+     * @return Application
+     */
+    public function getApplicationEntity()
+    {
+        return $this->instance->getLayerset()->getApplication();
+    }
+
+    /**
+     * @return SourceInstance
+     */
+    public function getSourceInstance()
+    {
+        return $this->instance;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
@@ -38,6 +38,30 @@ class Endpoint
     }
 
     /**
+     * Returns the URL base the Browser / JS client should use to access the tunnel.
+     *
+     * @return string
+     */
+    public function getPublicBaseUrl()
+    {
+        return $this->service->getPublicBaseUrl($this);
+    }
+
+    /**
+     * Returns the URL the Browser / JS client should use to access a specific WMS function (by given URL) via
+     * the tunnel.
+     *
+     * @param string $url NOTE: scheme/host/path completely ignored, only query string is relevant
+     * @return string
+     * @throws \RuntimeException if no REQUEST=... in given $url
+     */
+    public function generatePublicUrl($url)
+    {
+        return $this->service->generatePublicUrl($this, $url);
+    }
+
+
+    /**
      * @return Application
      */
     public function getApplicationEntity()

--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/Endpoint.php
@@ -5,7 +5,6 @@ use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\CoreBundle\Utils\RequestUtil;
-use Mapbender\WmsBundle\Component\InstanceTunnel;
 use Mapbender\WmsBundle\Component\WmsInstanceLayerEntityHandler;
 use Mapbender\WmsBundle\Component\WmsSourceEntityHandler;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class Endpoint
 {
-    /** @var InstanceTunnel */
+    /** @var InstanceTunnelService */
     protected $service;
 
     /** @var SourceInstance */
@@ -27,7 +26,7 @@ class Endpoint
 
     /**
      * InstanceTunnel constructor.
-     * @param InstanceTunnel
+     * @param InstanceTunnelService
      * @param SourceInstance $instance
      */
     public function __construct($service, SourceInstance $instance)

--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
@@ -1,9 +1,8 @@
 <?php
 
 
-namespace Mapbender\WmsBundle\Component;
+namespace Mapbender\CoreBundle\Component\Source\Tunnel;
 
-use Mapbender\CoreBundle\Component\Source\Tunnel\Endpoint;
 use Mapbender\CoreBundle\Controller\ApplicationController;
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -18,7 +17,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @package Mapbender\WmsBundle\Component
  */
-class InstanceTunnel
+class InstanceTunnelService
 {
     /** @var UrlGeneratorInterface */
     protected $router;
@@ -26,7 +25,6 @@ class InstanceTunnel
     /**
      * InstanceTunnel constructor.
      * @param UrlGeneratorInterface $router
-     * @param SourceInstance $instance
      */
     public function __construct(UrlGeneratorInterface $router)
     {

--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @see WmsInstanceEntityHandler::getConfiguration()
  * @see WmsInstanceLayerEntityHandler::getLegendConfig()
  *
- * @package Mapbender\WmsBundle\Component
+ * By default registered in container as mapbender.source.instancetunnel.service, see services.xml
  */
 class InstanceTunnelService
 {

--- a/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
@@ -1,8 +1,9 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
 
+use Mapbender\CoreBundle\Component\Source\Tunnel\Endpoint;
 use Mapbender\CoreBundle\Entity\SourceInstance;
-use Mapbender\WmsBundle\Component\InstanceTunnel;
+use Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService;
 
 /**
  * Description of SourceInstanceEntityHandler
@@ -13,7 +14,7 @@ use Mapbender\WmsBundle\Component\InstanceTunnel;
  */
 abstract class SourceInstanceEntityHandler extends EntityHandler
 {
-    /** @var InstanceTunnel */
+    /** @var InstanceTunnelService */
     protected $tunnel;
 
     /**
@@ -56,12 +57,12 @@ abstract class SourceInstanceEntityHandler extends EntityHandler
     abstract public function getSensitiveVendorSpecific();
 
     /**
-     * @return InstanceTunnel
+     * @return Endpoint
      */
     protected function getTunnel()
     {
         if (!$this->tunnel) {
-            /** @var InstanceTunnel $tunnelService */
+            /** @var InstanceTunnelService $tunnelService */
             $tunnelService = $this->container->get('mapbender.source.instancetunnel.service');
             $this->tunnel = $tunnelService->makeEndpoint($this->entity);
         }

--- a/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
+++ b/src/Mapbender/CoreBundle/Component/SourceInstanceEntityHandler.php
@@ -3,7 +3,6 @@ namespace Mapbender\CoreBundle\Component;
 
 use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\WmsBundle\Component\InstanceTunnel;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Description of SourceInstanceEntityHandler
@@ -62,9 +61,9 @@ abstract class SourceInstanceEntityHandler extends EntityHandler
     protected function getTunnel()
     {
         if (!$this->tunnel) {
-            /** @var UrlGeneratorInterface $router */
-            $router = $this->container->get('router');
-            $this->tunnel = new InstanceTunnel($router, $this->entity);
+            /** @var InstanceTunnel $tunnelService */
+            $tunnelService = $this->container->get('mapbender.source.instancetunnel.service');
+            $this->tunnel = $tunnelService->makeEndpoint($this->entity);
         }
         return $this->tunnel;
     }

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -7,9 +7,9 @@ use Mapbender\CoreBundle\Asset\AssetFactory;
 use Mapbender\CoreBundle\Component\Application;
 use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
+use Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService;
 use Mapbender\CoreBundle\Entity\Application as ApplicationEntity;
 use Mapbender\CoreBundle\Utils\RequestUtil;
-use Mapbender\WmsBundle\Component\InstanceTunnel;
 use Mapbender\WmsBundle\Entity\WmsSource;
 use OwsProxy3\CoreBundle\Component\CommonProxy;
 use OwsProxy3\CoreBundle\Component\ProxyQuery;
@@ -387,7 +387,7 @@ class ApplicationController extends Controller
         if (!$requestType) {
             throw new BadRequestHttpException('Missing mandatory parameter `request` in tunnelAction');
         }
-        /** @var InstanceTunnel $tunnelService */
+        /** @var InstanceTunnelService $tunnelService */
         $tunnelService = $this->get('mapbender.source.instancetunnel.service');
         $instanceTunnel = $tunnelService->makeEndpoint($instance);
         $url = $instanceTunnel->getInternalUrl($request);

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -387,7 +387,9 @@ class ApplicationController extends Controller
         if (!$requestType) {
             throw new BadRequestHttpException('Missing mandatory parameter `request` in tunnelAction');
         }
-        $instanceTunnel = new InstanceTunnel($this->get('router'), $instance);
+        /** @var InstanceTunnel $tunnelService */
+        $tunnelService = $this->get('mapbender.source.instancetunnel.service');
+        $instanceTunnel = $tunnelService->makeEndpoint($instance);
         $url = $instanceTunnel->getInternalUrl($request);
         if (!$url) {
             throw new NotFoundHttpException('Operation "' . $requestType . '" is not supported by "tunnelAction".');

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -9,7 +9,7 @@ use Mapbender\CoreBundle\Component\EntityHandler;
 use Mapbender\CoreBundle\Component\SecurityContext;
 use Mapbender\CoreBundle\Entity\Application as ApplicationEntity;
 use Mapbender\CoreBundle\Utils\RequestUtil;
-use Mapbender\WmsBundle\Component\InstanceTunnelHandler;
+use Mapbender\WmsBundle\Component\InstanceTunnel;
 use Mapbender\WmsBundle\Entity\WmsSource;
 use OwsProxy3\CoreBundle\Component\CommonProxy;
 use OwsProxy3\CoreBundle\Component\ProxyQuery;
@@ -387,7 +387,7 @@ class ApplicationController extends Controller
         if (!$requestType) {
             throw new BadRequestHttpException('Missing mandatory parameter `request` in tunnelAction');
         }
-        $instanceTunnel = new InstanceTunnelHandler($instance);
+        $instanceTunnel = new InstanceTunnel($this->get('router'), $instance);
         $url = $instanceTunnel->getInternalUrl($request);
         if (!$url) {
             throw new NotFoundHttpException('Operation "' . $requestType . '" is not supported by "tunnelAction".');

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -7,7 +7,7 @@
         <parameter key="signer.class">Mapbender\CoreBundle\Component\Signer</parameter>
         <parameter key="assetic.filter.scss.class">Eslider\Filter\ScssFilter</parameter>
         <parameter key="mapbender.owsproxy.httpclient.legacy.class">Mapbender\CoreBundle\Component\OwsProxy\LegacyService</parameter>
-        <parameter key="mapbender.source.instancetunnel.service.class">Mapbender\WmsBundle\Component\InstanceTunnel</parameter>
+        <parameter key="mapbender.source.instancetunnel.service.class">Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService</parameter>
     </parameters>
 
     <services>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="signer.class">Mapbender\CoreBundle\Component\Signer</parameter>
         <parameter key="assetic.filter.scss.class">Eslider\Filter\ScssFilter</parameter>
         <parameter key="mapbender.owsproxy.httpclient.legacy.class">Mapbender\CoreBundle\Component\OwsProxy\LegacyService</parameter>
+        <parameter key="mapbender.source.instancetunnel.service.class">Mapbender\WmsBundle\Component\InstanceTunnel</parameter>
     </parameters>
 
     <services>
@@ -86,6 +87,10 @@
         <service id="mapbender.validator.css" class="Mapbender\CoreBundle\Validator\Constraints\ScssValidator">
             <argument type="service" id="service_container" />
             <tag name="validator.constraint_validator" alias="mapbender.validator.css" />
+        </service>
+
+        <service id="mapbender.source.instancetunnel.service" class="%mapbender.source.instancetunnel.service.class%">
+            <argument type="service" id="router" />
         </service>
 
         <service id="owsproxy.httpclient" class="%mapbender.owsproxy.httpclient.legacy.class%">

--- a/src/Mapbender/WmsBundle/Command/UrlValidateCommand.php
+++ b/src/Mapbender/WmsBundle/Command/UrlValidateCommand.php
@@ -29,7 +29,8 @@ class UrlValidateCommand extends ContainerAwareCommand
     {
         $origin = new WmsOrigin($input->getArgument('serviceUrl'), $input->getOption('user'), $input->getOption('password'));
 
-        $importer = new Importer($this->getContainer());
+        /** @var Importer $importer */
+        $importer = $this->getContainer()->get('mapbender.importer.source.wms.service');
         $result = $importer->evaluateServer($origin, true);
         $wmsSource = $result->getWmsSourceEntity();
 

--- a/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
+++ b/src/Mapbender/WmsBundle/Component/InstanceTunnel.php
@@ -3,8 +3,10 @@
 
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Component\Source\Tunnel\Endpoint;
 use Mapbender\CoreBundle\Controller\ApplicationController;
 use Mapbender\CoreBundle\Entity\SourceInstance;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -17,10 +19,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @package Mapbender\WmsBundle\Component
  */
-class InstanceTunnel extends InstanceTunnelHandler
+class InstanceTunnel
 {
     /** @var UrlGeneratorInterface */
     protected $router;
+    /** @var Endpoint */
+    protected $endpoint;
 
     /**
      * InstanceTunnel constructor.
@@ -30,7 +34,12 @@ class InstanceTunnel extends InstanceTunnelHandler
     public function __construct(UrlGeneratorInterface $router, SourceInstance $instance)
     {
         $this->router = $router;
-        parent::__construct($instance);
+        $this->endpoint = $this->makeEndpoint($instance);
+    }
+
+    public function makeEndpoint(SourceInstance $instance)
+    {
+        return new Endpoint($this, $instance);
     }
 
     /**
@@ -43,8 +52,8 @@ class InstanceTunnel extends InstanceTunnelHandler
         return $this->router->generate(
             'mapbender_core_application_instancetunnel',
             array(
-                'slug' => $this->instance->getLayerset()->getApplication()->getSlug(),
-                'instanceId' => $this->instance->getId()),
+                'slug' => $this->endpoint->getApplicationEntity()->getSlug(),
+                'instanceId' => $this->endpoint->getSourceInstance()->getId()),
             UrlGeneratorInterface::ABSOLUTE_URL
         );
     }
@@ -71,5 +80,27 @@ class InstanceTunnel extends InstanceTunnelHandler
             }
         }
         throw new \RuntimeException('Failed to tunnelify url, no `request` param found: ' . var_export($url, true));
+    }
+
+    /**
+     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getInternalUrl(Request $request)
+    {
+        return $this->endpoint->getInternalUrl($request);
+    }
+
+    /**
+     * Gets the url on the wms service that satisfies the given $request (=Symfony Http Request object)
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getInternalGetLegendGraphicUrl(Request $request)
+    {
+        return $this->endpoint->getInternalGetLegendGraphicUrl($request);
     }
 }

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -14,6 +14,15 @@ use OwsProxy3\CoreBundle\Component\ProxyQuery;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Service class that produces WmsSource entities by evaluating a "GetCapabilities" document, either directly
+ * in-memory, or from a given WmsOrigin (which is just url + username + password).
+ * WmsSource is bundled in a Response class with validation errors. This is done because validation exceptions
+ * can be optionally suppressed ("onlyValid"=false). In that case, the Response will contain the exception, if
+ * any. By default, validation exceptions are thrown.
+ *
+ * An instance is registered in container as mapbender.importer.source.wms.service, see services.xml
+ */
 class Importer extends ContainerAware
 {
     /**

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -9,7 +9,6 @@ use Mapbender\WmsBundle\Entity\WmsInstance;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Mapbender\WmsBundle\Entity\WmsLayerSource;
 use Mapbender\WmsBundle\Entity\WmsSource;
-use Symfony\Component\Routing\Router;
 
 /**
  * Description of WmsInstanceLayerEntityHandler
@@ -328,9 +327,9 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     {
         $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
         if (WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource())) {
-            /** @var Router $router */
-            $router = $this->container->get('router');
-            $tunnel = new InstanceTunnel($router, $entity->getSourceInstance());
+            /** @var InstanceTunnel $tunnelService */
+            $tunnelService = $this->container->get('mapbender.source.instancetunnel.service');
+            $tunnel = $tunnelService->makeEndpoint($this->entity->getSourceInstance());
         } else {
             $tunnel = null;
         }

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService;
 use Mapbender\CoreBundle\Component\SourceInstanceItemEntityHandler;
 use Mapbender\CoreBundle\Component\Utils;
 use Mapbender\CoreBundle\Entity\SourceInstance;
@@ -327,7 +328,7 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
     {
         $styleLegendUrl = $this->getLegendUrlFromStyles($entity->getSourceItem());
         if (WmsSourceEntityHandler::useTunnel($entity->getSourceInstance()->getSource())) {
-            /** @var InstanceTunnel $tunnelService */
+            /** @var InstanceTunnelService $tunnelService */
             $tunnelService = $this->container->get('mapbender.source.instancetunnel.service');
             $tunnel = $tunnelService->makeEndpoint($this->entity->getSourceInstance());
         } else {

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -93,7 +93,8 @@ class RepositoryController extends Controller
         $form->submit($request);
         $onlyvalid = $form->get('onlyvalid')->getData();
         if ($form->isValid()) {
-            $importer = new Importer($this->container);
+            /** @var Importer $importer */
+            $importer = $this->container->get('mapbender.importer.source.wms.service');
             $origin = new WmsOrigin($wmssource_req->getOriginUrl(), $wmssource_req->getUsername(), $wmssource_req->getPassword());
 
             try {
@@ -176,7 +177,8 @@ class RepositoryController extends Controller
             $form          = $this->createForm(new WmsSourceSimpleType(), $wmssource_req);
             $form->submit($request);
             if ($form->isValid()) {
-                $importer = new Importer($this->container);
+                /** @var Importer $importer */
+                $importer = $this->container->get('mapbender.importer.source.wms.service');
                 $origin = new WmsOrigin($wmssource_req->getOriginUrl(), $wmssource_req->getUsername(), $wmssource_req->getPassword());
                 try {
                     $importerResponse = $importer->evaluateServer($origin, false);

--- a/src/Mapbender/WmsBundle/Element/WmsLoader.php
+++ b/src/Mapbender/WmsBundle/Element/WmsLoader.php
@@ -197,7 +197,8 @@ class WmsLoader extends Element
         $onlyValid = $request->get("onlyvalid");
 
         $wmsOrigin = new WmsOrigin($requestUrl, $requestUserName, $requestPassword);
-        $importer = new Importer($this->container);
+        /** @var Importer $importer */
+        $importer = $this->container->get('mapbender.importer.source.wms.service');
         $importerResponse = $importer->evaluateServer($wmsOrigin, $onlyValid);
 
         return $importerResponse->getWmsSourceEntity();

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -3,7 +3,13 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="mapbender.importer.source.wms.service.class">Mapbender\WmsBundle\Component\Wms\Importer</parameter>
         <parameter key="wmsloader.example_url">https://wms.wheregroup.com/cgi-bin/mapbender_user.xml?VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;SERVICE=WMS</parameter>
     </parameters>
+    <services>
+        <service id="mapbender.importer.source.wms.service" class="%mapbender.importer.source.wms.service.class%">
+            <argument type="service" id="service_container" />
+        </service>
+    </services>
 </container>
 


### PR DESCRIPTION
This cleans up some poor choices made when previously breaking code out of controller actions
* [Instance tunnel handling](https://github.com/mapbender/mapbender/compare/505a7da98f6850e2ca97f1baa347e2b415195518...2fc3c78b37b42db74b7e0601d750d50400b12889)
* [WMS loading](https://github.com/mapbender/mapbender/commit/a73d3a5e28085c85d6375378e13036fede232d1a)

These changes have originally been introduced post 3.0.5.3 / 3.0.6.3 for internal code reusability. They have not been part of tagged releases, so there is no particular pressure to maintain previously poor API signature choices.

This pull transforms InstanceTunnel and Wms Importer into proper container-registered services and adjusts their usages accordingly (`container->get` instead of `new`), so we don't add new service pattern violations to the next release.

Previous InstanceTunnel implementation violated service architecture in two ways
* explicit runtime instantiation of service
* non-reusable service pre-bound to single task

InstanceTunnel and InstanceTunnelHandler have been consolidated into a new class with different constructor signature (to resolve the task-prebind) and method signatures, and registered in the container. Explicit instantiations have been replaced with container->get.

Wms Importer class was already service-conformant, but was not registered in the container. This registration has been added. Explicit instantiations have been replaced with container->get.

Collateral: InstanceTunnelService now resides in CoreBundle, because that is also the site of usage (ApplicationController:instanceTunnelAction).