### PR TITLE
Fix misaligned delete button in print admin view

### DIFF
--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
@@ -115,6 +115,7 @@
 .collectionRemove {
   line-height: $inputHeight;
   position: absolute;
-  right: 33px;
-  top: 27px;
+  right: 31px;
+  top: -6px;
+  z-index: 1;
 }


### PR DESCRIPTION
This fixes misaligned delete-buttons in admin view for template collections (#799 )