### PR TITLE
Fix/target element type robustness

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
@@ -84,9 +84,11 @@ class TargetElementType extends AbstractType
         /** @var EntityRepository $repository */
         $repository = $this->getContainer()->get('doctrine')->getRepository($options['class']);
         $qb = $repository->createQueryBuilder($builderName);
+        $applicationFilter = $qb->expr()->eq($builderName . '.application', $options['application']->getId());
         $filter = $qb->expr()->andX();
+        $filter->add($applicationFilter);
+
         if (!empty($options['element_class'])) {
-            $filter->add($qb->expr()->eq($builderName . '.application', $options['application']->getId()));
             if (is_integer(strpos($options['element_class'], "%"))) {
                 $classComparison = $qb->expr()->like($builderName . '.class', ':class');
             } else {
@@ -106,8 +108,6 @@ class TargetElementType extends AbstractType
             if (count($elm_ids) > 0) {
                 $filter->add($qb->expr()->in($builderName . '.id', ':elm_ids'));
                 $qb->setParameter('elm_ids', $elm_ids);
-            } else {
-                $filter->add($qb->expr()->eq($builderName . '.application', $options['application']->getId()));
             }
         }
         $qb->where($filter);

--- a/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
@@ -62,7 +62,6 @@ class TargetElementType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $type = $this;
-
         $resolver->setDefaults(array(
             'application' => null,
             'element_class' => null,
@@ -70,75 +69,81 @@ class TargetElementType extends AbstractType
             'property' => 'title',
             'empty_value' => 'Choose an option',
             'empty_data' => '',
+            // Symfony does not recognize array-style callables
             'query_builder' => function(Options $options) use ($type) {
-                $builderName = preg_replace("/[^\w]/", "", $options['property_path']);
-                $repository = $type->getContainer()->get('doctrine')->getRepository($options['class']);
-                if (isset($options['element_class']) && $options['element_class'] !== null) {
-                    $qb = $repository->createQueryBuilder($builderName);
-                    if (is_integer(strpos($options['element_class'], "%"))) {
-                        $filter = $qb->expr()->andX(
-                                $qb->expr()->eq($builderName . '.application', $options['application']->getId()),
-                                                $qb->expr()->like($builderName . '.class', ':class'));
-                        $qb->where($filter);
-                        $qb->setParameter('class', $options['element_class']);
-                    } else {
-                        $filter = $qb->expr()->andX(
-                                $qb->expr()->eq($builderName . '.application', $options['application']->getId()),
-                                                $qb->expr()->eq($builderName . '.class', ':class'));
-                        $qb->where($filter);
-                        $qb->setParameter('class', $options['element_class']);
-                    }
-                    return $qb;
-                } else {
-                    $elm_ids = array();
-                    foreach ($options['application']->getElements() as $element_entity) {
-                        $class = $element_entity->getClass();
-                        $appl = new Application($type->getContainer(), $options['application'], array());
-                        $element = new $class($appl, $type->getContainer(), $element_entity);
-                        $elm_class = get_class($element);
-                        if ($elm_class::$ext_api) {
-                            $elm_ids[] = $element->getId();
-                        }
-                    }
-                    $qb = $repository->createQueryBuilder($builderName);
-                    $filter = $qb->expr()->andX();
-                    if (count($elm_ids) > 0) {
-                        $filter->add($qb->expr()->in($builderName . '.id', ':elm_ids'));
-                        $qb->where($filter);
-                        $qb->setParameter('elm_ids', $elm_ids);
-                    } else {
-                        $filter->add($qb->expr()->eq($builderName . '.application', $options['application']->getId()));
-                        $qb->where($filter);
-                    }
-                    return $qb;
+                return $type->getChoicesQueryBuilder($options);
+            }
+        ));
+    }
+
+    public function getChoicesQueryBuilder(Options $options)
+    {
+        $builderName = preg_replace("/[^\w]/", "", $options['property_path']);
+        $repository = $this->getContainer()->get('doctrine')->getRepository($options['class']);
+        if (isset($options['element_class']) && $options['element_class'] !== null) {
+            $qb = $repository->createQueryBuilder($builderName);
+            if (is_integer(strpos($options['element_class'], "%"))) {
+                $filter = $qb->expr()->andX(
+                        $qb->expr()->eq($builderName . '.application', $options['application']->getId()),
+                                        $qb->expr()->like($builderName . '.class', ':class'));
+                $qb->where($filter);
+                $qb->setParameter('class', $options['element_class']);
+            } else {
+                $filter = $qb->expr()->andX(
+                        $qb->expr()->eq($builderName . '.application', $options['application']->getId()),
+                                        $qb->expr()->eq($builderName . '.class', ':class'));
+                $qb->where($filter);
+                $qb->setParameter('class', $options['element_class']);
+            }
+            return $qb;
+        } else {
+            $elm_ids = array();
+            foreach ($options['application']->getElements() as $element_entity) {
+                $class = $element_entity->getClass();
+                $appl = new Application($this->getContainer(), $options['application'], array());
+                $element = new $class($appl, $this->getContainer(), $element_entity);
+                $elm_class = get_class($element);
+                if ($elm_class::$ext_api) {
+                    $elm_ids[] = $element->getId();
                 }
             }
-                ));
+            $qb = $repository->createQueryBuilder($builderName);
+            $filter = $qb->expr()->andX();
+            if (count($elm_ids) > 0) {
+                $filter->add($qb->expr()->in($builderName . '.id', ':elm_ids'));
+                $qb->where($filter);
+                $qb->setParameter('elm_ids', $elm_ids);
+            } else {
+                $filter->add($qb->expr()->eq($builderName . '.application', $options['application']->getId()));
+                $qb->where($filter);
             }
-
-            /**
-             * @inheritdoc
-             */
-            public function buildForm(FormBuilderInterface $builder, array $options)
-            {
-                $entityManager = $this->container->get('doctrine')->getManager();
-                $transformer = new ElementIdTransformer($entityManager);
-                $builder->addModelTransformer($transformer);
-            }
-
-            public function buildView(FormView $view, FormInterface $form, array $options)
-            {
-                /** @var \Symfony\Component\Translation\TranslatorInterface $translator */
-                $translator = $this->container->get('translator');
-                $translatedLcLabels = array_map(function($element) use ($translator) {
-                    $transLabel = $translator->trans($element->label);
-                    // sorting should be case-insensitive
-                    return mb_strtolower($transLabel);
-                    }, $view->vars['choices']);
-                // we use array_multisort instead of usort to avoid a bug in many
-                // PHP5.x versions
-                // see https://bugs.php.net/bug.php?id=50688
-                array_multisort($view->vars['choices'], $translatedLcLabels);
-            }
-
+            return $qb;
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $entityManager = $this->container->get('doctrine')->getManager();
+        $transformer = new ElementIdTransformer($entityManager);
+        $builder->addModelTransformer($transformer);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        /** @var \Symfony\Component\Translation\TranslatorInterface $translator */
+        $translator = $this->container->get('translator');
+        $translatedLcLabels = array_map(function($element) use ($translator) {
+            $transLabel = $translator->trans($element->label);
+            // sorting should be case-insensitive
+            return mb_strtolower($transLabel);
+            }, $view->vars['choices']);
+        // we use array_multisort instead of usort to avoid a bug in many
+        // PHP5.x versions
+        // see https://bugs.php.net/bug.php?id=50688
+        array_multisort($view->vars['choices'], $translatedLcLabels);
+    }
+
+}

--- a/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
@@ -85,7 +85,7 @@ class TargetElementType extends AbstractType
         $repository = $this->getContainer()->get('doctrine')->getRepository($options['class']);
         $qb = $repository->createQueryBuilder($builderName);
         $filter = $qb->expr()->andX();
-        if (isset($options['element_class'])) {
+        if (!empty($options['element_class'])) {
             $filter->add($qb->expr()->eq($builderName . '.application', $options['application']->getId()));
             if (is_integer(strpos($options['element_class'], "%"))) {
                 $classComparison = $qb->expr()->like($builderName . '.class', ':class');
@@ -98,11 +98,8 @@ class TargetElementType extends AbstractType
             $elm_ids = array();
             foreach ($options['application']->getElements() as $element_entity) {
                 $class = $element_entity->getClass();
-                $appl = new Application($this->getContainer(), $options['application'], array());
-                $element = new $class($appl, $this->getContainer(), $element_entity);
-                $elm_class = get_class($element);
-                if ($elm_class::$ext_api) {
-                    $elm_ids[] = $element->getId();
+                if ($class::$ext_api) {
+                    $element_entity->getId();
                 }
             }
 

--- a/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/TargetElementType.php
@@ -3,13 +3,12 @@
 namespace Mapbender\CoreBundle\Element\Type;
 
 use Doctrine\ORM\EntityRepository;
-use Mapbender\CoreBundle\Component\Element;
+use Mapbender\CoreBundle\Entity\Element;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Mapbender\CoreBundle\Component\Application;
 use Mapbender\CoreBundle\Form\DataTransformer\ElementIdTransformer;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -99,9 +98,12 @@ class TargetElementType extends AbstractType
         } else {
             $elm_ids = array();
             foreach ($options['application']->getElements() as $element_entity) {
-                $class = $element_entity->getClass();
-                if ($class::$ext_api) {
-                    $element_entity->getId();
+                /** @var Element $element_entity */
+                $elementComponentClass = $element_entity->getClass();
+                if (class_exists($elementComponentClass)) {
+                    if ($elementComponentClass::$ext_api) {
+                        $element_entity->getId();
+                    }
                 }
             }
 


### PR DESCRIPTION
This is development QoL.

Avoids errors when editing applications that may contain Elements not present in the code (on the current branch etc).

When editing any Element that can control a "target" (Button, FeatureInfo etc), the backend generates a list of potential targets by scanning all Elements (including inactive ones) present in the Application.

Previously, any dangling class references would lead to an exception. I.e. editing any controlling-type Element in the backend "Layouts" section would fail building the form with an HTTP 500 status.

This pull introduces a change mirroring already present existance checks for the concrete Element class  found elsewhere:
* Layout section itself displays the Element with an empty title
* Application frontend rendering and config generation skips processing the Element altogether

This pull only touches one class (the TargetElementType form type), which is identical between 3.0.5 and 3.0.6. Because the class is barely getting touched, I took the opportunity to do some c&p folding and fix the formatting.

Dummy Application component instantiation was redundant and has been removed.

The significant logic change is entirely in [the final commit](https://github.com/mapbender/mapbender/pull/811/commits/a682cc2b53eb687c4c70447f87a9cfb89822330d).