### PR TITLE
Feature/application config cache

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
@@ -1,0 +1,95 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Cache;
+
+
+use Mapbender\CoreBundle\Entity\Application;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Caching service for assorted Mapbender Application-specific raw string data values.
+ * Storage backend pluggable via container.
+ *
+ * First implementation only handles the frontend configuration and defaults to a filesystem backend.
+ *
+ * Instance registered in container as mapbender.presenter.application.cache (see services.xml)
+ */
+class ApplicationDataService
+{
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /** @var Backend\File */
+    protected $backend;
+
+    /**
+     * ApplicationDataService constructor.
+     * @param LoggerInterface $logger
+     * @param Backend\File $backend
+     */
+    public function __construct(LoggerInterface $logger, $backend)
+    {
+        $this->logger = $logger;
+        $this->backend = $backend;
+    }
+
+    /**
+     * Returns, if available in cache, the json-serialized configuration as a single string. If not cached, or cache
+     * held stale non-reusable data, returns boolean false.
+     *
+     * @param Application $application
+     * @return string|false
+     */
+    public function getConfigurationJson(Application $application)
+    {
+        $mark = $this->getMark($application);
+        return $this->backend->get(array($application->getSlug(), 'config.json'), $mark);
+    }
+
+    /**
+     * Sends data directly to the browser if available in cache, including appropriate headers.
+     * If no cached configuration is available, emits nothing and returns false.
+     *
+     * @param Application $application
+     * @param string[] $keyPath
+     * @param string $mimeType
+     * @return boolean true if emission performed, false if no cache data available.
+     */
+    public function emitValue(Application $application, $keyPath, $mimeType)
+    {
+        $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
+        $mark = $this->getMark($application);
+        return $this->backend->emit($fullKeyPath, $mark, $mimeType);
+    }
+
+    /**
+     * @param Application $application
+     * @param string[] $keyPath
+     * @param string $value
+     */
+    public function putValue(Application $application, $keyPath, $value)
+    {
+        $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
+        $mark = $this->getMark($application);
+        $this->backend->put($fullKeyPath, $value, $mark);
+    }
+
+    /**
+     * Generates the reusability mark for application data.
+     * @todo: container compilation time should also be considered (for "app_dev" mode)
+     *
+     * @param Application $application
+     * @return string
+     */
+    protected function getMark(Application $application)
+    {
+        $updated = $application->getUpdated();
+        // NOTE: $updated is NULL for yaml applications ...
+        if ($updated) {
+            return $updated->format('U-u');
+        } else {
+            return 'never';
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
@@ -102,7 +102,9 @@ class ApplicationDataService
             $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
             $this->backend->put($fullKeyPath, $value, $signature);
         } catch (NotCachable $e) {
-            // do nothing
+            // Not creating a cache entry should not be a visible error condition, just like not getting
+            // a reusable entry from the cache is not an error condition.
+            // => do nothing, let the application continue normally
         }
     }
 

--- a/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
@@ -4,6 +4,7 @@
 namespace Mapbender\CoreBundle\Component\Cache;
 
 
+use Mapbender\CoreBundle\Component\Exception\CacheMiss;
 use Mapbender\CoreBundle\Component\Exception\NotCachable;
 use Mapbender\CoreBundle\Entity\Application;
 use Psr\Log\LoggerInterface;
@@ -54,6 +55,8 @@ class ApplicationDataService
             return $this->backend->get($fullKeyPath, $signature);
         } catch (NotCachable $e) {
             return false;
+        } catch (CacheMiss $e) {
+            return false;
         }
     }
 
@@ -81,6 +84,8 @@ class ApplicationDataService
             // @todo: add etag etc
             return $response;
         } catch (NotCachable $e) {
+            return false;
+        } catch (CacheMiss $e) {
             return false;
         }
     }

--- a/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/ApplicationDataService.php
@@ -49,9 +49,9 @@ class ApplicationDataService
     public function getValue(Application $application, $keyPath)
     {
         try {
-            $mark = $this->getMark($application);
+            $signature = $this->getSignature($application);
             $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
-            return $this->backend->get($fullKeyPath, $mark);
+            return $this->backend->get($fullKeyPath, $signature);
         } catch (NotCachable $e) {
             return false;
         }
@@ -69,9 +69,9 @@ class ApplicationDataService
     public function getResponse(Application $application, $keyPath, $mimeType)
     {
         try {
-            $mark = $this->getMark($application);
+            $signature = $this->getSignature($application);
             $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
-            $content = $this->backend->get($fullKeyPath, $mark);
+            $content = $this->backend->get($fullKeyPath, $signature);
             if ($content === false) {
                 return false;
             }
@@ -93,23 +93,23 @@ class ApplicationDataService
     public function putValue(Application $application, $keyPath, $value)
     {
         try {
-            $mark = $this->getMark($application);
+            $signature = $this->getSignature($application);
             $fullKeyPath = array_merge(array($application->getSlug()), $keyPath);
-            $this->backend->put($fullKeyPath, $value, $mark);
+            $this->backend->put($fullKeyPath, $value, $signature);
         } catch (NotCachable $e) {
             // do nothing
         }
     }
 
     /**
-     * Generates the reusability mark for application data.
+     * Generates the reusability signature for application data.
      * Considers application "updated" column plus container compilation time, so any change to the application
      * or any configuration file makes the cache stale.
      *
      * @param Application $application
-     * @return array
+     * @return string
      */
-    protected function getMark(Application $application)
+    protected function getSignature(Application $application)
     {
         $parts = array();
         if ($this->containerTimestamp !== null) {
@@ -126,6 +126,6 @@ class ApplicationDataService
         if (!$parts) {
             throw new NotCachable();
         }
-        return $parts;
+        return print_r($parts, true);
     }
 }

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -62,12 +62,8 @@ class File
      */
     public function get($keyPath, $mark)
     {
-        // prepend root path
-        array_unshift($keyPath, $this->rootPath);
-        $fullPath = implode('/', $keyPath);
-
         try {
-            return $this->getInternal($fullPath, $mark);
+            return $this->getInternal($keyPath, $mark);
         } catch (CacheMiss $e) {
             // @todo: should this be allowed to bubble?
             return false;
@@ -75,38 +71,16 @@ class File
     }
 
     /**
-     * Sends cached data (if present + reusable) directly to the browser with the given $mimeType
-     *
-     * @param string[] $keyPath
-     * @param mixed $mark to verify reusability
-     * @param string $mimeType
-     * @return bool true if data sent, false if no reusable cache item was available
-     * @throws \Exception
+     * @param string[] $keyPath multi-component key
+     * @param mixed $mark
+     * @return string
+     * @throws CacheMiss
      */
-    public function emit($keyPath, $mark, $mimeType)
+    protected function getInternal($keyPath, $mark)
     {
-        // prepend root path
         array_unshift($keyPath, $this->rootPath);
         $fullPath = implode('/', $keyPath);
 
-        try {
-            $value = $this->getInternal($fullPath, $mark);
-            header("Content-Type: $mimeType");
-            header("Content-Length: " . strlen($value));
-            echo $value;
-            return true;
-        } catch (CacheMiss $e) {
-            return false;
-        }
-    }
-
-    /**
-     * @param string $fullPath
-     * @param mixed $mark
-     * @return string
-     */
-    protected function getInternal($fullPath, $mark)
-    {
         $valueInternal = @file_get_contents($fullPath);
         if (!$valueInternal || strlen($valueInternal) < 16) {
             throw new CacheMiss();

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -32,11 +32,13 @@ class File
     protected $storagePattern;
 
 
-    public function __construct(ContainerInterface $container)
+    /**
+     * @param string $rootPath of all cache files
+     * @throws \RuntimeException if $rootPath is not writable
+     */
+    public function __construct($rootPath)
     {
-        /** @var BaseKernel $kernel */
-        $kernel = $container->get('kernel');
-        $rootPath = realpath($kernel->getCacheDir());
+        $rootPath = realpath($rootPath);
         if (!is_dir($rootPath) || !is_writable($rootPath)) {
             throw new \RuntimeException("Cache path {$rootPath} is not writable");
         }

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -50,7 +50,7 @@ class File
     public function put($keyPath, $value, $signature)
     {
         $fullPath = $this->getFullPath($keyPath);
-        @mkdir(dirname($fullPath));
+        @mkdir(dirname($fullPath), 0777, true);
         // Bake the $signature completely into the stored value. This is done to
         // 1) achieve complete atomicity of put / get
         // 2) be independent of various mtime resolutions on various filesystems when using time stamps

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -10,8 +10,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Cache backend using the file system.
  * This uses the default Symfony cache directories also used by twig, doctrine etc as the base storage location.
  *
- * Cache backend provides raw key:string value storage and handles automatic invalidation based on "marks"
- * (which can be timestamps, but can also be more complex, as long as they are serializable).
+ * Cache backend provides raw key:string value storage and handles automatic invalidation based on signatures
+ * (which can be timestamps, but any arbitrary string will work).
  *
  * Instance registered in container at mapbender.presenter.application.cache.backend (see serviccs.xml)
  */
@@ -34,21 +34,21 @@ class File
     /**
      * @param string[] $keyPath a multi-component key, in this backend used as a subdirectory hierarchy
      * @param string $value will be stored exactly as given
-     * @param mixed $mark to determine reusability of the cache entry later in get
+     * @param string $signature to determine reusability of the cache entry later in get
      */
-    public function put($keyPath, $value, $mark)
+    public function put($keyPath, $value, $signature)
     {
         // prepend root path
         array_unshift($keyPath, $this->rootPath);
         $fullPath = implode('/', $keyPath);
         @mkdir(dirname($fullPath));
-        // Bake the $mark completely into the stored value. This is done to
+        // Bake the $signature completely into the stored value. This is done to
         // 1) achieve complete atomicity of put / get
         // 2) be independent of various mtime resolutions on various filesystems when using time stamps
-        // 3) support arbitrary (any serializable) marks instead of just timestamps
-        $markSerialized = serialize($mark);
-        // Encode the length of the serialized mark and the data itself in a fixed-length fashion, to ease reading
-        $prefix = sprintf("%6d:%6d:%s:", strlen($markSerialized), strlen($value), $markSerialized);
+        // 3) support arbitrary (any serializable) signatures instead of just timestamps
+
+        // Encode the length of the signature and the data itself in a fixed-length fashion, to ease reading
+        $prefix = sprintf("%6d:%6d:%s:", strlen($signature), strlen($value), $signature);
         $valueInternal = $prefix . $value;
         @file_put_contents($fullPath, $valueInternal, LOCK_EX);
     }
@@ -57,13 +57,13 @@ class File
      * Retrieves a stored value from the cache, if reusable.
      *
      * @param string[] $keyPath multi-component key
-     * @param mixed $mark to verify reusability
+     * @param string $signature to verify reusability
      * @return string|false string on hit, boolean false on miss
      */
-    public function get($keyPath, $mark)
+    public function get($keyPath, $signature)
     {
         try {
-            return $this->getInternal($keyPath, $mark);
+            return $this->getInternal($keyPath, $signature);
         } catch (CacheMiss $e) {
             // @todo: should this be allowed to bubble?
             return false;
@@ -72,11 +72,11 @@ class File
 
     /**
      * @param string[] $keyPath multi-component key
-     * @param mixed $mark
+     * @param string $signature
      * @return string
      * @throws CacheMiss
      */
-    protected function getInternal($keyPath, $mark)
+    protected function getInternal($keyPath, $signature)
     {
         array_unshift($keyPath, $this->rootPath);
         $fullPath = implode('/', $keyPath);
@@ -86,14 +86,13 @@ class File
             throw new CacheMiss();
         }
         $header = substr($valueInternal, 0, 14);
-        $markLength = intval(substr($header, 0, 6));
-        $markSerialized = serialize($mark);
-        $markPrevious = substr($valueInternal, 14, $markLength);
-        if ($markPrevious === false || $markPrevious !== $markSerialized) {
+        $signatureLength = intval(substr($header, 0, 6));
+        $cachedSignature = substr($valueInternal, 14, $signatureLength);
+        if ($cachedSignature === false || $cachedSignature !== $signature) {
             throw new CacheMiss();
         }
         $valueLength = intval(substr($header, 7, 6));
-        $valueStart = 14 + $markLength + 1;
+        $valueStart = 14 + $signatureLength + 1;
         if (strlen($valueInternal) < ($valueStart + $valueLength)) {
             throw new CacheMiss();
         }

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -20,7 +20,7 @@ class File
 {
     // constants related to internal header construction
     const H_LENGTHOF_SIGNATURE_LENGTH = 6;
-    const H_LENGTHOF_VALUE_LENGTH = 6;
+    const H_LENGTHOF_VALUE_LENGTH = 8;          // <100MB max cachable value length
 
     /** @var string */
     protected $rootPath;

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -3,7 +3,7 @@
 
 namespace Mapbender\CoreBundle\Component\Cache\Backend;
 use Mapbender\BaseKernel;
-use Symfony\Component\Debug\Exception\DummyException;
+use Mapbender\CoreBundle\Component\Exception\CacheMiss;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -138,7 +138,7 @@ class File
         try {
             $header = fread($stream, 14);
             if ($header === false || strlen($header) != 14) {
-                throw new DummyException();
+                throw new CacheMiss();
             }
             $markSerialized = serialize($mark);
             $markLength = intval(substr($header, 0, 6));
@@ -146,14 +146,13 @@ class File
 
             $markPrevious = fread($stream, $markLength + 1);
             if ($markPrevious === false || substr($markPrevious, 0, -1) !== $markSerialized) {
-                throw new DummyException();
+                throw new CacheMiss();
             }
             return array(
                 'length' => $valueLength,
                 'stream' => $stream,
             );
-        } catch (DummyException $e) {
-            // this is a cache miss
+        } catch (CacheMiss $e) {
             flock($stream, LOCK_UN);
             fclose($stream);
             return false;

--- a/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
+++ b/src/Mapbender/CoreBundle/Component/Cache/Backend/File.php
@@ -1,0 +1,167 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Cache\Backend;
+use Mapbender\BaseKernel;
+use Symfony\Component\Debug\Exception\DummyException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Cache backend using the file system.
+ * This uses the default Symfony cache directories also used by twig, doctrine etc as the base storage location.
+ *
+ * Cache backend provides raw key:string value storage and handles automatic invalidation based on "marks"
+ * (which can be timestamps, but can also be more complex, as long as they are serializable).
+ *
+ * Instance registered in container at mapbender.presenter.application.cache.backend (see serviccs.xml)
+ */
+class File
+{
+    /** @var string */
+    protected $rootPath;
+
+    public function __construct(ContainerInterface $container)
+    {
+        /** @var BaseKernel $kernel */
+        $kernel = $container->get('kernel');
+        $rootPath = realpath($kernel->getCacheDir());
+        if (!is_dir($rootPath) || !is_writable($rootPath)) {
+            throw new \RuntimeException("Cache path {$rootPath} is not writable");
+        }
+        $this->rootPath = $rootPath;
+    }
+
+    /**
+     * @param string[] $keyPath a multi-component key, in this backend used as a subdirectory hierarchy
+     * @param string $value will be stored exactly as given
+     * @param mixed $mark to determine reusability of the cache entry later in get
+     */
+    public function put($keyPath, $value, $mark)
+    {
+        // prepend root path
+        array_unshift($keyPath, $this->rootPath);
+        $fullPath = implode('/', $keyPath);
+        @mkdir(dirname($fullPath));
+        // Bake the $mark completely into the stored value. This is done to
+        // 1) achieve complete atomicity of put / get
+        // 2) be independent of various mtime resolutions on various filesystems when using time stamps
+        // 3) support arbitrary (any serializable) marks instead of just timestamps
+        $markSerialized = serialize($mark);
+        // Encode the length of the serialized mark and the data itself in a fixed-length fashion, to ease reading
+        $prefix = sprintf("%6d:%6d:%s:", strlen($markSerialized), strlen($value), $markSerialized);
+        $valueInternal = $prefix . $value;
+        @file_put_contents($fullPath, $valueInternal, LOCK_EX);
+    }
+
+    /**
+     * Retrieves a stored value from the cache, if reusable.
+     *
+     * @param string[] $keyPath multi-component key
+     * @param mixed $mark to verify reusability
+     * @return string|false string on hit, boolean false on miss
+     */
+    public function get($keyPath, $mark)
+    {
+        // prepend root path
+        array_unshift($keyPath, $this->rootPath);
+        $fullPath = implode('/', $keyPath);
+
+        $cacheInfo = $this->getInternal($fullPath, $mark);
+        if (!$cacheInfo) {
+            return false;
+        }
+        try {
+            $valueLength = $cacheInfo['length'];
+            // NOTE: fread($stream, 0) is a php warning
+            if ($valueLength > 0) {
+                $value = fread($cacheInfo['stream'], $valueLength);
+            } else {
+                $value = '';
+            }
+            flock($cacheInfo['stream'], LOCK_UN);
+            fclose($cacheInfo['stream']);
+            return $value;
+        } catch (\Exception $e) {
+            flock($cacheInfo['stream'], LOCK_UN);
+            fclose($cacheInfo['stream']);
+            throw $e;
+        }
+    }
+
+    /**
+     * Sends cached data (if present + reusable) directly to the browser with the given $mimeType
+     *
+     * @param string[] $keyPath
+     * @param mixed $mark to verify reusability
+     * @param string $mimeType
+     * @return bool true if data sent, false if no reusable cache item was available
+     * @throws \Exception
+     */
+    public function emit($keyPath, $mark, $mimeType)
+    {
+        // prepend root path
+        array_unshift($keyPath, $this->rootPath);
+        $fullPath = implode('/', $keyPath);
+
+        $cacheInfo = $this->getInternal($fullPath, $mark);
+        if (!$cacheInfo) {
+            return false;
+        }
+        try {
+            header("Content-Type: $mimeType");
+            header("Content-Length: {$cacheInfo['length']}");
+            fpassthru($cacheInfo['stream']);
+            flock($cacheInfo['stream'], LOCK_UN);
+            fclose($cacheInfo['stream']);
+            return true;
+        } catch (\Exception $e) {
+            flock($cacheInfo['stream'], LOCK_UN);
+            fclose($cacheInfo['stream']);
+            throw $e;
+        }
+    }
+
+    /**
+     * @param string $fullPath
+     * @param mixed $mark
+     * @return array|false
+     */
+    protected function getInternal($fullPath, $mark)
+    {
+        $stream = @fopen($fullPath, 'rb');
+        if ($stream === false) {
+            return false;
+        }
+        if (false === flock($stream, LOCK_SH)) {
+            return false;
+        }
+        try {
+            $header = fread($stream, 14);
+            if ($header === false || strlen($header) != 14) {
+                throw new DummyException();
+            }
+            $markSerialized = serialize($mark);
+            $markLength = intval(substr($header, 0, 6));
+            $valueLength = intval(substr($header, 7, 6));
+
+            $markPrevious = fread($stream, $markLength + 1);
+            if ($markPrevious === false || substr($markPrevious, 0, -1) !== $markSerialized) {
+                throw new DummyException();
+            }
+            return array(
+                'length' => $valueLength,
+                'stream' => $stream,
+            );
+        } catch (DummyException $e) {
+            // this is a cache miss
+            flock($stream, LOCK_UN);
+            fclose($stream);
+            return false;
+        } catch (\Exception $e) {
+            // this is something severely wrong, rethrow after release lock + file
+            flock($stream, LOCK_UN);
+            fclose($stream);
+            throw $e;
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Exception/CacheMiss.php
+++ b/src/Mapbender/CoreBundle/Component/Exception/CacheMiss.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Exception;
+
+
+class CacheMiss extends \Exception
+{
+}

--- a/src/Mapbender/CoreBundle/Component/Exception/NotCachable.php
+++ b/src/Mapbender/CoreBundle/Component/Exception/NotCachable.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Exception;
+
+
+class NotCachable extends \Exception
+{
+}

--- a/src/Mapbender/CoreBundle/Component/Presenter/Application/ConfigService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/Application/ConfigService.php
@@ -2,6 +2,7 @@
 
 namespace Mapbender\CoreBundle\Component\Presenter\Application;
 
+use Mapbender\CoreBundle\Component\Cache\ApplicationDataService;
 use Mapbender\CoreBundle\Component\Element as Element;
 use Mapbender\CoreBundle\Component\Presenter\SourceService;
 use Mapbender\CoreBundle\Entity\Application;
@@ -14,8 +15,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Mapbender\CoreBundle\Component\Presenter\ApplicationService;
 
 /**
- * Services that generates the frontend-facing configuration for a Mapbender application
- * @todo: plug in caching
+ * Service that generates the frontend-facing configuration for a Mapbender application
  *
  * Instance registerd in container as mapbender.presenter.application.config.service
  *
@@ -34,12 +34,16 @@ class ConfigService
     protected $sourceServices = array();
     /** @var SourceService|null */
     protected $defaultSourceService;
+    /** @var ApplicationDataService */
+    protected $cacheService;
+
 
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
         $this->basePresenter = $container->get('mapbender.presenter.application.service');
+        $this->cacheService = $container->get('mapbender.presenter.application.cache');
     }
 
     /**
@@ -269,5 +273,15 @@ class ConfigService
         /** @var LoggerInterface $logger */
         $logger = $this->container->get('logger');
         return $logger;
+    }
+
+    /**
+     * @return ApplicationDataService
+     */
+    public function getCacheService()
+    {
+        /** @var ApplicationDataService $cacheService */
+        $cacheService = $this->container->get('mapbender.presenter.application.cache');
+        return $cacheService;
     }
 }

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -233,17 +233,19 @@ class ApplicationController extends Controller
         $cacheService = $configService->getCacheService();
         $cacheKeyPath = array('config.json');
         $cachable = !!$this->container->getParameter('cachable.mapbender.application.config');
-        if (!$cachable || !$cacheService->emitValue($applicationEntity, $cacheKeyPath, 'application/json')) {
+        if ($cachable) {
+            $response = $cacheService->getResponse($applicationEntity, $cacheKeyPath, 'application/json');
+        } else {
+            $response = false;
+        }
+        if (!$cachable || !$response) {
             $freshConfig = $configService->getConfiguration($applicationEntity);
             $response = new JsonResponse($freshConfig);
             if ($cachable) {
                 $cacheService->putValue($applicationEntity, $cacheKeyPath, $response->getContent());
             }
-            return $response;
-        } else {
-            // headers + content already emitted from cache, no response
-            return null;
         }
+        return $response;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -19,6 +19,7 @@ use OwsProxy3\CoreBundle\Component\Utils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -226,13 +227,20 @@ class ApplicationController extends Controller
      */
     public function configurationAction($slug)
     {
-        $config  = $this->getApplication($slug)->getConfiguration();
+        $applicationEntity = $this->getApplication($slug)->getEntity();
         $this->get("session")->set("proxyAllowed", true);
-        return new Response(
-            $config,
-            200,
-            array('Content-Type' => 'text/json')
-        );
+        $configService = $this->getConfigService();
+        $cacheService = $configService->getCacheService();
+        $cacheKeyPath = array('config.json');
+        if (!$cacheService->emitValue($applicationEntity, $cacheKeyPath, 'application/json')) {
+            $freshConfig = $configService->getConfiguration($applicationEntity);
+            $response = new JsonResponse($freshConfig);
+            $cacheService->putValue($applicationEntity, $cacheKeyPath, $response->getContent());
+            return $response;
+        } else {
+            // headers + content already emitted from cache, no response
+            return null;
+        }
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -232,10 +232,13 @@ class ApplicationController extends Controller
         $configService = $this->getConfigService();
         $cacheService = $configService->getCacheService();
         $cacheKeyPath = array('config.json');
-        if (!$cacheService->emitValue($applicationEntity, $cacheKeyPath, 'application/json')) {
+        $cachable = !!$this->container->getParameter('cachable.mapbender.application.config');
+        if (!$cachable || !$cacheService->emitValue($applicationEntity, $cacheKeyPath, 'application/json')) {
             $freshConfig = $configService->getConfiguration($applicationEntity);
             $response = new JsonResponse($freshConfig);
-            $cacheService->putValue($applicationEntity, $cacheKeyPath, $response->getContent());
+            if ($cachable) {
+                $cacheService->putValue($applicationEntity, $cacheKeyPath, $response->getContent());
+            }
             return $response;
         } else {
             // headers + content already emitted from cache, no response

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ContainerUpdateTimestampPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ContainerUpdateTimestampPass.php
@@ -9,6 +9,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * Pseudo-compiler pass that persists the information WHEN the container has been compiled.
  * This information is not accessible via standard Symfony machinery, even though it is generated and used internally.
+ *
+ * The container compilation time is used to invalidate cached data after any configuration changes, including (but
+ * not limited to) changes in yaml-based applications.
  */
 class ContainerUpdateTimestampPass implements CompilerPassInterface
 {

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ContainerUpdateTimestampPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ContainerUpdateTimestampPass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+
+/**
+ * Pseudo-compiler pass that persists the information WHEN the container has been compiled.
+ * This information is not accessible via standard Symfony machinery, even though it is generated and used internally.
+ */
+class ContainerUpdateTimestampPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $now = microtime(true);
+        $container->setParameter('container.compilation_timestamp_float', $now);
+    }
+}

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -2,6 +2,7 @@
 namespace Mapbender\CoreBundle;
 
 use Mapbender\CoreBundle\Component\MapbenderBundle;
+use Mapbender\CoreBundle\DependencyInjection\Compiler\ContainerUpdateTimestampPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\MapbenderYamlCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -18,6 +19,7 @@ class MapbenderCoreBundle extends MapbenderBundle
         parent::build($container);
 
         $container->addCompilerPass(new MapbenderYamlCompilerPass());
+        $container->addCompilerPass(new ContainerUpdateTimestampPass());
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -12,6 +12,8 @@
         <parameter key="mapbender.presenter.source.service.class">Mapbender\CoreBundle\Component\Presenter\SourceService</parameter>
         <parameter key="mapbender.presenter.application.service.class">Mapbender\CoreBundle\Component\Presenter\ApplicationService</parameter>
         <parameter key="mapbender.presenter.application.config.service.class">Mapbender\CoreBundle\Component\Presenter\Application\ConfigService</parameter>
+        <parameter key="mapbender.presenter.application.cache.class">Mapbender\CoreBundle\Component\Cache\ApplicationDataService</parameter>
+        <parameter key="mapbender.presenter.application.cache.backend.class">Mapbender\CoreBundle\Component\Cache\Backend\File</parameter>
     </parameters>
 
     <services>
@@ -122,6 +124,12 @@
         <service id="mapbender.presenter.source.service" class="%mapbender.presenter.source.service.class%">
             <argument type="service" id="service_container" />
         </service>
+        <service id="mapbender.presenter.application.cache" class="%mapbender.presenter.application.cache.class%">
+            <argument type="service" id="logger" />
+            <argument type="service" id="mapbender.presenter.application.cache.backend" />
+        </service>
+        <service id="mapbender.presenter.application.cache.backend" class="%mapbender.presenter.application.cache.backend.class%">
+            <argument type="service" id="service_container" />
+        </service>
     </services>
 </container>
-

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
         <parameter key="mapbender.presenter.application.config.service.class">Mapbender\CoreBundle\Component\Presenter\Application\ConfigService</parameter>
         <parameter key="mapbender.presenter.application.cache.class">Mapbender\CoreBundle\Component\Cache\ApplicationDataService</parameter>
         <parameter key="mapbender.presenter.application.cache.backend.class">Mapbender\CoreBundle\Component\Cache\Backend\File</parameter>
+        <parameter key="cachable.mapbender.application.config">true</parameter>
     </parameters>
 
     <services>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -127,6 +127,7 @@
         <service id="mapbender.presenter.application.cache" class="%mapbender.presenter.application.cache.class%">
             <argument type="service" id="logger" />
             <argument type="service" id="mapbender.presenter.application.cache.backend" />
+            <argument>%container.compilation_timestamp_float%</argument>
         </service>
         <service id="mapbender.presenter.application.cache.backend" class="%mapbender.presenter.application.cache.backend.class%">
             <argument type="service" id="service_container" />

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -131,7 +131,7 @@
             <argument>%container.compilation_timestamp_float%</argument>
         </service>
         <service id="mapbender.presenter.application.cache.backend" class="%mapbender.presenter.application.cache.backend.class%">
-            <argument type="service" id="service_container" />
+            <argument>%kernel.cache_dir%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This plugs a performance regression introduced in the context of plugging security issues related to "instance tunneling" getLegendGraphic requests.

We introduce machinery to cache arbitrary application-specific data. The cache is self-managing / self-invalidating. Based on Application `updated` and time of the last container compilation, values are stale with no outside interaction (i.e. no deletion of cache files). Get is fully atomic. Put is nearly atomic, save for a potential mkdir vs external deletion race, but any errors this might produce are caught and processing is stopped.

Config caching is generally less aggressive than the existing caching systems for js and css assets, so the amount of manual cache clears should not increase.

Config caching can be disabled via parameter `cachable.mapbbender.application.config`.

On my X230, config response latency improves anywhere between 40% and 850%, depending on application complexity. Configs are identical (md5sum and all that). Configs still update as expected when editing the application in the backend. Yaml applications update immediately in app_dev, and require a (Symfony) cache clear in "prod" (same as before).

## caching off
### monster application (144kB config)
```
ron@flake:~$ wrk -c 2 -t 2 -d 20s 'http://305.mapbender.local/app.php/application/teh-grids/config'
Running 20s test @ http://305.mapbender.local/app.php/application/teh-grids/config
  2 threads and 2 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    94.61ms    5.69ms 175.83ms   99.29%
    Req/Sec    10.57      2.42    20.00     93.47%
  422 requests in 20.02s, 59.64MB read
Requests/sec:     21.08
Transfer/sec:      2.98MB
```
### small application (10kB config)
```
ron@flake:~$ wrk -c 2 -t 2 -d 20s 'http://305.mapbender.local/app.php/application/mapbender_mobile/config'
Running 20s test @ http://305.mapbender.local/app.php/application/mapbender_mobile/config
  2 threads and 2 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    13.67ms    1.12ms  32.01ms   95.80%
    Req/Sec    73.19      6.35    80.00     56.75%
  2928 requests in 20.01s, 27.38MB read
Requests/sec:    146.30
Transfer/sec:      1.37MB
```

## caching on
### monster application (144kB config)
```
ron@flake:~$ wrk -c 2 -t 2 -d 20s 'http://305.mapbender.local/app.php/application/teh-grids/config'
Running 20s test @ http://305.mapbender.local/app.php/application/teh-grids/config
  2 threads and 2 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.96ms    1.18ms  26.11ms   91.96%
    Req/Sec   100.85      9.62   111.00     79.25%
  4022 requests in 20.03s, 564.37MB read
Requests/sec:    200.79
Transfer/sec:     28.18MB
```

### small application (10kB config)
```
ron@flake:~$ wrk -c 2 -t 2 -d 20s 'http://305.mapbender.local/app.php/application/mapbender_mobile/config'
Running 20s test @ http://305.mapbender.local/app.php/application/mapbender_mobile/config
  2 threads and 2 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.19ms    1.24ms  40.81ms   94.18%
    Req/Sec   109.39      9.57   121.00     78.50%
  4360 requests in 20.01s, 40.77MB read
Requests/sec:    217.88
Transfer/sec:      2.04MB
```

## Related
Basing cache invalidation also on container compilation time goes beyond existing caching mechanisms for js / css assets, which only look at the `updated` time on the Application entity, but don't consider system configuration changes.

Those systems are also pretty much hard-wired to Assetic and Twig embedding, making them difficult to expand upon.

Strategically, caching systems should unify on top of the simplest implementation.

The machinery introduced here is basic and bare bones and makes few assumptions about intended usage. The cache deals only with raw strings and offers prepackaged retrieval as Response object only as an extra convenience.

Caching of StringAsset types etc could easily be layered on top of this.