### PR TITLE
Fix BSS menu not closing after selection

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.basesourceswitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.basesourceswitcher.js
@@ -19,7 +19,8 @@
 
             $('.basesourcesubswitcher', $(this.element)).addClass('hidden');
 
-            $('.basesourcegroup', this.element).on('click', $.proxy(this._showHideMenu, this));
+            $('.basesourcegroup', this.element).on('mouseenter', $.proxy(this._showMenu, this));
+            $('.basesourcegroup', this.element).on('mouseleave', $.proxy(this._hideMenu, this));
 
             this._showActive();
 
@@ -29,14 +30,16 @@
             $(document).on('mbmapsourceloaderror', $.proxy(this._removeSourceFromLoad, this));
         },
 
-        _showHideMenu: function(e) {
+        _showMenu: function(e) {
             var $bsswtch = $('.basesourcesubswitcher', $(e.currentTarget));
 
-            if ($bsswtch.hasClass('hidden')) {
-                $bsswtch.removeClass('hidden');
-            } else {
-                $bsswtch.addClass('hidden');
-            }
+            $bsswtch.removeClass('hidden');
+        },
+
+        _hideMenu: function(e) {
+            var $bsswtch = $('.basesourcesubswitcher', $(e.currentTarget));
+
+            $bsswtch.addClass('hidden');
         },
 
         _hideSources: function () {


### PR DESCRIPTION
After https://github.com/mapbender/mapbender/issues/785#issuecomment-384877571 was reopened, this should fix the problem of non-closing BaseSourceSwitcher-menus. 
You actually don't have to click anymore, to open the dropdown menu, hovering over it is enough.