### PR TITLE
Feature/dgsv imprint and data policy

### DIFF
--- a/src/Mapbender/CoreBundle/Controller/SiteController.php
+++ b/src/Mapbender/CoreBundle/Controller/SiteController.php
@@ -1,0 +1,82 @@
+<?php
+namespace Mapbender\CoreBundle\Controller;
+
+use Symfony\Bridge\Twig\TwigEngine;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+
+/**
+ * Controller for site-wide URLs (!= backend, != Application-specific)
+ */
+class SiteController extends Controller
+{
+    /**
+     * Render imprint.
+     *
+     * @Route("/imprint")
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function imprintAction(Request $request)
+    {
+        $exposeImprint = $this->container->getParameter('mapbender.imprint.expose');
+        if (!$exposeImprint) {
+            throw new NotFoundHttpException();
+        }
+        $contentTemplate = $this->container->getParameter('mapbender.imprint.template.content');
+        if ($request->query->get('embed')) {
+            $template = $contentTemplate;
+            $templateVars = array();
+        } else {
+            $template = $this->container->getParameter('mapbender.imprint.template.page');
+            $templateVars = array(
+                'contentTemplate' => $contentTemplate,
+            );
+        }
+        $html = $this->getTemplatingEngine()->render($template, $templateVars);
+        return new Response($html);
+    }
+
+    /**
+     * Render data policy.
+     *
+     * @Route("/data-policy")
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function dataPolicyAction(Request $request)
+    {
+        $exposeImprint = $this->container->getParameter('mapbender.data_policy.expose');
+        if (!$exposeImprint) {
+            throw new NotFoundHttpException();
+        }
+        $contentTemplate = $this->container->getParameter('mapbender.data_policy.template.content');
+        if ($request->query->get('embed')) {
+            $template = $contentTemplate;
+            $templateVars = array();
+        } else {
+            $template = $this->container->getParameter('mapbender.data_policy.template.page');
+            $templateVars = array(
+                'contentTemplate' => $contentTemplate,
+            );
+        }
+        $html = $this->getTemplatingEngine()->render($template, $templateVars);
+        return new Response($html);
+    }
+
+    /**
+     * @return TwigEngine
+     */
+    protected function getTemplatingEngine()
+    {
+        /** @var TwigEngine $engine */
+        $engine = $this->get('templating');
+        return $engine;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -17,6 +17,16 @@
              Caching machinery can only be safely enabled after these cases have been adressed properly -->
         <parameter key="cachable.mapbender.application.config">false</parameter>
         <parameter key="mapbender.source.typedirectory.service.class">Mapbender\CoreBundle\Component\Source\TypeDirectoryService</parameter>
+        <!-- Configuration knobs for imprint and data policy. See SiteController -->
+        <!-- The two `.expose` parameters are a booleans that open the URL routes /imprint and /data-policy respectively -->
+        <!-- The template pairs are twig templates for a) full page (including HTML head etc) and b) content only (to support
+             Ajax-loaded dialog content etc) -->
+        <parameter key="mapbender.imprint.expose">true</parameter>
+        <parameter key="mapbender.imprint.template.page">@MapbenderCore/Site/imprint.page.html.twig</parameter>
+        <parameter key="mapbender.imprint.template.content">@MapbenderCore/Site/imprint.content.html.twig</parameter>
+        <parameter key="mapbender.data_policy.expose">true</parameter>
+        <parameter key="mapbender.data_policy.template.page">@MapbenderCore/Site/data_policy.page.html.twig</parameter>
+        <parameter key="mapbender.data_policy.template.content">@MapbenderCore/Site/data_policy.content.html.twig</parameter>
     </parameters>
 
     <services>

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -391,3 +391,25 @@ mb:
 
 mb.imprint.title: Impressum
 mb.data_policy.title: Datenschutzrichtlinie
+mb.imprint.instructions: |
+  Dies ist ein Platzhalter für den von Mapbender unter der URL /imprint auslieferbaren Impressumstext.
+  Sie haben zwei Möglichkeiten Ihren eigenen Text zu hinterlegen:
+  1) Eigenes Template (erlaubt HTML-Formatierung)
+  Hierzu legen sie eine Datei mit HTML- und optional Twig-Inhalten in application/app/Resources/MapbenderCoreBundle/views/Site/imprint.content.html.twig ab. Der HTML-Kopf wird hierbei vom System
+  bereitgestellt. Wenn Sie eine komplette HTML-Seite (inklusive <head>) hinterlegen möchten, nennen Sie die Datei stattdessen imprint.page.html.twig (gleiches Verzeichnis).
+
+  2) Unformatierter Fließtext im Übersetzungskatalog
+  Unter dem Schlüssel mb.imprint.content kann in den Übersetzungskatalogen Freitext hinterlegt werden, der dann auf der URL /imprint ausgeliefert wird.
+  Die Übersetzungskataloge sind YAML-Dateien die Sie in application/app/Resources/MapbenderCoreBundle/translations/ hinterlegen können. Die Dateien
+  heißen (sprachabhängig) messages.de.yml, messages.en.yml usw. Diese Methode unterstützt derzeit keinerlei Formatierungen, lediglich Zeilenumbrüche werden ausgewertet.
+mb.data_policy.instructions: |
+  Dies ist ein Platzhalter für den von Mapbender auslieferbaren Datenschutzrichlinientext.
+  Sie haben zwei Möglichkeiten Ihren eigenen Text zu hinterlegen:
+  1) Eigenes Template (erlaubt HTML-Formatierung)
+  Hierzu legen sie eine Datei mit HTML- und optional Twig-Inhalten in application/app/Resources/MapbenderCoreBundle/views/Site/data_policy.content.html.twig ab. Der HTML-Kopf wird hierbei vom System
+  bereitgestellt. Wenn Sie eine komplette HTML-Seite (inklusive <head>) hinterlegen möchten, nennen Sie die Datei stattdessen data_policy.page.html.twig (gleiches Verzeichnis).
+
+  2) Unformatierter Fließtext im Übersetzungskatalog
+  Unter dem Schlüssel mb.data_policy.content kann in den Übersetzungskatalogen Freitext hinterlegt werden, der dann auf der URL /data-policy ausgeliefert wird.
+  Die Übersetzungskataloge sind YAML-Dateien die Sie in application/app/Resources/MapbenderCoreBundle/translations/ hinterlegen können. Die Dateien
+  heißen (sprachabhängig) messages.de.yml, messages.en.yml usw. Diese Methode unterstützt derzeit keinerlei Formatierungen, lediglich Zeilenumbrüche werden ausgewertet.

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -388,3 +388,6 @@ mb:
       datails: 'Die Karte kann nicht angezeigt werden.'
       exception: 'Ausnahmefehler: %exception%'
       statuscode: 'HTTP Statuscode'
+
+mb.imprint.title: Impressum
+mb.data_policy.title: Datenschutzrichtlinie

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -391,3 +391,25 @@ Search: Search
 
 mb.imprint.title: Imprint
 mb.data_policy.title: Data policy
+mb.imprint.instructions: |
+  This is a placeholder for content delivered via Mapbender's builtin /imprint URL.
+  You can customize this text in one of two ways:
+  1) Add a custom HTML document
+  Place your file with HTML (and optionall Twig) content in application/app/Resources/MapbenderCoreBundle/views/Site/imprint.content.html.twig. The system will
+  provide the HTML skeleton around this. If instead you want to use a full HTML document (including <head>), name your file imprint.page.html.twig instead (same directory).
+
+  2) Unformatted text in translation catalog
+  You can place free text under the translation key mb.imprint.content, which will then be rendered on the imprint URL.
+  The translation catalogs are YAML files you can place in application/app/Resources/MapbenderCoreBundle/translations/. The files are named
+  messages.de.yml, messages.en.yml etc, one file per target language. This method does not support any formatting or markup beyond simple line breaks.
+mb.data_policy.instructions: |
+  This is a placeholder for content delivered via Mapbender's builtin /data-policy URL.
+  You can customize this text in one of two ways:
+  1) Add a custom HTML document
+  Place your file with HTML (and optionall Twig) content in application/app/Resources/MapbenderCoreBundle/views/Site/data_policy.content.html.twig. The system will
+  provide the HTML skeleton around this. If instead you want to use a full HTML document (including <head>), name your file data_policy.page.html.twig instead (same directory).
+
+  2) Unformatted text in translation catalog
+  You can place free text under the translation key mb.data_policy.content, which will then be rendered on the /data-policy URL.
+  The translation catalogs are YAML files you can place in application/app/Resources/MapbenderCoreBundle/translations/. The files are named
+  messages.de.yml, messages.en.yml etc, one file per target language. This method does not support any formatting or markup beyond simple line breaks.

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -388,3 +388,6 @@ mb:
       exception: 'Exception: %exception%'
       statuscode: 'HTTP status code'
 Search: Search
+
+mb.imprint.title: Imprint
+mb.data_policy.title: Data policy

--- a/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.content.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.content.html.twig
@@ -1,4 +1,4 @@
-{% set textTranslationKey = 'mapbender.data_policy.content' %}
+{% set textTranslationKey = 'mb.data_policy.content' %}
 {% set text = textTranslationKey | trans %}
 {% if text != textTranslationKey %}
     {{ text | nl2br }}

--- a/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.content.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.content.html.twig
@@ -1,0 +1,7 @@
+{% set textTranslationKey = 'mapbender.data_policy.content' %}
+{% set text = textTranslationKey | trans %}
+{% if text != textTranslationKey %}
+    {{ text | nl2br }}
+{% else %}
+    {{ 'mapbender.data_policy.instructions' | trans | nl2br }}
+{% endif %}

--- a/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.page.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Site/data_policy.page.html.twig
@@ -1,0 +1,4 @@
+{% extends "MapbenderCoreBundle::index.html.twig" %}
+
+{% block title %}{{ 'mb.data_policy.title' | trans }}{% endblock %}
+{% block content %}{% include contentTemplate %}{% endblock %}

--- a/src/Mapbender/CoreBundle/Resources/views/Site/imprint.content.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Site/imprint.content.html.twig
@@ -1,0 +1,7 @@
+{% set textTranslationKey = 'mb.imprint.content' %}
+{% set text = textTranslationKey | trans %}
+{% if text != textTranslationKey %}
+    {{ text | nl2br }}
+{% else %}
+    {{ 'mb.imprint.instructions' | trans | nl2br }}
+{% endif %}

--- a/src/Mapbender/CoreBundle/Resources/views/Site/imprint.page.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Site/imprint.page.html.twig
@@ -1,0 +1,4 @@
+{% extends "MapbenderCoreBundle::index.html.twig" %}
+
+{% block title %}{{ 'mb.imprint.title' | trans }}{% endblock %}
+{% block content %}{% include contentTemplate %}{% endblock %}


### PR DESCRIPTION
Open TODOs:
* link embedding in login template (in FOM)
* link embedding in backend skeleton (in FOM)

NOTE: branch is based off release/3.0.5 in case we need to merge into older projects. You can trivially integrate locally with master by
```sh
git fetch origin
git checkout -b integration/local-throwaway-for-testing origin/master
git merge origin/feature/dgsv-imprint-and-data-policy
```

Add two URL endpoints `/imprint` and `/data-policy`.  
Provide customization knobs for
* effectively disabling the routes via parameters.yml `mapbender.imprint.expose` and `mapbender.data_policy.expose` (both booleans, both default to true)
* overridable twig templates separated by full page and content only (requests with `?embed=anything`)

If content has not been added, the URLs render basic instructions on content customization.

This change functions purely within Mapbender and does not require changes in starter, even though actual imprint / data policy content can (and should) be placed in the project starter.

Customization strategy (maximum control):
Add files (starter scope):  
`application/app/Resources/MapbenderCoreBundle/views/Site/imprint.content.html.twig`  
`application/app/Resources/MapbenderCoreBundle/views/Site/data_policy.content.html.twig`  
As the names indicate, you can use any HTML formatting and optionally Twig functionality you want.

That's it!  
These template overrides are picked up automatically by the framework. For production, you will need a `bin/composer run clean` to clear the cache though.
