### PR TITLE
Fix/wms loader format selections gh841

### DIFF
--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -198,8 +198,11 @@
                 }else if(mbMap.model.findSource(opts).length === 0){
                     mbMap.addSource(sourceDef, null, null);
                 }
-
             });
+            // Enable feature info
+            // @todo: find a way to do this directly on the map, without using the layertree
+            // @todo: fix default for newly added source (no fi) to match default layertree visual (fi on)
+             $('.mb-element-layertree .featureInfoWrapper input[type="checkbox"]').trigger('change');
         },
         _getCapabilitiesUrlError: function(xml, textStatus, jqXHR){
             Mapbender.error(Mapbender.trans('mb.wms.wmsloader.error.load'));

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -178,6 +178,8 @@
                 },
                 dataType: 'json',
                 success: function(data, textStatus, jqXHR){
+                    data.configuration.options.info_format = self.options.defaultInfoFormat;
+                    data.configuration.options.format = self.options.defaultFormat;
                     self._addSources([data], sourceOpts)
                 },
                 error: function(jqXHR, textStatus, errorThrown){


### PR DESCRIPTION
Fixes [issue 841](https://github.com/mapbender/mapbender/issues/841).

Configured WMS Loader settings for format and info format override server-picked values.

Enables FeatureInfo after adding sources. This is a bit of a hack as it piggybacks on layer tree event handlers.
