### PR TITLE
Fixes WMS Loader metadata dialog by prohibiting the load metadata ico…

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -926,7 +926,7 @@
                 }
 
                 if ($.inArray("metadata", self.options.menu) === -1 || menu.find(
-                    '.layer-metadata').length === 0 || isNaN(parseInt(source.origId))) {
+                    '.layer-metadata').length === 0 || (source.hasOwnProperty('wmsloader') && source.wmsloader === true) || isNaN(parseInt(source.origId))) {
                     $('.layer-metadata', menu).remove();
                 } else {
                     atLeastOne = true;

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -193,6 +193,7 @@
             $.each(sourceDefs, function(idx, sourceDef) {
                 var opts = {configuration: {options: {url: sourceDef.configuration.options.url}}};
                 sourceDef.configuration.status = 'ok';
+                sourceDef.wmsloader = true;
                 if(!sourceOpts.global.mergeSource){
                     mbMap.addSource(sourceDef, null, null);
                 }else if(mbMap.model.findSource(opts).length === 0){


### PR DESCRIPTION
Zeigt das Icon für den Metadata-Dialog nicht an, wenn ein WMS-Dienst über den WMS-Loader geladen wird. So werden Fehler im Metadata-Popup verhindert. Diese Fehler sind bisher entstanden, weil die Metadaten-Anzeige für über den WMS-Loader geladenen Dienste vom Mapbender nicht unterstützt wird.

Siehe Issue: https://github.com/mapbender/mapbender/issues/809