### PR TITLE
Move WMS layer order default application from entity => entity handle…

### DIFF
--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -180,7 +180,17 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
                     "outOfBounds" => null
                 ),
             );
-            switch ($entity->getSourceInstance()->getLayerOrder()) {
+            $layerOrderDefaultKey = 'wms.default_layer_order';
+            if ($this->container->hasParameter($layerOrderDefaultKey)) {
+                $configuredDefaultLayerOrder = $this->container->getParameter($layerOrderDefaultKey);
+                // if the default has not been configured explicitly, use the "traditional" value
+                $layerOrderDefault = $configuredDefaultLayerOrder ?: WmsInstance::LAYER_ORDER_TOP_DOWN;
+            } else {
+                $layerOrderDefault = WmsInstance::LAYER_ORDER_TOP_DOWN;
+            }
+            $layerOrder = $entity->getSourceInstance()->getLayerOrder() ?: $layerOrderDefault;
+
+            switch ($layerOrder) {
                 default:
                 case WmsInstance::LAYER_ORDER_TOP_DOWN:
                     // do nothing

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -8,6 +8,7 @@ use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\WmsBundle\Component\DimensionInst;
 use Mapbender\WmsBundle\Component\VendorSpecific;
+use Mapbender\WmsBundle\Component\WmsInstanceLayerEntityHandler;
 use Mapbender\WmsBundle\Component\WmsMetadata;
 
 /**
@@ -611,15 +612,16 @@ class WmsInstance extends SourceInstance
     }
 
     /**
-     * @return string
+     * Returns desired layer order, as a string enum ('standard' or 'reverse')
+     * NOTE: this is a recently added column; there will be NULLs in the DB for updated applications.
+     *       The default for these cases is provided at the "Handler" level.
+     * @see WmsInstanceLayerEntityHandler::generateConfiguration()
+     *
+     * @return string|null
      */
     public function getLayerOrder()
     {
-        // NOTE: this is a recently added column; there will be NULLs in the DB for updated applications
-        //       we convert these NULLs to our desired default (not the default for new instances, which can
-        //       be configured)
-        //       the layerOrder column will be properly populated when instances are saved
-        return $this->layerOrder ?: self::LAYER_ORDER_TOP_DOWN;
+        return $this->layerOrder;
     }
 
     /**


### PR DESCRIPTION
Remove default for null columns from Entity getLayerOrder.

A/B testing on Postgres revealed that for reasons not entirely understood the entity does not update in the database if the only changed column is layerOrder as long as the getter provides a default. Removing the default (i.e. getLayerOrder returns plain attribute, whatever it is) restores reliable database updates.

Add back the (configurable) default into the frontend config emission machinery.
