### PR TITLE
WMS Loader: Split WMS

### DIFF
--- a/src/Mapbender/WmsBundle/Element/WmsLoader.php
+++ b/src/Mapbender/WmsBundle/Element/WmsLoader.php
@@ -204,6 +204,7 @@ class WmsLoader extends Element
     protected function splitLayers($layerConfiguration)
     {
         $children = $layerConfiguration['configuration']['children'][0]['children'];
+        $layerConfigurations = array();
         foreach ($children as $child) {
             $layerConfiguration['configuration']['children'][0]['children'] = [$child];
             $layerConfiguration['configuration']['children'][0]['options']['title'] = $child['options']['title']

--- a/src/Mapbender/WmsBundle/Element/WmsLoader.php
+++ b/src/Mapbender/WmsBundle/Element/WmsLoader.php
@@ -176,8 +176,14 @@ class WmsLoader extends Element
         /** @var TypeDirectoryService $directory */
         $directory = $this->container->get('mapbender.source.typedirectory.service');
         $layerConfiguration = $directory->getSourceService($wmsInstance)->getConfiguration($wmsInstance);
+        $elementConfig = $this->getConfiguration();
+        if ($elementConfig['splitLayers']) {
+            $layerConfigurations = $this->splitLayers($layerConfiguration);
+        } else {
+            $layerConfigurations = [$layerConfiguration];
+        }
 
-        return new JsonResponse($layerConfiguration);
+        return new JsonResponse($layerConfigurations);
     }
 
     protected function getWmsSource($request)
@@ -193,5 +199,20 @@ class WmsLoader extends Element
         $importerResponse = $importer->evaluateServer($wmsOrigin, $onlyValid);
 
         return $importerResponse->getWmsSourceEntity();
+    }
+
+    protected function splitLayers($layerConfiguration)
+    {
+        $children = $layerConfiguration['configuration']['children'][0]['children'];
+        foreach ($children as $child) {
+            $layerConfiguration['configuration']['children'][0]['children'] = [$child];
+            $layerConfiguration['configuration']['children'][0]['options']['title'] = $child['options']['title']
+                . ' ('
+                . $layerConfiguration['configuration']['title']
+                . ')'
+            ;
+            $layerConfigurations[] = $layerConfiguration;
+        }
+        return $layerConfigurations;
     }
 }

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -178,9 +178,14 @@
                 },
                 dataType: 'json',
                 success: function(data, textStatus, jqXHR){
-                    data.configuration.options.info_format = self.options.defaultInfoFormat;
-                    data.configuration.options.format = self.options.defaultFormat;
-                    self._addSources([data], sourceOpts)
+                    var i;
+
+                    for (i = 0; i < data.length; i++) {
+                      data[i].configuration.options.info_format = self.options.defaultInfoFormat;
+                      data[i].configuration.options.format = self.options.defaultFormat;
+                    }
+
+                    self._addSources(data, sourceOpts);
                 },
                 error: function(jqXHR, textStatus, errorThrown){
                     self._getCapabilitiesUrlError(jqXHR, textStatus, errorThrown);


### PR DESCRIPTION
Teilt die Layer eines WMS-Dienstes in Root-Layer auf.

Diese Funktion war bereits einmal clientseitig implementiert in der jetzt als deprecated markierten `mapbender.geosource.wms.js`: 

https://github.com/mapbender/mapbender/blob/master/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js#L244

