### PR TITLE
Replace PHP7+ '??' operator with PHP5.3-compatible '?:'

### DIFF
--- a/src/Mapbender/Component/SymlinkInstaller/SymlinkInstaller.php
+++ b/src/Mapbender/Component/SymlinkInstaller/SymlinkInstaller.php
@@ -120,7 +120,7 @@ class SymlinkInstaller implements SymlinkInstallerInterface
     {
         $this->checkSettings();
 
-        $this->filesystem->symlink($this->relativeOriginDir ?? $this->originDir, $this->targetDir);
+        $this->filesystem->symlink($this->relativeOriginDir ?: $this->originDir, $this->targetDir);
 
         if (!file_exists($this->targetDir)) {
             throw new IOException(sprintf('Symbolic link "%s" was created but appears to be broken.', $this->targetDir), 0, null, $this->targetDir);


### PR DESCRIPTION
"Null coalesce" `??` is a new PHP7.0 operator.
See http://php.net/manual/en/language.operators.comparison.php

The good old "ternary with no middle part" `?:` is legal since PHP5.3 (as documented on the same manual page).

They are not 100% equivalent. `?:` will take the right value if the left is falsy (empty string etc), while `??` checks strictly and only for null.

I think in this use case the replacement is valid though.