### PR TITLE
[WIP] dynamic layer reordering vs reversed layer order

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -184,8 +184,8 @@
             $('li.leave[data-type="simple"]', $sourceContainer).each(function() {
                 var $t = $(this);
                 var layerId = $t.attr('data-id');
-                if (layerId !== undefined) {
-                    layerIdOrder.push(layerId.toString());
+                if (typeof layerId !== "undefined") {
+                    layerIdOrder.push("" + layerId);
                 }
             });
             this.model.setSourceLayerOrder(sourceId, layerIdOrder.reverse());

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -217,10 +217,10 @@
                         if (type === 'theme' || type === 'root') {
                             self._updateSourceOrder();
                             // self._sortTheme($elm);
-                        } else if ($elm.attr('data-type') === 'simple') {
+                        } else if (type === 'simple' || type === 'group') {
                             self._updateSource($elm.closest('.serviceContainer'));
                         } else {
-                            console.warn("Warning: unhandled element in layertree sorting", $elm);
+                            console.warn("Warning: unhandled element in layertree sorting", type, $elm);
                         }
                     }
                 });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -188,7 +188,7 @@
                     layerIdOrder.push(layerId.toString());
                 }
             });
-            this.model.setSourceLayerOrder(sourceId, layerIdOrder);
+            this.model.setSourceLayerOrder(sourceId, layerIdOrder.reverse());
         },
         /**
          * Applies the new (going by DOM) ordering between sources.
@@ -540,7 +540,6 @@
         _removeChild: function(changed) {
             var self = this;
             if (changed && changed.sourceIdx && changed.childRemoved) {
-                var source = this.model.getSource(changed.sourceIdx);
                 $('ul.layers:first li[data-id="' + changed.childRemoved.layer.options.id + '"]', self.element).
                     remove();
             }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -214,13 +214,18 @@
                     update: function(event, ui) {
                         var $elm = $(ui.item);
                         var type = $elm.attr('data-type');
-                        if (type === 'theme' || type === 'root') {
-                            self._updateSourceOrder();
-                            // self._sortTheme($elm);
-                        } else if (type === 'simple' || type === 'group') {
-                            self._updateSource($elm.closest('.serviceContainer'));
-                        } else {
-                            console.warn("Warning: unhandled element in layertree sorting", type, $elm);
+                        switch (type) {
+                            case 'theme':
+                            case 'root':
+                                self._updateSourceOrder();
+                                break;
+                            case 'simple':
+                            case 'group':
+                                self._updateSource($elm.closest('.serviceContainer'));
+                                break;
+                            default:
+                                console.warn("Warning: unhandled element in layertree sorting", type, $elm);
+                                break;
                         }
                     }
                 });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -205,8 +205,7 @@
         _createSortable: function() {
             var self = this;
             $("ul.layers", this.element).each(function() {
-                var that = this;
-                $(that).sortable({
+                $(this).sortable({
                     axis: 'y',
                     items: "> li:not(.notreorder)",
                     distance: 6,

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -85,7 +85,7 @@
             widget.onMapLayerChanges();
 
             $(document)
-                .bind('mbmapsourceadded mbmapsourcechanged mbmapsourcechanged mbmapsourcemoved', $.proxy(widget.onMapLayerChanges, widget))
+                .bind('mbmapsourceadded mbmapsourcechanged mbmapsourcemoved', $.proxy(widget.onMapLayerChanges, widget))
                 .unbind('mbmapsourceloadend', widget.onMapLoaded);
         },
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -76,9 +76,7 @@
         addSource: function(sourceDef){
             this.model.addSource({
                 add: {
-                    sourceDef: sourceDef,
-                    before: null,
-                    after: null
+                    sourceDef: sourceDef
                 }
             });
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -734,11 +734,11 @@ Mapbender.Geo.SourceHandler = Class({
         return null;
     },
     'public function setLayerOrder': function(source, layerIdOrder) {
-        var self = this;
-        Mapbender.Geo.layerOrderMap["" + source.id] = $.map(layerIdOrder, function(layerId) {
-            var layerObj = self.findLayer(source, {id: layerId});
+        var newLayerNameOrder = $.map(layerIdOrder, function(layerId) {
+            var layerObj = this.findLayer(source, {id: layerId});
             return layerObj.layer.options.name;
-        });
+        }.bind(this));
+        Mapbender.Geo.layerOrderMap["" + source.id] = newLayerNameOrder;
     }
 });
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -228,7 +228,7 @@ Mapbender.Geo.SourceHandler = Class({
             layers: [
             ],
             found: false,
-            cut_with: includeOffset
+            includeOffset: includeOffset
         };
         if (rootLayer.options.id.toString() === offsetLayer.options.id.toString()) {
             options.found = true;
@@ -245,7 +245,7 @@ Mapbender.Geo.SourceHandler = Class({
                 for (; i < layer.children.length; i++) {
                     if (layer.children[i].options.id.toString() === offsetLayer.options.id.toString()) {
                         options.found = true;
-                        if (options.cut_with) {
+                        if (options.includeOffset) {
                             var lays = layer.children.slice().splice(i, layer.children.length - i);
                             options.layers = options.layers.concat(lays);
                             break;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -245,14 +245,18 @@ Mapbender.Geo.SourceHandler = Class({
                 for (; i < layer.children.length; i++) {
                     if (layer.children[i].options.id.toString() === offsetLayer.options.id.toString()) {
                         options.found = true;
-                        if (options.includeOffset) {
-                            var lays = layer.children.slice().splice(i, layer.children.length - i);
-                            options.layers = options.layers.concat(lays);
-                            break;
+                    }
+                    if (options.found) {
+                        var matchOffset = i;
+                        if (!options.includeOffset) {
+                            matchOffset += 1;
                         }
-                    } else if (options.found) {
-                        var lays = layer.children.slice().splice(i, layer.children.length - i);
-                        options.layers = options.layers.concat(lays);
+                        var matchLength = layer.children.length - matchOffset;
+                        // splice modifies the original Array => work with a shallow copy
+                        var layersCopy = layer.children.slice();
+                        var matchedLayers = layersCopy.splice(matchOffset, matchLength);
+                        options.layers = options.layers.concat(matchedLayers);
+
                         break;
                     }
                     options = _findLayers(layer.children[i], offsetLayer, options);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -50,7 +50,9 @@ Mapbender.Event.Dispatcher = Class({
  * Abstract Geo Source Handler
  * @author Paul Schmidt
  */
-Mapbender.Geo = {};
+Mapbender.Geo = {
+    'layerOrderMap': {}
+};
 Mapbender.Geo.SourceHandler = Class({
     'extends': Mapbender.Event.Dispatcher
 }, {
@@ -591,7 +593,7 @@ Mapbender.Geo.SourceHandler = Class({
                 layerChanged.state = layer.state;
                 result.changed.children[layer.options.id] = layerChanged;
             }
-            var customLayerOrder = self._layerOrderMap[source.id];
+            var customLayerOrder = Mapbender.Geo.layerOrderMap["" + source.id];
             if (customLayerOrder && customLayerOrder.length && result.layers && result.layers.length) {
                 result.layers = _.filter(customLayerOrder, function(layerName) {
                     return result.layers.indexOf(layerName) !== -1;
@@ -729,7 +731,7 @@ Mapbender.Geo.SourceHandler = Class({
     },
     'public function setLayerOrder': function(source, layerIdOrder) {
         var self = this;
-        this._layerOrderMap[source.id] = $.map(layerIdOrder, function(layerId) {
+        Mapbender.Geo.layerOrderMap["" + source.id] = $.map(layerIdOrder, function(layerId) {
             var layerObj = self.findLayer(source, {id: layerId});
             return layerObj.layer.options.name;
         });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -54,6 +54,7 @@ Mapbender.Geo = {};
 Mapbender.Geo.SourceHandler = Class({
     'extends': Mapbender.Event.Dispatcher
 }, {
+    _layerOrderMap: {},
     'private string layerNameIdent': 'name',
     'private object defaultOptions': {},
     'abstract public function create': function(options) {
@@ -590,6 +591,13 @@ Mapbender.Geo.SourceHandler = Class({
                 layerChanged.state = layer.state;
                 result.changed.children[layer.options.id] = layerChanged;
             }
+            var customLayerOrder = self._layerOrderMap[source.id];
+            if (customLayerOrder && customLayerOrder.length && result.layers && result.layers.length) {
+                result.layers = _.filter(customLayerOrder, function(layerName) {
+                    return result.layers.indexOf(layerName) !== -1;
+                });
+            }
+
             return layer;
         }
     },
@@ -718,6 +726,13 @@ Mapbender.Geo.SourceHandler = Class({
             return source.configuration.options.bbox;
         }
         return null;
+    },
+    'public function setLayerOrder': function(source, layerIdOrder) {
+        var self = this;
+        this._layerOrderMap[source.id] = $.map(layerIdOrder, function(layerId) {
+            var layerObj = self.findLayer(source, {id: layerId});
+            return layerObj.layer.options.name;
+        });
     }
 });
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -244,12 +244,12 @@ Mapbender.Geo.SourceHandler = Class({
                     if (layer.children[i].options.id.toString() === offsetLayer.options.id.toString()) {
                         options.found = true;
                         if (options.cut_with) {
-                            var lays = layer.children.splice(i, layer.children.length - i);
+                            var lays = layer.children.slice().splice(i, layer.children.length - i);
                             options.layers = options.layers.concat(lays);
                             break;
                         }
                     } else if (options.found) {
-                        var lays = layer.children.splice(i, layer.children.length - i);
+                        var lays = layer.children.slice().splice(i, layer.children.length - i);
                         options.layers = options.layers.concat(lays);
                         break;
                     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -219,9 +219,7 @@ Mapbender.Model = {
                         layerDef['origId'] = idx;
                         self.addSource({
                             add: {
-                                sourceDef: layerDef,
-                                before: null,
-                                after: null
+                                sourceDef: layerDef
                             }
                         });
                     });
@@ -809,10 +807,9 @@ Mapbender.Model = {
      */
     addSource: function(addOptions) {
         var self = this;
+        var before;
         if (addOptions.add) {
             var sourceDef = addOptions.add.sourceDef;
-            var before = addOptions.add.before;
-            var after = addOptions.add.after;
             sourceDef.id = this.generateSourceId();
 
             if (typeof sourceDef.origId === 'undefined') {
@@ -822,26 +819,16 @@ Mapbender.Model = {
                 name: 'beforeSourceAdded',
                 value: {
                     source: sourceDef,
-                    before: before,
-                    after: after
+                    before: null,
+                    after: null
                 }
             });
             if (!this.getSourcePos(sourceDef)) {
-                if (!before && !after) {
-                    before = {
-                        source: this.sourceTree[this.sourceTree.length - 1]
-                    };
-                    after = null;
-                }
                 this.sourceTree.push(sourceDef);
-            } else {
-                if (!before && !after) {
-                    before = {
-                        source: this.sourceTree[this.sourceTree.length - 1]
-                    };
-                    after = null;
-                }
             }
+            before = {
+                source: this.sourceTree[this.sourceTree.length - 1]
+            };
             var source = sourceDef;
             var mapQueryLayer = this.map.layers(this._convertLayerDef(source));
             if (mapQueryLayer) {
@@ -867,13 +854,10 @@ Mapbender.Model = {
                         added: {
                             source: source,
                             before: before,
-                            after: after
+                            after: null
                         }
                     }
                 });
-                if (after) {
-                    this._moveSource(source, before, after);
-                }
                 this._checkAndRedrawSource({
                     sourceIdx: {
                         id: source.id

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -1088,7 +1088,7 @@ Mapbender.Model = {
         var oldPositions = [];
         var zIndexes = [];
         var sourceIdToSource = {};
-        $.each(sourceObjs, function(i, sourceObj) {
+        _.forEach(sourceObjs, function(sourceObj) {
             oldPositions.push(self.getSourcePos(sourceObj));
             sourceIdToSource[sourceObj.id] = sourceObj;
             zIndexes.push(self.map.layersList[sourceObj.mqlid].position());

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -1054,37 +1054,22 @@ Mapbender.Model = {
      * @param {string[]} newLayerIdOrder
      */
     setSourceLayerOrder: function(sourceId, newLayerIdOrder) {
-        var sourceObj = this.getSource({id: sourceId});
-        var geoSourceType = Mapbender.source[sourceObj.type];
-        var layerConfigs = $.map(newLayerIdOrder, function(layerId) {
-            return geoSourceType.findLayer(sourceObj, {id: layerId}).layer;
-        });
-        layerConfigs = _.filter(layerConfigs, function(layerConf) {
-            return !!layerConf.state.visibility;
-        });
-        var layerNames = $.map(layerConfigs, function(layerConf) {
-            return layerConf.options.name;
-        });
-        var layerStyles = $.map(layerConfigs, function(layerConf) {
-            return layerConf.options.style || '';
-        });
-        var activeInfoLayerConfigs = _.filter(layerConfigs, function(layerConf) {
-            return layerConf.options.treeOptions.info === true;
-        });
-        var infoLayers = $.map(activeInfoLayerConfigs, function(layerConf) {
-            return layerConf.options.name;
-        });
+        var sourceIdx = {id: sourceId};
+        var sourceObj = this.getSource(sourceIdx);
+        var geoSource = Mapbender.source[sourceObj.type];
+
+        geoSource.setLayerOrder(sourceObj, newLayerIdOrder);
+
         this.mbMap.fireModelEvent({
             name: 'sourceMoved',
-            // no receiver cares about the bizarre "changeOptions" return value
+            // no receiver uses the bizarre "changeOptions" return value
+            // on this event
             value: null
         });
-        var mqLayer = this.map.layersList[sourceObj.mqlid];
-        if (this._resetSourceVisibility(mqLayer, layerNames, infoLayers, layerStyles)) {
-            mqLayer.olLayer.removeBackBuffer();
-            mqLayer.olLayer.createBackBuffer();
-            mqLayer.olLayer.redraw(true);
-        }
+        this._checkAndRedrawSource({
+            sourceIdx: sourceIdx,
+            options: {children: {}}
+        });
     },
     /**
      * Bring the sources identified by the given ids into the given order.

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -807,7 +807,6 @@ Mapbender.Model = {
      */
     addSource: function(addOptions) {
         var self = this;
-        var before;
         if (addOptions.add) {
             var sourceDef = addOptions.add.sourceDef;
             sourceDef.id = this.generateSourceId();
@@ -826,9 +825,6 @@ Mapbender.Model = {
             if (!this.getSourcePos(sourceDef)) {
                 this.sourceTree.push(sourceDef);
             }
-            before = {
-                source: this.sourceTree[this.sourceTree.length - 1]
-            };
             var source = sourceDef;
             var mapQueryLayer = this.map.layers(this._convertLayerDef(source));
             if (mapQueryLayer) {
@@ -853,7 +849,11 @@ Mapbender.Model = {
                     value: {
                         added: {
                             source: source,
-                            before: before,
+                            // legacy: no known consumer evaluates these props,
+                            // but even if, they've historically been wrong anyway
+                            // was: "before": always last source previously in list, even though
+                            // the new source was actually added *after* that
+                            before: null,
                             after: null
                         }
                     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -993,30 +993,7 @@ Mapbender.Model = {
                 }
             }
             if (changeOpts.move) {
-                var tomove = {
-                    source: this.getSource(
-                        changeOpts.move.tomove.sourceIdx)
-                };
-                if (changeOpts.move.tomove.layerIdx) {
-                    tomove['layerId'] = changeOpts.move.tomove.layerIdx.id;
-                }
-                var before = changeOpts.move.before;
-                if (before) {
-                    before = {
-                        source: this.getSource(
-                            changeOpts.move.before.sourceIdx),
-                        layerId: changeOpts.move.before.layerIdx.id
-                    };
-                }
-                var after = changeOpts.move.after;
-                if (after) {
-                    after = {
-                        source: this.getSource(
-                            changeOpts.move.after.sourceIdx),
-                        layerId: changeOpts.move.after.layerIdx.id
-                    };
-                }
-                this._moveSourceOrLayer(tomove, before, after);
+                console.error("mapbender.model:changeSource with 'move' is gone", changeOpts);
             }
             if (changeOpts.layerRemove) {
                 var sourceToChange = this.getSource(changeOpts.layerRemove.sourceIdx);
@@ -1067,60 +1044,6 @@ Mapbender.Model = {
             this.changeSource(toChangeOptions);
         }
 
-    },
-    _moveSourceOrLayer: function(tomove, before, after) {
-        var layerToMove;
-        if (before && after
-            && before.source.id.toString() === after.source.id.toString()
-            && before.source.id.toString() === tomove.source.id.toString()) {
-//            window.console && console.log("move layer inside");
-            var beforeLayer = Mapbender.source[before.source.type].findLayer(before.source, {
-                id: before.layerId
-            });
-            var afterLayer = Mapbender.source[after.source.type].findLayer(after.source, {
-                id: after.layerId
-            });
-            layerToMove = Mapbender.source[tomove.source.type].findLayer(tomove.source, {
-                id: tomove.layerId
-            });
-            var targetIdx = layerToMove.idx > afterLayer.idx ? beforeLayer.idx + 1 : beforeLayer.idx;
-            this._reorderLayers(tomove.source, layerToMove.layer, beforeLayer.parent, targetIdx, before, after);
-        } else if (before && before.source.id.toString() === tomove.source.id.toString()) {
-//            window.console && console.log("move layer into last pos");
-            var beforeLayer = Mapbender.source[before.source.type].findLayer(before.source, {
-                id: before.layerId
-            });
-            layerToMove = Mapbender.source[tomove.source.type].findLayer(tomove.source, {
-                id: tomove.layerId
-            });
-            this._reorderLayers(tomove.source, layerToMove.layer, beforeLayer.parent, beforeLayer.idx, before, after);
-        } else if (after && after.source.id.toString() === tomove.source.id.toString()) {
-//            window.console && console.log("move layer into first pos");
-            var afterLayer = Mapbender.source[after.source.type].findLayer(after.source, {
-                id: after.layerId
-            });
-            layerToMove = Mapbender.source[tomove.source.type].findLayer(tomove.source, {
-                id: tomove.layerId
-            });
-            this._reorderLayers(tomove.source, layerToMove.layer, afterLayer.parent, afterLayer.idx, before, after);
-        } else if (before && before.source.origId === tomove.source.origId) {
-            ;
-        } else if (after && after.source.origId === tomove.source.origId) {
-            ;
-        } else if (before && !after) {
-            if (!tomove.layerId) {
-//                window.console && console.log("move source into last pos");
-                this._moveSource(tomove.source, before, after);
-            }
-        } else if (after && !before) { // move source for tree
-            if (!tomove.layerId) {
-                this._moveSource(tomove.source, before, after);
-            }
-        } else {
-            if (!tomove.layerId) { // move source for tree
-                this._moveSource(tomove.source, before, after);
-            }
-        }
     },
     /**
      * Updates the source identified by given id with a new layer order.
@@ -1222,41 +1145,6 @@ Mapbender.Model = {
             this.sourceTree[oldPos] = injectSourceObj;
             self.map.layersList[injectSourceObj.mqlid].position(injectSourceZ);
         }
-    },
-    /**
-     *
-     */
-    _moveSource: function(source, before, after) {
-        var old_pos = this.getSourcePos(source);
-        var new_pos;
-        if (before && before.source && after && after.source) {
-            var before_pos = this.getSourcePos(before.source);
-            var after_pos = this.getSourcePos(after.source);
-            if (old_pos <= before_pos)
-                new_pos = before_pos;
-            else if (old_pos > before_pos)
-                new_pos = after_pos;
-        } else if (before && before.source) {
-            new_pos = this.getSourcePos(before.source);
-        } else if (after && after.source) {
-            new_pos = this.getSourcePos(after.source);
-        }
-        if (old_pos === new_pos)
-            return;
-        this.sourceTree.splice(new_pos, 0, this.sourceTree.splice(old_pos, 1)[0]);
-        var mqL = this.map.layersList[source.mqlid];
-        if (old_pos > new_pos) {
-            mqL.down(Math.abs(old_pos - new_pos));
-        } else {
-            mqL.up(Math.abs(old_pos - new_pos));
-        }
-        var changed = this.createChangedObj(source);
-        changed.after = after;
-        changed.before = before;
-        this.mbMap.fireModelEvent({
-            name: 'sourceMoved',
-            value: changed
-        });
     },
     /*
      * Changes the map's projection.

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -1087,30 +1087,6 @@ Mapbender.Model = {
         }
     },
     /**
-     *
-     */
-    _reorderLayers: function(source, layerToMove, targetParent, targetIdx, before, after) {
-        var removed = Mapbender.source[source.type].removeLayer(source, layerToMove);
-        var added = Mapbender.source[source.type].addLayer(source, removed.layer, targetParent, targetIdx);
-        var changed = this.createChangedObj(source);
-        changed.children[added.options.id] = added;
-        changed.layerId = added.options.id;
-        changed.after = after;
-        changed.before = before;
-        this.mbMap.fireModelEvent({
-            name: 'sourceMoved',
-            value: changed
-        });
-        this._checkAndRedrawSource({
-            sourceIdx: {
-                id: source.id
-            },
-            options: {
-                children: {}
-            }
-        });
-    },
-    /**
      * Bring the sources identified by the given ids into the given order.
      * All other sources will be left alone!
      *

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -200,9 +200,9 @@
                 sourceDef.configuration.status = 'ok';
                 sourceDef.wmsloader = true;
                 if(!sourceOpts.global.mergeSource){
-                    mbMap.addSource(sourceDef, null, null);
+                    mbMap.addSource(sourceDef);
                 }else if(mbMap.model.findSource(opts).length === 0){
-                    mbMap.addSource(sourceDef, null, null);
+                    mbMap.addSource(sourceDef);
                 }
             });
             // Enable feature info

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -30,6 +30,7 @@ Mapbender.Geo.WmsSourceHandler = Class({'extends': Mapbender.Geo.SourceHandler }
             rootLayer.options.treeOptions.selected = false;
             rootLayer.options.treeOptions.allow.selected = false;
         }
+        var layerNames = [];
 
         function _setProperties(layer, parent, id, num, options){
             /* set unic id for a layer */
@@ -46,10 +47,13 @@ Mapbender.Geo.WmsSourceHandler = Class({'extends': Mapbender.Geo.SourceHandler }
                 for(var i = 0; i < layer.children.length; i++) {
                     _setProperties(layer.children[i], layer, id, i, options);
                 }
+            } else {
+                layerNames.push(layer.options.name);
             }
         }
         
         _setProperties(rootLayer, null, sourceDef.id, 0, sourceDef.configuration.options);
+        Mapbender.Geo.layerOrderMap["" + sourceDef.id] = layerNames;
         var finalUrl = sourceDef.configuration.options.url;
         
         if(sourceDef.configuration.options.proxy === true && !sourceDef.configuration.options.tunnel) {


### PR DESCRIPTION
Status: dynamic reordering of both static and dynamically added sources and layers works as intended. "Themed" layertree was tested as well.
Layer order self-reset on scroll / dynamic layer de-/reactivation has been resolved.


We had some issues with dynamic layer reordering in combination with "Reversed (QGIS style)" layer order in some applications.

The previous code performed a multitude of incremental "Move this layer before this second layer and / or after that third layer" updates to the internal "geosource" data structures, in hopes that the internal structure would always remain in sync with the (visible) DOM order. This was often not the case. Particularly, when many layers were moved in bulk, the before / after layers could point to already moved ones, breaking the process.

The changes on this branch make setting the desired layer order per source a one-shot bulk operation, and remove the incremental single-layer "move" operations.

The layertree was adapted to use the bulk layer order setter on the geosource, so the result will remain consistent with the visible DOM order of the layers.
The "sourceMoved" event is still fired but without the old structured "changed" payload, which would have been excrutiatingly hard to emulate. The only known consumer of this event (inside our own codebase) is the legend widget, which [does not access this information at all](https://github.com/mapbender/mapbender/blob/v3.0.7.1/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js#L105).

The layer ordering ended up as global state (keyed on source id), which is fugly. I resorted to this because JOII would not let me access parent-declared object properties in a child instance...
