### PR TITLE
Change default prefix for printouts to mapbender. Ticket 855

### DIFF
--- a/src/Mapbender/CoreBundle/Element/PrintClient.php
+++ b/src/Mapbender/CoreBundle/Element/PrintClient.php
@@ -100,7 +100,7 @@ class PrintClient extends Element
                 "comment1" => array("label" => 'Comment 1', "options" => array("required" => false)),
                 "comment2" => array("label" => 'Comment 2', "options" => array("required" => false))),
             "replace_pattern" => null,
-            "file_prefix" => 'mapbender3'
+            "file_prefix" => 'mapbender'
         );
     }
 


### PR DESCRIPTION
This PR changes the default prefix for printouts to mapbender instead mapbender3. So a default printout file is now called mapbender_<date> instead of mapbender3_<date>.