### PR TITLE
Fix error add mouse position control

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.coordinatesdisplay.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.coordinatesdisplay.js
@@ -24,20 +24,16 @@
             this.options.empty = this.options.empty || '';
             this.options.prefix = this.options.prefix || '';
             this.options.separator = this.options.separator || ' ';
-            $(document).on('mbmapsrschanged', $.proxy(this._reset, this));
+            $(document).on('mbmapsrschanged', $.proxy(this._updateProjection, this));
 
             this.options.numDigits = isNaN(parseInt(this.options.numDigits, this.RADIX))
                 ? 0
                 : parseInt(this.options.numDigits, this.RADIX);
             this.options.numDigits = this.options.numDigits < 0 ? 0 : this.options.numDigits;
 
-            this._reset();
-        },
-
-        _reset: function (event, srs) {
             var model = this.map.model;
             var isdeg = model.getCurrentProjectionObject().getUnits() === 'dd';
-            srs = { projection: {projCode: model.getCurrentProjectionCode()}};
+            var srs = {projection: {projCode: model.getCurrentProjectionCode()}};
 
             if (this.crs !== null && (this.crs === srs.projection.projCode)) {
                 return;
@@ -54,6 +50,12 @@
             };
             model.createMousePositionControl(elementConfig);
             this.crs = srs.projection.projCode;
+        },
+
+        _updateProjection: function () {
+          var projection = this.map.model.getCurrentProjectionCode();
+          this.map.model.mousePositionControlUpdateProjection(projection);
+          this.crs = projection;
         }
     });
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.ol4.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.ol4.js
@@ -1386,6 +1386,19 @@ Mapbender.Model.prototype.createMousePositionControl = function createMousePosit
 };
 
 /**
+ *
+ * @param projection
+ */
+Mapbender.Model.prototype.mousePositionControlUpdateProjection = function mousePositionControlUpdateProjection(projection) {
+    'use strict';
+    this.map.getControls().forEach(function (control) {
+        if (control instanceof ol.control.MousePosition) {
+            control.setProjection(projection);
+        }
+    });
+};
+
+/**
  * @param {object} options
  * @returns {object}
  */


### PR DESCRIPTION
Das Fixed den Fehler, dass beim srs switchen ein neuer Mouse Position Control dazugefügt wird:

![unbenannt](https://user-images.githubusercontent.com/24896163/42020040-07ef2df6-7ab7-11e8-97ff-1925cf4e42c0.png)

Jetzt wird ein neuer Mouse Position Control nur in der` setup()` Funktion gesetzt. Beim srs switchen event wird jetzt nur noch die Projektion upgedatet.