### PR TITLE
Fix/configurable print service classname

### DIFF
--- a/src/Mapbender/CoreBundle/Element/PrintClient.php
+++ b/src/Mapbender/CoreBundle/Element/PrintClient.php
@@ -211,7 +211,7 @@ class PrintClient extends Element
                     $data['legends'] = json_decode($data['legends'], true);
                 }
 
-                $printservice = new PrintService($this->container);
+                $printservice = $this->getPrintService();
 
                 $displayInline = true;
                 $filename = 'mapbender_print.pdf';
@@ -243,5 +243,15 @@ class PrintClient extends Element
 
                 return new JsonResponse($templates);
         }
+    }
+
+    /**
+     * @return PrintService
+     */
+    protected function getPrintService()
+    {
+        $container = $this->container;
+        $printServiceClassName = $container->getParameter('mapbender.print.service.class');
+        return new $printServiceClassName($container);
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -17,6 +17,8 @@
              Caching machinery can only be safely enabled after these cases have been adressed properly -->
         <parameter key="cachable.mapbender.application.config">false</parameter>
         <parameter key="mapbender.source.typedirectory.service.class">Mapbender\CoreBundle\Component\Source\TypeDirectoryService</parameter>
+        <parameter key="mapbender.print.service.class">Mapbender\PrintBundle\Component\PrintService</parameter>
+        <parameter key="mapbender.imageexport.service.class">Mapbender\PrintBundle\Component\ImageExportService</parameter>
     </parameters>
 
     <services>

--- a/src/Mapbender/PrintBundle/Command/RunJobCommand.php
+++ b/src/Mapbender/PrintBundle/Command/RunJobCommand.php
@@ -34,6 +34,16 @@ class RunJobCommand extends ContainerAwareCommand
     }
 
     /**
+     * @return PrintService
+     */
+    protected function getPrintService()
+    {
+        $container = $this->getContainer();
+        $printServiceClassName = $container->getParameter('mapbender.print.service.class');
+        return new $printServiceClassName($container);
+    }
+
+    /**
      * @inheritdoc
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -41,7 +51,7 @@ class RunJobCommand extends ContainerAwareCommand
         $jobArray = $this->getJobArray($input->getArgument('inputFile'));
 
         // PrintService::doPrint returns the PDF body as a binary string
-        $service = new PrintService($this->getContainer());
+        $service = $this->getPrintService();
         $outputBody = $service->doPrint($jobArray);
 
         $outputFileName= $input->getArgument('outputFile');

--- a/src/Mapbender/PrintBundle/Element/ImageExport.php
+++ b/src/Mapbender/PrintBundle/Element/ImageExport.php
@@ -109,9 +109,17 @@ class ImageExport extends Element
             case 'export':
                 $request = $this->container->get('request');
                 $data = $request->get('data');
-                $exportservice = new ImageExportService($this->container);
+                $exportservice = $this->getExportService();
                 $exportservice->export($data);
         }
     }
 
+    /**
+     * @return ImageExportService
+     */
+    protected function getExportService()
+    {
+        $exportServiceClassName = $this->container->getParameter('mapbender.imageexport.service.class');
+        return new $exportServiceClassName($this->container);
+    }
 }


### PR DESCRIPTION
First simple step to ease project customization.

Replaces `new PrintService(...)` and `new ImageExportService(...)` with class name lookups from container parameters  
`mapbender.print.service.class`  
`mapbender.imageexport.service.class`

=> you can plug other classes in your parameters.yml, no more need to adapt PrintClient Element et al.
