### PR TITLE
Fix/print with invalid sources

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -513,9 +513,37 @@
 
             if (lyrCount === 0){
                 Mapbender.info(Mapbender.trans('mb.core.printclient.info.noactivelayer'));
-            }else{
-                // we click a hidden submit button to check the required fields
-                form.find('input[type="submit"]').click();
+            } else {
+                var request = new XMLHttpRequest();
+                request.open('POST', url, true);
+                request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+                request.responseType = 'blob';
+
+                request.onload = function() {
+                    // Only handle status code 200
+                    if(request.status === 200) {
+                        // Try to find out the filename from the content disposition `filename` value
+
+                        var filename = 'mapbender3.pdf';
+
+                        // The actual download
+                        var blob = new Blob([request.response], { type: 'application/pdf' });
+                        var link = document.createElement('a');
+                        link.href = window.URL.createObjectURL(blob);
+                        link.download = filename;
+
+                        document.body.appendChild(link);
+
+                        link.click();
+
+                        setTimeout(function(){ document.body.removeChild(link); }, 2000);
+                    } else {
+                        // some error handling should be done here...
+
+                    }
+                };
+
+                request.send(form.serialize());
             }
 
             if(this.options.autoClose){

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -537,9 +537,6 @@
                         link.click();
 
                         setTimeout(function(){ document.body.removeChild(link); }, 2000);
-                    } else {
-                        // some error handling should be done here...
-
                     }
                 };
 

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -271,27 +271,29 @@ class PrintService extends ImageExportService
         foreach ($this->mapRequests as $i => $url) {
             $this->getLogger()->debug("Print Request Nr.: " . $i . ' ' . $url);
 
-            $mapRequestResponse = $this->mapRequest($url);
+            try {
+
+                $mapRequestResponse = $this->mapRequest($url);
+            } catch (\Exception $e) {
+                continue;
+            }
 
             $imageName    = $this->makeTempFile('mb_print');
-            $imageNames[] = $imageName;
             $rawImage = $this->serviceResponseToGdImage($imageName, $mapRequestResponse);
 
             if (!$rawImage) {
                 $logger->debug("ERROR! PrintRequest failed: " . $url);
                 $logger->debug($mapRequestResponse->getContent());
-                print_r('an error has occurred. see log for more details <br>');
-                print_r($mapRequestResponse->getContent());
-                foreach ($imageNames as $i => $imageName) {
-                    unlink($imageName);
-                }
-                exit;
+                continue;
             }
 
             if ($rawImage !== null) {
                 $this->forceToRgba($imageName, $rawImage, $this->data['layers'][$i]['opacity']);
             }
+
+            $imageNames[] = $imageName;
         }
+
         return $imageNames;
     }
 


### PR DESCRIPTION
Ticket https://github.com/mapbender/mapbender/issues/853. The print pdf request is made via xhttp instead of via form submitting now (refactoring). A new tab is not opened anymore.  Invalid layer urls and internal server side errors do not hinder the generation of the pdf document.
