### PR TITLE
Fix redlining dialog no second sketch #955

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -202,7 +202,7 @@
         },
         _removeAllFeatures: function(){
             $('.geometry-table tr', this.element).remove();
-            this.map.removeLayer(this.layer);
+            this.layer.removeAllFeatures();
         },
         _deactivateControl: function(){
             if(this.selectedFeature) {


### PR DESCRIPTION
This fixes #995. After the dialog is closed, only the layer's features are removed, not the layer itself.