### PR TITLE
Revert keyword data type back to string Fix #1000

### DIFF
--- a/src/Mapbender/CoreBundle/Entity/Keyword.php
+++ b/src/Mapbender/CoreBundle/Entity/Keyword.php
@@ -27,7 +27,7 @@ abstract class Keyword
 
     /**
      * @var string $title The source title
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", nullable=false)
      */
     protected $value;
 
@@ -49,6 +49,7 @@ abstract class Keyword
      */
     public function setValue($value)
     {
+        if (strlen($value) > 256) $value = substr($value, 0, 255);
         $this->value = $value;
 
         return $this;

--- a/src/Mapbender/CoreBundle/Entity/Keyword.php
+++ b/src/Mapbender/CoreBundle/Entity/Keyword.php
@@ -49,7 +49,7 @@ abstract class Keyword
      */
     public function setValue($value)
     {
-        if (mb_strlen($value) > 256) {
+        if (mb_strlen($value) > 255) {
             $value = mb_substr($value, 0, 255);
         }
         $this->value = $value;

--- a/src/Mapbender/CoreBundle/Entity/Keyword.php
+++ b/src/Mapbender/CoreBundle/Entity/Keyword.php
@@ -49,7 +49,9 @@ abstract class Keyword
      */
     public function setValue($value)
     {
-        if (strlen($value) > 256) $value = substr($value, 0, 255);
+        if (mb_strlen($value) > 256) {
+            $value = mb_substr($value, 0, 255);
+        }
         $this->value = $value;
 
         return $this;


### PR DESCRIPTION
Changed keyword data type back to string. If a source is configured to have a longer keyword list, it will now be cut off after 255 chars.