### PR TITLE
Skip empty layer names when collecting feature info QUERY_LAYERS value

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -401,7 +401,12 @@ Mapbender.Geo.SourceHandler = Class({
                 }
             }
             if (layer.options.treeOptions.info === true && layer.state.visibility) {
-                result.infolayers.push(layer.options[self.layerNameIdent]);
+                var layerName = layer.options[self.layerNameIdent];
+                // layer names can be emptyish, most commonly on root layers
+                // we will avoid appending an empty string to the list of queryable layers
+                if (layerName && layerName.length) {
+                    result.infolayers.push(layer.options[self.layerNameIdent]);
+                }
             }
             if (layer.children) {
                 for (var j = 0; j < layer.children.length; j++) {


### PR DESCRIPTION
Avoid sending FeatureInfo requests with empty layer names. This happens when collecting root or group layers for feature info, and triggers WMS errors.