### PR TITLE
Internalize mapbender versioning into mapbender repository

### DIFF
--- a/src/Mapbender/CoreBundle/Command/VersionCommand.php
+++ b/src/Mapbender/CoreBundle/Command/VersionCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Command;
+
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VersionCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('mapbender:version')
+            ->setHelp('Display Mapbender version')
+            // --version is taken by Symfony...
+            ->addOption('--number-only', null, InputOption::VALUE_NONE, 'Display only version (default: name and version)')
+            ->addOption('--name-only', null, InputOption::VALUE_NONE, 'Display only name (default: name and version)')
+            ->addOption('--project', null, InputOption::VALUE_NONE, 'Display project [name and] version instead of Mapbender [name and] version')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        if ($input->getOption('name-only') && $input->getOption('number-only')) {
+            throw new \InvalidArgumentException("Can't combine --name-only and --number-only");
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        if ($input->getOption('project')) {
+            $name = $this->getContainer()->getParameter('branding.project_name');
+            $version = $this->getContainer()->getParameter('branding.project_version');
+        } else {
+            $name = $this->getContainer()->getParameter('mapbender.branding.name');
+            $version = $this->getContainer()->getParameter('mapbender.version');
+        }
+        if ($input->getOption('name-only')) {
+            $output->writeln($name);
+        } elseif ($input->getOption('number-only')) {
+            $output->writeln($version);
+        } else {
+            $output->writeln("{$name} {$version}");
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
@@ -1,0 +1,156 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+
+use Mapbender\CoreBundle\Utils\ArrayUtil;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Mapbender knows its own version and branding.
+ *
+ * What Mapbender doesn't know is project branding and versioning.
+ *
+ * This pass detects and uses project branding, if present, to allow overrides of the default Mapbender branding.
+ * The result is written into the container and also into some legacy variables ('fom.server_version' et al, also
+ * a twig global) for backwards compatibility with old templates.
+ *
+ * The result is a hopefully happy conglomerate of (completely populated) container parameters:
+ * * mapbender.version          (set in CoreBundle/Resources/config/mapbender.yml)
+ * * mapbender.branding.name    (set in CoreBundle/Resources/config/mapbender.yml)
+ * * mabbender.branding.logo    (web-relative path; set in CoreBundle/Resources/config/mapbender.yml)
+ * * branding.project_name      (override in parameters.yml; defaults to %mapbender.branding.name% if empty)
+ * * branding.project_version   (override in parameters.yml; defaults to %mapbender.version% if empty)
+ * * branding.logo              (override in parameters.yml; defaults to %mapbender.branding.logo% if empty)
+ * * branding.favicon           (web-relative path; defaults to favicon.ico)
+ *
+ * Most frontend areas should display project branding to support customization.
+ *
+ * The mapbender.* paramters will remain available. They will mostly be useful for self-identification in debugging,
+ * logging and other internal machinery.
+ */
+class ProvideBrandingPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $name = $this->selectProjectName($container);
+        $version = $this->selectProjectVersion($container);
+        $logo = $this->selectLogo($container);
+        $container->setParameter('branding.project_name', $name);
+        $container->setParameter('branding.project_name', $version);
+        $container->setParameter('branding.logo', $logo);
+        $this->forwardSelectionToFom($container, $name, $version, $logo);
+    }
+
+    public static function selectProjectName(ContainerInterface $container)
+    {
+        // project wins, unless it's empty
+        if ($container->hasParameter('branding.project_name')) {
+            $projectValue = $container->getParameter('branding.project_name');
+            if ($projectValue) {
+                return $projectValue;
+            }
+        }
+        $mbName = $container->getParameter('mapbender.branding.name');
+        $fomOverrideName = ArrayUtil::getDefault(static::getFomParameter($container), 'server_name', null);
+        // disregard any historically used 'Mapbender' or 'Mapbender3' brandings from fom : server_name
+        if (empty($fomOverrideName) || preg_match('#^\s*mapbender\d?\s*$#', $fomOverrideName)) {
+            return $mbName;
+        } else {
+            // fom : server_name is sufficiently not "Mapbender"-ish, thus sufficiently likely to be a deliberately
+            //       chosen display string in the current project.
+            return $fomOverrideName;
+        }
+    }
+
+    public static function selectProjectVersion(ContainerInterface $container)
+    {
+        // project wins, unless it's empty
+        if ($container->hasParameter('branding.project_version')) {
+            $projectValue = $container->getParameter('branding.project_version');
+            if ($projectValue) {
+                return $projectValue;
+            }
+        }
+        $mbVersion = $container->getParameter('mapbender.version');
+        $fomOverrideVersion = ArrayUtil::getDefault(static::getFomParameter($container), 'server_version', null);
+        // disregard any historically used Mapbender versions (3.0.[<=7].[<=9] or "3.0pre2") from fom : server_version
+        if (empty($fomOverrideVersion) || preg_match('#^\s*3\.0((\.[0-7]\.\d)|(pre2))\s*$#', $fomOverrideVersion)) {
+            return $mbVersion;
+        } else {
+            return $fomOverrideVersion;
+        }
+    }
+
+    public static function selectLogo(ContainerInterface $container)
+    {
+        // project wins, unless it's empty
+        if ($container->hasParameter('branding.logo')) {
+            $projectValue = $container->getParameter('branding.logo');
+            if ($projectValue) {
+                return $projectValue;
+            }
+        }
+        $mbLogo = $container->getParameter('mapbender.branding.logo');
+        $fomOverrideLogo = ArrayUtil::getDefault(static::getFomParameter($container), 'server_logo', null);
+        $historicalLogos = array(
+            // these are all logo names ever referenced in parameters.yml.dist over the entire github
+            // history of mapbender-starter
+            // hint: git log -p parameters.yml.dist | grep -P '^[+-]\s*server_logo:' | awk '{print $3}' | sort -u
+            'bundles/mapbendercore/image/logo_mb3.png',
+            'bundles/mapbendercore/image/mapbender-logo.png',
+            'bundles/web/mapbendermanager/logo.png',
+        );
+
+        // disregard any historically used logos from fom : server_logo
+        if (empty($fomOverrideLogo) || in_array($fomOverrideLogo, $historicalLogos)) {
+            return $mbLogo;
+        } else {
+            return $fomOverrideLogo;
+        }
+    }
+
+    public static function forwardSelectionToFom(ContainerBuilder $container, $name, $version, $logo)
+    {
+        $fomParamReplacements = array(
+            'server_name' => $name,
+            'server_version' => $version,
+            'server_logo' => $logo,
+        );
+
+        $fomParam = $container->hasParameter('fom') ? $container->getParameter('fom') : array();
+        $mergedFomParam = array_replace($fomParam, $fomParamReplacements);
+        $container->setParameter('fom', $mergedFomParam);
+
+        // Forward to twig global; this mirrors legay Mapbender Starter config.yml, which adds the value of the 'fom'
+        // parameter as twig global 'fom' by expansion
+        // Because we just modified the 'fom' parameter, we must update the Twig global as well
+        $twigDefinition = $container->getDefinition('twig');
+        $twigMethodCalls = $twigDefinition->getMethodCalls();
+                $addGlobalMethodCallFound = false;
+        foreach ($twigMethodCalls as &$methodCall) {
+            /** @see \Twig_Environment::addGlobal() */
+            if ($methodCall[0] == 'addGlobal' && !empty($methodCall[1][0]) && $methodCall[1][0] == 'fom') {
+                $methodCall[1][1] = array_replace($methodCall[1][1], $mergedFomParam);
+                $twigDefinition->setMethodCalls($twigMethodCalls);
+                $addGlobalMethodCallFound = true;
+                break;
+            }
+        }
+        if (!$addGlobalMethodCallFound) {
+            // not added as twig global, but (still) required in many templates => add it
+            $twigDefinition->addMethodCall('addGlobal', array(
+                'fom',
+                $mergedFomParam,
+            ));
+        }
+    }
+
+    public static function getFomParameter(ContainerInterface $container, $default = array())
+    {
+        return $container->hasParameter('fom') ? $container->getParameter('fom') : $default;
+    }
+}

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
@@ -40,7 +40,7 @@ class ProvideBrandingPass implements CompilerPassInterface
         $version = $this->selectProjectVersion($container);
         $logo = $this->selectLogo($container);
         $container->setParameter('branding.project_name', $name);
-        $container->setParameter('branding.project_name', $version);
+        $container->setParameter('branding.project_version', $version);
         $container->setParameter('branding.logo', $logo);
         $this->forwardSelectionToFom($container, $name, $version, $logo);
     }

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php
@@ -121,7 +121,7 @@ class ProvideBrandingPass implements CompilerPassInterface
             'server_logo' => $logo,
         );
 
-        $fomParam = $container->hasParameter('fom') ? $container->getParameter('fom') : array();
+        $fomParam = static::getFomParameter($container);
         $mergedFomParam = array_replace($fomParam, $fomParamReplacements);
         $container->setParameter('fom', $mergedFomParam);
 
@@ -134,7 +134,7 @@ class ProvideBrandingPass implements CompilerPassInterface
         foreach ($twigMethodCalls as &$methodCall) {
             /** @see \Twig_Environment::addGlobal() */
             if ($methodCall[0] == 'addGlobal' && !empty($methodCall[1][0]) && $methodCall[1][0] == 'fom') {
-                $methodCall[1][1] = array_replace($methodCall[1][1], $mergedFomParam);
+                $methodCall[1][1] = array_replace($methodCall[1][1] ?: array(), $mergedFomParam);
                 $twigDefinition->setMethodCalls($twigMethodCalls);
                 $addGlobalMethodCallFound = true;
                 break;
@@ -151,6 +151,6 @@ class ProvideBrandingPass implements CompilerPassInterface
 
     public static function getFomParameter(ContainerInterface $container, $default = array())
     {
-        return $container->hasParameter('fom') ? $container->getParameter('fom') : $default;
+        return $container->hasParameter('fom') ? ($container->getParameter('fom') ?: $default) : $default;
     }
 }

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle;
 use Mapbender\CoreBundle\Component\MapbenderBundle;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\ContainerUpdateTimestampPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\MapbenderYamlCompilerPass;
+use Mapbender\CoreBundle\DependencyInjection\Compiler\ProvideBrandingPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -34,6 +35,7 @@ class MapbenderCoreBundle extends MapbenderBundle
                 $kernelPath . "/config/mapbender.yml")
         );
         $container->addCompilerPass(new ContainerUpdateTimestampPass());
+        $container->addCompilerPass(new ProvideBrandingPass());
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
@@ -16,3 +16,14 @@ parameters:
             published: true
             anonymous: true
             roles: [IS_AUTHENTICATED_ANONYMOUSLY]
+
+    mapbender.branding.name: Mapbender
+    mapbender.version: 3.0.7.4
+    mapbender.branding.logo: bundles/mapbendercore/image/logo_mb3.png
+    # These should all remain empty here, they are just for IDE search results.
+    # Customize these in your parameters.yml.
+    # The name will show up in page titles; the version will show in your backend;
+    # the logo will display on your login page, the backend again, and some of the application templates.
+    branding.project_name: ~
+    branding.project_version: ~
+    branding.logo: ~                # web-relative path


### PR DESCRIPTION
Branding, the everlasting joy of life.

This provides Mapbender-internal Mapbender versioning and naming, while still supporting explicit project branding overides.

A new compiler pass displaces [fom: server_version et al](https://github.com/mapbender/mapbender-starter/blob/644dbc24ece67d04bdd9dedcb8baf413d9cc5021/application/app/config/parameters.yml.dist#L20) as the authoritive source of the Mapbender version. Mapbender [gains version knowledge inside itself](https://github.com/mapbender/mapbender/blob/4e86c9f387ac9ee7e3e7737275c9fac29a8d5bce/src/Mapbender/CoreBundle/Resources/config/mapbender.yml#L20).

[Any `server_version` or `server_name` values configured in FOM that follow certain well-treaded patterns are dropped on the floor and replaced by Mapbender's own](https://github.com/mapbender/mapbender/blob/4e86c9f387ac9ee7e3e7737275c9fac29a8d5bce/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php#L80). If they deviate significantly from historic default values used in vanilla Github versions of Mapbender Starter, we treat them as desired project-specific overrides and leave them alone.

We also add new parameter keys for [direct project-specific overrides of name, version and logo](https://github.com/mapbender/mapbender/blob/4e86c9f387ac9ee7e3e7737275c9fac29a8d5bce/src/Mapbender/CoreBundle/DependencyInjection/Compiler/ProvideBrandingPass.php#L50). These will always win out, even if they happen to say "Mapbender3" "v3.0pre2" (which would be ignored if it appeared under fom : server_*).

Motivation: currently, git tags are the only hard source of Mapbender versioning information inside the actual Mapbender repository. `fom`: `server_*` is defined in another repository. This mandates parallel updates of multiple repositores at every versioning cycle and throws a wrench into introspection.

This pull obsoletes Mapbender version information in Mapbender Starter.  