### PR TITLE
Fix/print with invalid sources minimal

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -274,7 +274,6 @@ class PrintService extends ImageExportService
             $mapRequestResponse = $this->mapRequest($url);
 
             $imageName    = $this->makeTempFile('mb_print');
-            $imageNames[] = $imageName;
             $rawImage = $this->serviceResponseToGdImage($imageName, $mapRequestResponse);
 
             if (!$rawImage) {
@@ -282,10 +281,10 @@ class PrintService extends ImageExportService
                     'url' => $url,
                 ));
                 $logger->debug($mapRequestResponse->getContent());
+                unlink($imageName);
                 continue;
-            }
-
-            if ($rawImage !== null) {
+            } else {
+                $imageNames[] = $imageName;
                 $this->forceToRgba($imageName, $rawImage, $this->data['layers'][$i]['opacity']);
             }
         }

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -278,11 +278,10 @@ class PrintService extends ImageExportService
             $rawImage = $this->serviceResponseToGdImage($imageName, $mapRequestResponse);
 
             if (!$rawImage) {
-
-                $logger->debug("ERROR! PrintRequest failed: " . $url);
+                $logger->warning("Print request produced no valid image response, skipping layer", array(
+                    'url' => $url,
+                ));
                 $logger->debug($mapRequestResponse->getContent());
-                print_r('an error has occurred. see log for more details <br>');
-                print_r($mapRequestResponse->getContent());
                 continue;
             }
 

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -278,14 +278,12 @@ class PrintService extends ImageExportService
             $rawImage = $this->serviceResponseToGdImage($imageName, $mapRequestResponse);
 
             if (!$rawImage) {
+
                 $logger->debug("ERROR! PrintRequest failed: " . $url);
                 $logger->debug($mapRequestResponse->getContent());
                 print_r('an error has occurred. see log for more details <br>');
                 print_r($mapRequestResponse->getContent());
-                foreach ($imageNames as $i => $imageName) {
-                    unlink($imageName);
-                }
-                exit;
+                continue;
             }
 
             if ($rawImage !== null) {


### PR DESCRIPTION
This is the minified version of #987.  

#987 was rejected because it breaks HTML5 form validation and increases temp file leakage. This has been coordinated with @inacht (see conversation in other pull).

This one here only implements suppression of invalid WMS (etc) responses in print, while continuing and delivering the remaining, valid layers.  
Extra requirements from #853 are not implemented because there is currently no safe approach to side-channel text feedback into a simple pdf download route.  

For extended user feedback about things going wrong in print we suggest either
1. using a database job log queryable via separate url endpoint (not the main print url, which is expected to spit out a PDF)  
2. Tracking warning messages in the print job's state and, if populated, appending a page to the PDF that lists these warnings  
