### PR TITLE
Fix/buttons remember their targets

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Button.php
+++ b/src/Mapbender/CoreBundle/Element/Button.php
@@ -84,7 +84,7 @@ class Button extends Element
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/element/button.scss'));
     }
 
-    public function getPublicConfiguration()
+    public function getConfiguration()
     {
         $config = $this->entity->getConfiguration();
         if (!empty($config['click']) && 0 === strpos($config['click'], '#')) {
@@ -94,6 +94,11 @@ class Button extends Element
         } else {
             return $config;
         }
+    }
+
+    public function getFrontendTemplatePath($suffix = '.html.twig')
+    {
+        return "MapbenderCoreBundle:Element:button{$suffix}";
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Button.php
+++ b/src/Mapbender/CoreBundle/Element/Button.php
@@ -84,17 +84,16 @@ class Button extends Element
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/element/button.scss'));
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render()
+    public function getPublicConfiguration()
     {
-        return $this->container->get('templating')
-                ->render('MapbenderCoreBundle:Element:button.html.twig',
-                    array(
-                    'id' => $this->getId(),
-                    'title' => $this->getTitle(),
-                    'configuration' => $this->entity->getConfiguration()));
+        $config = $this->entity->getConfiguration();
+        if (!empty($config['click']) && 0 === strpos($config['click'], '#')) {
+            return array_replace($config, array(
+                'click' => null,
+            ));
+        } else {
+            return $config;
+        }
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Button.php
+++ b/src/Mapbender/CoreBundle/Element/Button.php
@@ -75,7 +75,7 @@ class Button extends Element
     /**
      * @inheritdoc
      */
-    static public function listAssets()
+    public function getAssets()
     {
         return array(
             'js' => array(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -112,33 +112,34 @@
                 return true;
             }
         },
+        /**
+         * Calls 'activate' method on target if defined, and if in group, sets a visual highlight
+         */
         activate: function () {
             this.active = true;
 
             if (this.options.target) {
                 this._callTarget(this.options.action || 'defaultAction', [this.reset.bind(this)]);
+
+            }
+            if (this.options.group) {
+                this.button.checked = true;
                 $(this.button).parent().addClass("toolBarItemActive");
             }
-            if (!this.options.group) {
-                this.deactivate();
-            } else {
-                this.button.checked = true;
-            }
         },
+        /**
+         * Clears visual highlighting, marks inactive state and
+         * calls 'deactivate' method on target (if defined)
+         */
         deactivate: function () {
-            $(this.button).parent().removeClass("toolBarItemActive");
+            this.reset();
             if (this.options.target && this.options.deactivate) {
                 this._callTarget(this.options.deactivate);
             }
-
-            if (this.active) {
-                this.active = false;
-            }
-
-            if (this.options.group) {
-                this.button.checked = false;
-            }
         },
+        /**
+         * Clears visual highlighting, marks inactive state
+         */
         reset: function () {
             $(this.button).parent().removeClass("toolBarItemActive");
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -11,8 +11,8 @@
         },
 
         active: false,
-        button : null,
         targetWidget: null,
+        $toolBarItem: null,
 
         _create: function () {
             if (this.options.click) {
@@ -24,7 +24,7 @@
             var self = this,
                 option = {};
 
-            this.button = this.element[0];
+            this.$toolBarItem = $(this.element).closest('.toolBarItem');
 
             if (this.options.icon) {
                 $.extend(option, {
@@ -35,11 +35,7 @@
                 });
             }
 
-            if (this.options.group) {
-                this.button.checked = false;
-            }
-
-            $(this.button)
+            $(this.element)
                 .on('click', $.proxy(self._onClick, self))
                 .on('mbButtonDeactivate', $.proxy(self.deactivate, self));
         },
@@ -49,8 +45,7 @@
 
             // If we're part of a group, deactivate all other actions in this group
             if (this.options.group) {
-                var others = $('input[type="checkbox"]')
-                    .filter('[name="mb-button-group[' + this.options.group + ']"]')
+                var others = $('.mb-button[data-group="' + this.options.group + '"]')
                     .not($me);
 
                 others.trigger('mbButtonDeactivate');
@@ -113,6 +108,9 @@
          * Calls 'activate' method on target if defined, and if in group, sets a visual highlight
          */
         activate: function () {
+            if (this.active) {
+                return;
+            }
             this.active = true;
 
             if (this.options.target) {
@@ -120,8 +118,7 @@
 
             }
             if (this.options.group) {
-                this.button.checked = true;
-                $(this.button).parent().addClass("toolBarItemActive");
+                this.$toolBarItem.addClass("toolBarItemActive");
             }
         },
         /**
@@ -138,15 +135,8 @@
          * Clears visual highlighting, marks inactive state
          */
         reset: function () {
-            $(this.button).parent().removeClass("toolBarItemActive");
-
-            if (this.active) {
-                this.active = false;
-            }
-
-            if (this.options.group) {
-                this.button.checked = false;
-            }
+            this.$toolBarItem.removeClass("toolBarItemActive");
+            this.active = false;
         }
     });
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -41,10 +41,6 @@
         _onClick: function () {
             var $me = $(this.element);
 
-            if (this.options.click && (this.options.click.length > 0) && (this.options.click.charAt(0) === '#')) {
-                return;
-            }
-
             if (this.options.click) {
                 window.open(this.options.click, '_blank');
                 return;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -15,6 +15,12 @@
         targetWidget: null,
 
         _create: function () {
+            if (this.options.click) {
+                // this widget instance is superfluous, we rendered a link
+                // we can't really deactivate mapbender.initElement machinery
+                // so we still need to load the JS asset, and we still end up right here
+                return;
+            }
             var self = this,
                 option = {};
 
@@ -40,11 +46,6 @@
 
         _onClick: function () {
             var $me = $(this.element);
-
-            if (this.options.click) {
-                window.open(this.options.click, '_blank');
-                return;
-            }
 
             // If we're part of a group, deactivate all other actions in this group
             if (this.options.group) {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -247,6 +247,9 @@ div.notifyjs-container > div.notifyjs-bootstrap-base > span{
       }
     }
   }
+  .toolBar a.mb-button {
+    color: inherit;
+  }
 }
 
 .popupContainer label {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -67,7 +67,7 @@
           }
         }
       }
-      > label, > span {
+      > label, > span, > a span {
         margin-bottom: 0;
         &:hover{
           &:before{

--- a/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
@@ -1,4 +1,6 @@
-{% if configuration.group is defined %}
+{% if configuration.click %}
+  <a target="_blank" class="mb-button" href="{{ configuration.click }}" title="{{ configuration.tooltip|default(title)|trans }}"><label id="{{ id }}" class="{% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</label></a>
+{% elseif configuration.group is defined %}
   <label for="{{ id }}" title="{{ configuration.tooltip|default(title)|trans }}" class="mb-button {% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</label><input type="checkbox" class="mb-hiddenCheckbox" name="mb-button-group[{{ configuration.group }}]" value="{{ id }}" id="{{ id }}"/>
 {% else %}
   <span id="{{ id }}" class="iconBig {% if configuration.icon is defined %} {{ configuration.icon }}{% endif %}" title="{{ configuration.tooltip|default(title)|trans }}">{% if configuration.label %}{{ title|trans }}{% endif %}</span>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
@@ -1,7 +1,5 @@
 {% if configuration.click %}
-  <a target="_blank" class="mb-button" href="{{ configuration.click }}" title="{{ configuration.tooltip|default(title)|trans }}"><label id="{{ id }}" class="{% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</label></a>
-{% elseif configuration.group is defined %}
-  <label for="{{ id }}" title="{{ configuration.tooltip|default(title)|trans }}" class="mb-button {% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</label><input type="checkbox" class="mb-hiddenCheckbox" name="mb-button-group[{{ configuration.group }}]" value="{{ id }}" id="{{ id }}"/>
-{% else %}
-  <span id="{{ id }}" class="iconBig {% if configuration.icon is defined %} {{ configuration.icon }}{% endif %}" title="{{ configuration.tooltip|default(title)|trans }}">{% if configuration.label %}{{ title|trans }}{% endif %}</span>
+  <a id="{{ id }}" target="_blank" class="mb-button" href="{{ configuration.click }}" title="{{ configuration.tooltip|default(title)|trans }}"><span class="{% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</span></a>
+{% else  %}
+  <span id="{{ id }}" data-exclusive-group="{{ configuration.group }}" title="{{ configuration.tooltip|default(title)|trans }}" class="mb-button {% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</span>
 {% endif %}


### PR DESCRIPTION
Fixes #1016 Issue 2 (repeat interaction with 'dialog'-type Element works as expected irrespective of DOM motion).

Fixes partial of #992 
> If the element is included as a dialog, then the sketch functions works until the window is closed. If, after closing the dialog window, the module is activated again via the button, the elements no longer appear in the map. The list in the dialog will continue to list all items, but you don’t see them.

Alleviates #571 
With this pull buttons are either links or element triggers, never both. For the link case ('click' configured) the JS asset is only loaded because Mapbender does not currently support Elements that have no widget constructor. Backend configuration still remains a unified, unvalidated conglomerate of everything.

Change summary:
Buttons identify their targets once, on first click, and reuse that information from then on.

Pull removes the completely unsafe implicit call to deactivate in activate, which served the single purpose of suppressing the visual highlight on non-grouped buttons, while breaking any reasonably designed target widget if a deactivate call was configured. New behaviour is to not highlight to begin with unless in group, and to separate highlighting from widget interaction. It is now safe to configure (or automatically configure) a 'deactivate' action whenever an 'activate' action is set, with no exceptions. This was not advisable before.

Pull renders links (configuration value 'click') as `<a href="..." target="_blank" ...`, removes link emulation Javascript.

Pull removes hidden checkboxes, which were bugged and caused problems for legitimate application of checkboxes in toolbars. [Suppression of checkbox rendering for ungrouped buttons](https://github.com/mapbender/mapbender/blob/v3.0.7.4/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig#L1) never worked to begin with; an empty string is still defined, in a Twig expression.
Screen readers should be supported by adding the relevant `aria-` attributes, not with hidden checkboxes with unreliable state.