### PR TITLE
Fix/asset symmetry css vs scss

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetCache.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetCache.php
@@ -36,7 +36,7 @@ class ApplicationAssetCache
      * ApplicationAssetCache constructor.
      *
      * @param ContainerInterface $container
-     * @param StringAsset[]      $inputs
+     * @param (string|StringAsset)[]      $inputs
      * @param                    $type
      * @param bool               $force
      */

--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetCache.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetCache.php
@@ -3,7 +3,6 @@
 namespace Mapbender\CoreBundle\Asset;
 
 use Assetic\Asset\AssetCollection;
-use Assetic\Asset\FileAsset;
 use Assetic\Asset\StringAsset;
 use Assetic\AssetManager;
 use Assetic\Cache\FilesystemCache;
@@ -16,11 +15,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @author Andriy Oblivantsev <andriy.oblivantsev@wheregroup.com>
  * @package Mapbender\CoreBundle\Asset
  */
-class ApplicationAssetCache
+class ApplicationAssetCache extends AssetFactoryBase
 {
-    /** @var ContainerInterface  */
-    protected $container;
-
     /** @var array|\Assetic\Asset\FileAsset[]|\Assetic\Asset\StringAsset[]  */
     protected $inputs;
 
@@ -42,7 +38,7 @@ class ApplicationAssetCache
      */
     public function __construct(ContainerInterface $container, $inputs, $type, $force = false)
     {
-        $this->container = $container;
+        parent::__construct($container);
         $this->inputs = $inputs;
         $this->type = $type;
         $this->targetPath = $this->getTargetPath();
@@ -60,12 +56,10 @@ class ApplicationAssetCache
 
         // For each asset build compiled, cached asset
         $assetRootPath = $this->getWebDir();
-        $assetTargetPath = $this->targetPath;
 
         $assets = new AssetCollection(array(), array(), $assetRootPath);
         $assets->setTargetPath($this->targetPath);
 
-        $locator = $this->container->get('file_locator');
         $manager = new AssetManager();
         $cache = new FilesystemCache($static_assets_cache_path);
         $devCache = new FilesystemCache($static_assets_cache_path . '/.dev-cache');
@@ -78,25 +72,8 @@ class ApplicationAssetCache
                 $manager->set($name, $input);
                 continue;
             }
+            $fileAsset = $this->makeFileAsset($input, $this->type);
 
-            // First, build file asset with filters and public path information
-            $sourcePath = $this->getSourcePath($input);
-            if ($sourcePath) {
-                $file = $locator->locate($sourcePath);
-            } else {
-                $file = $locator->locate($input);
-            }
-
-            // Build filter list (None for JS/Trans, Compass for SASS and Rewrite for SASS/CSS)
-            $filters = array();
-            if('css' === $this->type) {
-                if('scss' === pathinfo($file, PATHINFO_EXTENSION)) {
-                    $filters[] = $this->container->get('assetic.filter.compass');
-                }
-                $filters[] = $this->container->get('assetic.filter.cssrewrite');
-            }
-
-            $fileAsset = new FileAsset($file, $filters, null, $assetRootPath . '/' . $sourcePath);
             $fileAsset->setTargetPath($this->targetPath);
 
             $name = str_replace(array('@', 'Resources/public/'), '', $input);
@@ -112,7 +89,7 @@ class ApplicationAssetCache
             $needsCompiling = false;
 
             // SASS things need to be compiled.
-            if('scss' === pathinfo($file, PATHINFO_EXTENSION)) $needsCompiling = true;
+            if('scss' === pathinfo($fileAsset->getSourcePath(), PATHINFO_EXTENSION)) $needsCompiling = true;
 
             if($needsCompiling) {
                 if($isDevPlus) {
@@ -144,42 +121,28 @@ class ApplicationAssetCache
     /**
      * @return string
      */
-    protected function getWebDir()
-    {
-        return dirname($this->container->getParameter('kernel.root_dir')) . '/web';
-    }
-
-    /**
-     * @param $input
-     * @return string
-     */
-    protected function getSourcePath($input)
-    {
-        if ($input[0] == '@') {
-            // Bundle name
-            $bundle = substr($input, 1, strpos($input, '/') - 1);
-            // Path inside the Resources/public folder
-            $assetPath = substr($input,
-                strlen('@' . $bundle . '/Resources/public'));
-            $assetDir = 'bundles/' . preg_replace('/bundle$/', '', strtolower($bundle));
-
-            return $this->getSourcePath($assetDir . $assetPath);
-        } else {
-            $webRoot = $this->getWebDir();
-            $inWeb = $webRoot . '/' . ltrim($input, '/');
-            if (@is_file($inWeb) && @is_readable($inWeb)) {
-                return $inWeb;
-            }
-        }
-    }
-
-    /**
-     * @return string
-     */
     protected function getTargetPath()
     {
         $route = $this->container->get('router')->getRouteCollection()->get('mapbender_core_application_assets');
         $target = str_replace('\\', '/', realpath($this->container->get('kernel')->getRootDir() . '/../web/app.php')) . $route->getPath();
         return $target;
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $assetType one of 'js', 'css', 'trans'
+     * @return object[]
+     * @todo: figure out assetic filter base class
+     */
+    protected function getFilters($fileName, $assetType)
+    {
+        $filters = array();
+        if ('css' === $assetType) {
+            if ('scss' === pathinfo($fileName, PATHINFO_EXTENSION)) {
+                $filters[] = $this->container->get('assetic.filter.compass');
+            }
+            $filters[] = $this->container->get('assetic.filter.cssrewrite');
+        }
+        return $filters;
     }
 }

--- a/src/Mapbender/CoreBundle/Asset/AssetFactoryBase.php
+++ b/src/Mapbender/CoreBundle/Asset/AssetFactoryBase.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Asset;
+
+use Assetic\Asset\FileAsset;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class AssetFactoryBase
+{
+    /** @var ContainerInterface  */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $assetType one of 'js', 'css', 'trans'
+     * @return object[]
+     * @todo: figure out assetic filter base class
+     */
+    protected function getFilters($fileName, $assetType)
+    {
+        return array();
+    }
+
+    /**
+     * @param string $input reference to an asset file
+     * @param string $type
+     * @return FileAsset
+     */
+    protected function makeFileAsset($input, $type)
+    {
+        /** @var FileLocator $locator */
+        $locator = $this->container->get('file_locator');
+
+        $sourcePath = $this->getSourcePath($input);
+        if ($sourcePath) {
+            $file = $locator->locate($sourcePath);
+        } else {
+            $file = $locator->locate($input);
+        }
+        // Build filter list (None for JS/Trans, Compass for SASS and Rewrite for SASS/CSS)
+        $filters = $this->getFilters($file, $type);
+        $fileAsset = new FileAsset($file, $filters, null, null);
+
+        return $fileAsset;
+    }
+
+    /**
+     * @param $input
+     * @return string
+     */
+    protected function getSourcePath($input)
+    {
+        if ($input[0] == '@') {
+            // Bundle name
+            $bundle = substr($input, 1, strpos($input, '/') - 1);
+            // Path inside the Resources/public folder
+            $assetPath = substr($input,
+                strlen('@' . $bundle . '/Resources/public'));
+            $assetDir = 'bundles/' . preg_replace('/bundle$/', '', strtolower($bundle));
+
+            return $this->getSourcePath($assetDir . $assetPath);
+        } else {
+            $webRoot = $this->getWebDir();
+            $inWeb = $webRoot . '/' . ltrim($input, '/');
+            if (@is_file($inWeb) && @is_readable($inWeb)) {
+                return $inWeb;
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getWebDir()
+    {
+        return dirname($this->container->getParameter('kernel.root_dir')) . '/web';
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Acl\Permission\MaskBuilder;
  *
  * @author Christian Wygoda
  */
-class Application
+class Application implements IAssetDependent
 {
     /**
      * @var ContainerInterface $container The container
@@ -140,7 +140,7 @@ class Application
      *
      * @return array
      */
-    public static function listAssets()
+    public function getAssets()
     {
         return array(
             'js'    => array(
@@ -158,13 +158,13 @@ class Application
     }
 
     /**
-     * Get the assets as an AsseticCollection.
+     * Get the list of asset paths of the given type ('css', 'js', 'trans')
      * Filters can be applied later on with the ensureFilter method.
      *
-     * @param string $type Can be 'css' or 'js' to indicate which assets to dump
-     * @return array
+     * @param string $type use 'css' or 'js' or 'trans'
+     * @return string[]
      */
-    public function getAssets($type)
+    public function getAssetGroup($type)
     {
         if ($type !== 'css' && $type !== 'js' && $type !== 'trans') {
             throw new \RuntimeException('Asset type \'' . $type .
@@ -177,7 +177,7 @@ class Application
         $translations      = array();
         $layerTranslations = array();
         $templating        = $this->container->get('templating');
-        $_assets           = $this::listAssets();
+        $_assets           = $this->getAssets();
 
         foreach ($_assets[ $type ] as $asset) {
             $this->addAsset($assets, $type, $asset);

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -344,6 +344,7 @@ class Application implements IAssetDependent
      * and the filename/path within that bundles Resources/public folder.
      *
      * @todo: This is duplicated in DumpMapbenderAssetsCommand
+     * @todo: the AssetFactory should do the ref collection and Bundle => path resolution
      *
      * @param object $object
      * @param string $file

--- a/src/Mapbender/CoreBundle/Component/IAssetDependent.php
+++ b/src/Mapbender/CoreBundle/Component/IAssetDependent.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component;
+
+/**
+ * Common interface for classes (Elements, Applications, Templates) that require certain assets to function.
+ */
+interface IAssetDependent
+{
+    /**
+     * Get lists of paths to required assets.
+     *
+     * Return should be a 2D array with top-level keys 'js', 'css' and 'trans'.
+     * Each sub-array lists the required assets.
+     *
+     * A plain name is interpreted as local to the provider's bundle.
+     *
+     * Use bundle-style paths ('@MapbenderSomethingBundle/Resources/public/...') to reference assets from a different
+     * bundle. Use absolute paths ('/components/something/...') to reference a file in the web folder.
+     *
+     * @return string[][]
+     */
+    public function getAssets();
+}

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -99,6 +99,7 @@ class ApplicationController extends Controller
             if ($custom) {
                 $refs[] = $custom;
             }
+            /** @todo: use route to assets action, not REQUEST_URI, so this can move away from here */
             $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), empty($sourcePath) ? "." : $sourcePath);
             $content = $factory->compile();
         } else {

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -92,9 +92,9 @@ class ApplicationController extends Controller
         }
 
         $application = $this->getApplication($slug);
+        $refs = $application->getAssetGroup($type);
         if ($type == "css") {
             $sourcePath = $request->getBasePath();
-            $refs       = array_unique($application->getAssets('css'));
             $custom     = $application->getCustomCssAsset();
             if ($custom) {
                 $refs[] = $custom;
@@ -102,7 +102,7 @@ class ApplicationController extends Controller
             $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), empty($sourcePath) ? "." : $sourcePath);
             $content = $factory->compile();
         } else {
-            $cache   = new ApplicationAssetCache($this->container, $application->getAssets($type), $type);
+            $cache   = new ApplicationAssetCache($this->container, $refs, $type);
             $assets  = $cache->fill($slug, 0);
             $content = $assets->dump();
         }


### PR DESCRIPTION
Surgical cherry-pick of asset pipeline changes down from ol4 branch
Complete cherry-pick 15c1f9937747ee9c0d8e89019f976ec84be49aa6  
Partial cherry-pick  2417e8edb4b5682dbb1c897ae256c884f26ace78  
Complete cherry-pick b591052a81e50693e935e87d72bc8f94fc85fc5f  

Fixes #1017.

Web-relative CSS, SCSS and JS references by Elements now behave exactly the same way.
