### PR TITLE
Fix/customizable backend element popups

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/featureinfo.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/featureinfo.scss
@@ -20,7 +20,6 @@
 
 .featureinfoDialog {
   .popupContent {
-    margin-bottom: 0;
     height: 100%;
     .contentItem {
       height: 100%;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -18,7 +18,9 @@ $popupModalWidth:500px;
 $popupMaxHeight:370px;
 $inputHeight:28px;
 
-$elementPopupWidth: $popupModalWidth - ($space * 3);
+$elementPopupWidth: $popupModalWidth;
+$elementPopupBodyWidth: $elementPopupWidth - ($space * 3);
+$elementPopupHeight: 550px;
 //----------------------------------------------------------------colors
 $firstColor:#404040; // dark gray
 $secondColor:#858585; // middle gray

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_popup.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_popup.scss
@@ -14,7 +14,9 @@
 .popupSubTitle{@extend .labelInput;}
 .popupContent, .popupSubContent{
   padding:0 20px;
-  margin-bottom: $space;
+  &+.popupContent, &+.popupSubcontent {
+    margin-top: $space;
+  }
 }
 .popupSubContent{width: 100%; height: 100%;}
 .popup{

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -181,7 +181,6 @@
 
 .metadataDialog{
   .popupContent {
-    margin-bottom: 0px;
     height: 100%;
     .contentItem {
       height: 100%;

--- a/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
@@ -205,8 +205,6 @@ $(function() {
             subtitle: " - " + Mapbender.trans(self.parent().siblings(".subTitle").text()),
             closeOnOutsideClick: true,
             cssClass: "elementPopup",
-            height: 550,
-            width: 550,
             content: [
                 $.ajax({
                     url: self.attr("href"),
@@ -273,8 +271,7 @@ $(function() {
         popup = new Mapbender.Popup2({
             title: Mapbender.trans("mb.manager.components.popup.edit_element.title"),
             closeOnOutsideClick: true,
-            height: 550,
-            width: 550,
+            cssClass: "elementPopup",
             content: [
                 $.ajax({
                     url: self.attr("data-url"),

--- a/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
@@ -609,7 +609,7 @@ $(function() {
             title: Mapbender.trans("mb.manager.components.popup.add_instance.title"),
             subTitle: " - " + self.parent().siblings(".subTitle").text(),
             closeOnOutsideClick: true,
-            height: 400,
+            cssClass: 'new-instance-select',
             content: [
                 $.ajax({url: self.attr("href")})
             ],

--- a/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/application-edit.js
@@ -276,9 +276,7 @@ $(function() {
                 $.ajax({
                     url: self.attr("data-url"),
                     complete: function() {
-                        $(".popupContent").removeClass("popupContent")
-                                .addClass("popupSubContent")
-                                .find('form').submit(submitHandler);
+                        $(".popupContent").find('form').submit(submitHandler);
                     }
                 })
             ],

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/map.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/map.scss
@@ -8,7 +8,7 @@
   }
   .singleRow {
     float: right;
-    width: $elementPopupWidth - $label - $space;
+    width: $elementPopupBodyWidth - $label - $space;
     .labelInput, & > .input {
       float: left;
     }

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/yaml.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/yaml.scss
@@ -4,6 +4,6 @@
     width: $label;
   }
   .dropdown, .input {
-    min-width: $elementPopupWidth - $label;
+    min-width: $elementPopupBodyWidth - $label - $space;
   }
 }

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
@@ -160,7 +160,14 @@
     color:lighten($darkFontColor, 10%);
   }
 }
-.elementPopup{width:$popupModalWidth;}
+.elementPopup {
+  width: $elementPopupWidth;
+  min-width: $popupModalWidth;
+  min-height: $elementPopupHeight;
+  .popupContent, .popupSubContent {
+    min-width: $elementPopupBodyWidth;
+  }
+}
 
 
 

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
@@ -169,7 +169,12 @@
   }
 }
 
-
+.popup.new-instance-select {
+  min-width: max($popupModalWidth, $elementPopupWidth);
+  min-height: $elementPopupHeight;
+  height: 80%;
+  width: 70%;
+}
 
 
 


### PR DESCRIPTION
Replaces [JavaScript-level hardcoded element popup sizes in the backend](https://github.com/mapbender/mapbender/commit/7fc82398a3a600a31900e34fd1cb15265cfeb634#diff-72433539832102ac198119358e5e88bdL208) with css, from [variables](https://github.com/mapbender/mapbender/commit/7fc82398a3a600a31900e34fd1cb15265cfeb634#diff-15dee3fc96f071979800ead67aedfc0fR21).

[Replaces JavaScript-level hardcoded "new instance" popup sizing with CSS](https://github.com/mapbender/mapbender/pull/1022/commits/e2a4948ceca34422fbcfd9d9644aab9382d2300a), using a percentage rule.

[Replaces various anti-bottom-margin workaround hacks with a follower rule](https://github.com/mapbender/mapbender/commit/48c889a4bac0f7f0d36c022e88a0a0feb4ef7698). Popup bodies no longer overflow into a scroll unless their content size warrants it.

Should resolve [#632](https://github.com/mapbender/mapbender/issues/632) and offer improved project customizability without needing further code pulls.
