### PR TITLE
Fix in-place layerSet and child layer order reversals

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -210,11 +210,9 @@
          */
         _getSubLayers: function(source, layer, level, children) {
             var widget = this;
-            if(layer.children) {
-                _.chain(layer.children).reverse().each(function(childLayer) {
-                    children = children.concat(widget._getSubLayer(source, childLayer, "wms", level, []));
-                });
-            }
+            (layer.children || []).map(function(childLayer) {
+                children = children.concat(widget._getSubLayer(source, childLayer, "wms", level, []));
+            });
             return children;
         },
 
@@ -269,7 +267,7 @@
                 }
 
                 var childrenLegend = false;
-                _.chain(sublayer.children).reverse().each(function(subLayerChild) {
+                _.chain(sublayer.children).each(function(subLayerChild) {
                     var legendLayer = widget.getLegend(subLayerChild, widget.options.generateLegendGraphicUrl);
                     var hasLegendUrl = legendLayer && legendLayer.url;
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
@@ -47,7 +47,7 @@
 
             element.addClass(options.anchor);
 
-            $.each(layerSet.reverse(), function(idx, item) {
+            $.each(layerSet, function(idx, item) {
                 $.each(item, function(idx2, layerDef) {
                     if(layerDef.type !== "wms") {
                         return;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -207,11 +207,14 @@ Mapbender.Model = {
             this.map.olMap.events.register('movestart', this, $.proxy(this._preCheckChanges, this));
 
             this.map.olMap.events.register('moveend', this, $.proxy(this._checkChanges, this));
-            $.each(this.mbMap.options.layersets.reverse(), function(idx, layersetId) {
+            // Array.protoype.reverse is in-place
+            // see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse
+            // Do not use .reverse on centrally shared values without making your own copy
+            $.each(this.mbMap.options.layersets.slice().reverse(), function(idx, layersetId) {
                 if(!Mapbender.configuration.layersets[layersetId]) {
                     return;
                 }
-                $.each(Mapbender.configuration.layersets[layersetId].reverse(), function(lsidx, defArr) {
+                $.each(Mapbender.configuration.layersets[layersetId].slice().reverse(), function(lsidx, defArr) {
                     $.each(defArr, function(idx, layerDef) {
                         layerDef['origId'] = idx;
                         self.addSource({


### PR DESCRIPTION
Fixes #1024 

Ordering of source layers, per-source layer requests, source and sublayer display in Llayertertree, source and sublayer display in Legend no longer depend on any other Element being present or not in the application.

Collateral: order of legends within a source group now matches layertree display order ("high layer" first, "base layer" last).