### PR TITLE
Fix/reduce deprecated framework usages

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -2,7 +2,7 @@
 namespace Mapbender\CoreBundle\Component;
 
 use Assetic\Asset\StringAsset;
-use Doctrine\ORM\PersistentCollection;
+use Doctrine\Common\Persistence\ObjectRepository;
 use Mapbender\CoreBundle\Component\Element as ElementComponent;
 use Mapbender\CoreBundle\Component\Presenter\Application\ConfigService;
 use Mapbender\CoreBundle\Entity\Application as Entity;
@@ -460,11 +460,12 @@ class Application
         } else {
             $count = 0;
         }
+        /** @var ObjectRepository $rep */
         $rep = $container->get('doctrine')->getRepository('MapbenderCoreBundle:Application');
         do {
             $copySlug = $slug . "_" . $suffix . ($count > 0 ? '_' . $count : '');
             $count++;
-        } while ($rep->findOneBySlug($copySlug));
+        } while ($rep->findOneBy(array('slug' => $copySlug)));
         return $copySlug;
     }
 

--- a/src/Mapbender/CoreBundle/DataFixtures/ORM/Epsg/LoadEpsgData.php
+++ b/src/Mapbender/CoreBundle/DataFixtures/ORM/Epsg/LoadEpsgData.php
@@ -34,7 +34,7 @@ class LoadEpsgData implements FixtureInterface
             if ($temp[0] === null || strlen($temp[0]) === 0) {
                 continue;
             }
-            $srs = $repo->findOneByName($temp[0]);
+            $srs = $repo->findOneBy(array('name' => $temp[0]));
             if ($srs) {
                 $srs->setTitle($temp[1]);
                 $srs->setDefinition($temp[2]);

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -22,6 +22,7 @@ use Mapbender\ManagerBundle\Form\Type\ApplicationType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -430,16 +431,11 @@ class ApplicationController extends WelcomeController
                 break;
         }
 
-        return new Response(
-            json_encode(
-                array(
-                'oldState' => $currentState ? 'enabled' : 'disabled',
-                'newState' => $newState ? 'enabled' : 'disabled',
-                'message' => $message)
-            ),
-            200,
-            array('Content-Type' => 'application/json')
-        );
+        return new JsonResponse(array(
+            'oldState' => $currentState ? 'enabled' : 'disabled',
+            'newState' => $newState ? 'enabled' : 'disabled',
+            'message' => $message
+        ));
     }
 
     /**

--- a/src/Mapbender/ManagerBundle/Controller/ElementController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ElementController.php
@@ -176,7 +176,7 @@ class ElementController extends Controller
 
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->find($id);
 
         if (!$element) {
             throw $this->createNotFoundException('The element with the id "'
@@ -257,7 +257,7 @@ class ElementController extends Controller
         $doctrine          = $this->getDoctrine();
         $entityManager     = $doctrine->getManager();
         $elementRepository = $doctrine->getRepository('MapbenderCoreBundle:Element');
-        $element           = $elementRepository->findOneById($id);
+        $element           = $elementRepository->find($id);
 
         if (!$element) {
             throw $this->createNotFoundException("The element with the id \"$id\" does not exist.");
@@ -309,11 +309,9 @@ class ElementController extends Controller
      */
     public function confirmDeleteAction($slug, $id)
     {
-        $application = $this->get('mapbender')->getApplicationEntity($slug);
-
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->find($id);
 
         if (!$element) {
             throw $this->createNotFoundException('The element with the id "'
@@ -337,7 +335,7 @@ class ElementController extends Controller
 
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->find($id);
 
         if (!$element) {
             throw $this->createNotFoundException('The element with the id "'
@@ -382,7 +380,7 @@ class ElementController extends Controller
     {
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->find($id);
 
         if (!$element) {
             throw $this->createNotFoundException('The element with the id "'
@@ -500,7 +498,7 @@ class ElementController extends Controller
     {
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->find($id);
 
         $enabled = $this->get("request")->get("enabled");
         if (!$element) {

--- a/src/Mapbender/ManagerBundle/Controller/ElementController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ElementController.php
@@ -3,16 +3,15 @@ namespace Mapbender\ManagerBundle\Controller;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use FOM\ManagerBundle\Configuration\Route as ManagerRoute;
 use Mapbender\CoreBundle\Component\Application as ApplicationComponent;
 use Mapbender\CoreBundle\Component\Element as ComponentElement;
-use Mapbender\CoreBundle\Component\SecurityContext;
 use Mapbender\CoreBundle\Entity\Element;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -390,10 +389,10 @@ class ElementController extends Controller
         $newregion = $this->get("request")->get("region");
         if (intval($number) === $element->getWeight() && $element->getRegion() ===
             $newregion) {
-            return new Response(json_encode(array(
-                    'error' => '',
-                    'result' => 'ok')), 200,
-                array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                'error' => '',      // why?
+                'result' => 'ok',   // why?
+            ));
         }
         if ($element->getRegion() === $newregion) {
             $em = $this->getDoctrine()->getManager();
@@ -481,11 +480,10 @@ class ElementController extends Controller
             $em->persist($application);
             $em->flush();
         }
-        return new Response(json_encode(array(
-                'error' => '',
-                'result' => 'ok')), 200,
-            array(
-            'Content-Type' => 'application/json'));
+        return new JsonResponse(array(
+            'error' => '',      // why?
+            'result' => 'ok',   // why?
+        ));
     }
 
     /**
@@ -502,9 +500,11 @@ class ElementController extends Controller
 
         $enabled = $this->get("request")->get("enabled");
         if (!$element) {
-            return new Response(json_encode(array(
-                    'error' => 'An element with the id "' . $id . '" does not exist.')),
-                200, array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                /** @todo: use http status codes to communicate error conditions */
+                'error' => 'An element with the id "' . $id . '" does not exist.',
+            ));
+
         } else {
             $enabled_before = $element->getEnabled();
             $enabled = $enabled === "true" ? true : false;
@@ -513,14 +513,16 @@ class ElementController extends Controller
             $em->persist($element->getApplication()->setUpdated(new \DateTime('now')));
             $em->persist($element);
             $em->flush();
-            return new Response(json_encode(array(
-                    'success' => array(
-                        "id" => $element->getId(),
-                        "type" => "element",
-                        "enabled" => array(
-                            'before' => $enabled_before,
-                            'after' => $enabled)))), 200,
-                array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                'success' => array(         // why?
+                    "id" => $element->getId(),
+                    "type" => "element",
+                    "enabled" => array(
+                        'before' => $enabled_before,
+                        'after' => $enabled,
+                    ),
+                ),
+            ));
         }
     }
 

--- a/src/Mapbender/ManagerBundle/Controller/ElementController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ElementController.php
@@ -9,15 +9,11 @@ use Mapbender\CoreBundle\Component\Application as ApplicationComponent;
 use Mapbender\CoreBundle\Component\Element as ComponentElement;
 use Mapbender\CoreBundle\Component\SecurityContext;
 use Mapbender\CoreBundle\Entity\Element;
-use Mapbender\CoreBundle\Form\Type\BaseElementType;
-use Mapbender\CoreBundle\Validator\Constraints\ContainsElementTarget;
-use Mapbender\CoreBundle\Validator\Constraints\ContainsElementTargetValidator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Acl\Domain\Acl;
 
 /**
  * Class ElementController
@@ -205,10 +201,10 @@ class ElementController extends Controller
     public function updateAction($slug, $id)
     {
         $application = $this->get('mapbender')->getApplicationEntity($slug);
-
+        /** @var Element $element */
         $element = $this->getDoctrine()
             ->getRepository('MapbenderCoreBundle:Element')
-            ->findOneById($id);
+            ->findOneBy(array('id' => $id));
 
         if (!$element) {
             throw $this->createNotFoundException('The element with the id "'
@@ -228,6 +224,7 @@ class ElementController extends Controller
 
             $entity_class = $element->getClass();
             $appl = new ApplicationComponent($this->container, $application);
+            /** @var ComponentElement $elComp */
             $elComp = new $entity_class($appl, $this->container, $element);
             $elComp->postSave();
             $this->get('session')->getFlashBag()->set('success',

--- a/src/Mapbender/ManagerBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/ManagerBundle/Controller/RepositoryController.php
@@ -5,7 +5,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use FOM\ManagerBundle\Configuration\Route as ManagerRoute;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 
 /**
@@ -237,9 +237,10 @@ class RepositoryController extends Controller
             throw $this->createNotFoundException('The source instance id:"' . $instanceId . '" does not exist.');
         }
         if (intval($number) === $instance->getWeight() && $layersetId === $layersetId_new) {
-            return new Response(json_encode(array(
-                    'error' => '',
-                    'result' => 'ok')), 200, array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                'error' => '',      // why?
+                'result' => 'ok',   // why?
+            ));
         }
 
         if ($layersetId === $layersetId_new) {
@@ -330,10 +331,10 @@ class RepositoryController extends Controller
             }
         }
 
-        return new Response(json_encode(array(
-                'error' => '',
-                'result' => 'ok')), 200, array(
-            'Content-Type' => 'application/json'));
+        return new JsonResponse(array(
+            'error' => '',      // why?
+            'result' => 'ok',   // why?
+        ));
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -18,6 +18,7 @@ use Mapbender\WmsBundle\Form\Type\WmsSourceSimpleType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -380,15 +381,18 @@ class RepositoryController extends Controller
         $instLay = $this->loadEntityByPk('MapbenderWmsBundle:WmsInstanceLayer', $instLayerId);
 
         if (!$instLay) {
-            return new Response(json_encode(array(
-                    'error' => 'The wms instance layer with'
+            return new JsonResponse(array(
+                /** @todo: use http status codes to communicate error conditions */
+                'error' => 'The wms instance layer with'
                     .' the id "'.$instanceId.'" does not exist.',
-                    'result' => '')), 200, array('Content-Type' => 'application/json'));
+                'result' => '',     // why?
+            ));
         }
         if (intval($number) === $instLay->getPriority()) {
-            return new Response(json_encode(array(
-                    'error' => '',
-                    'result' => 'ok')), 200, array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                'error' => '',      // why?
+                'result' => 'ok',   // why?
+            ));
         }
         $em       = $this->getDoctrine()->getManager();
         $instLay->setPriority($number);
@@ -429,10 +433,10 @@ class RepositoryController extends Controller
         $wmsinsthandler->save();
         $em->flush();
         $em->getConnection()->commit();
-        return new Response(json_encode(array(
-                'error' => '',
-                'result' => 'ok')), 200, array(
-            'Content-Type' => 'application/json'));
+        return new JsonResponse(array(
+            'error' => '',      // why?
+            'result' => 'ok',   // why?
+        ));
     }
 
     /**
@@ -446,11 +450,10 @@ class RepositoryController extends Controller
         $enabled     = $this->getRequest()->get("enabled");
         $wmsinstance = $this->loadEntityByPk("MapbenderWmsBundle:WmsInstance", $instanceId);
         if (!$wmsinstance) {
-            return new Response(
-                json_encode(array('error' => 'The wms instance with the id "'.$instanceId.'" does not exist.')),
-                200,
-                array('Content-Type' => 'application/json')
-            );
+            return new JsonResponse(array(
+                /** @todo: use http status codes to communicate error conditions */
+                'error' => 'The wms instance with the id "'.$instanceId.'" does not exist.',
+            ));
         } else {
             $enabled_before = $wmsinstance->getEnabled();
             $enabled        = $enabled === "true";
@@ -459,13 +462,16 @@ class RepositoryController extends Controller
                 $wmsinstance->getLayerSet()->getApplication()->setUpdated(new \DateTime('now')));
             $this->getDoctrine()->getManager()->persist($wmsinstance);
             $this->getDoctrine()->getManager()->flush();
-            return new Response(json_encode(array(
-                    'success' => array(
-                        "id" => $wmsinstance->getId(),
-                        "type" => "instance",
-                        "enabled" => array(
-                            'before' => $enabled_before,
-                            'after' => $enabled)))), 200, array('Content-Type' => 'application/json'));
+            return new JsonResponse(array(
+                'success' => array(         // why?
+                    "id" => $wmsinstance->getId(),
+                    "type" => "instance",
+                    "enabled" => array(
+                        'before' => $enabled_before,
+                        'after' => $enabled,
+                    ),
+                ),
+            ));
         }
     }
 


### PR DESCRIPTION
This is further prep work to get ready for Symfony 3.0+

Pull replaces various homegrown accesses to security machinery from Controller scopes with invocations to Symfony's Controller (base) class's built-in methods `getUser`, `isGranted`, but mostly `denyAccessUnlessGranted`. See [New in Symfony 2.6: New shortcut methods for controllers](https://symfony.com/blog/new-in-symfony-2-6-new-shortcut-methods-for-controllers).

Pull replaces various copy&paste jobs of [Symfony Controller's forward methd (since at least 2.3)](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php#L53) with invocations of that same built-in forward method.

Pull removes PHP magic [__call invocations on ObjectRepository instances](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityRepository.php#L163) with non-magic calls for introspectability. E.g. `findOneBySlug('ham')` becomes `findOneBy(array('slug' => 'ham'))`.

Pull replaces homegrown json response construction with framework's built-in JsonResponse. This class [has existed at least since Symfony 2.3](https://api.symfony.com/2.3/Symfony/Component/HttpFoundation/JsonResponse.html) and [works around various PHP json_encode behavior shenanigans](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/HttpFoundation/JsonResponse.php#L113) in ways that we should never attempt to replicate ourselves.