### PR TITLE
Remove readyCallback handling from all Elements where it is dysfunctional

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.copyright.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.copyright.js
@@ -62,18 +62,12 @@
         ready: function(callback) {
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -524,18 +524,12 @@
         ready: function(callback) {
             if (this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for (callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -1155,18 +1155,12 @@
         ready: function(callback) {
             if (this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for (callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -14,7 +14,7 @@
         model: null,
         map: null,
         readyState: false,
-        readyCallbacks: [],
+
         /**
          * Creates the map widget
          */
@@ -258,18 +258,12 @@
         ready: function(callback){
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
@@ -221,8 +221,6 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
 
@@ -233,10 +231,6 @@
             var widget = this;
             widget._trigger('ready');
 
-            for (var callback in widget.readyCallbacks) {
-                callback();
-                delete(widget.readyCallbacks[callback]);
-            }
             widget.readyState = true;
         }
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -623,18 +623,12 @@
         ready: function(callback) {
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -332,18 +332,12 @@
         ready: function(callback){
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
@@ -225,18 +225,12 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scalebar.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scalebar.js
@@ -61,18 +61,12 @@
         ready: function(callback) {
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaledisplay.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaledisplay.js
@@ -67,18 +67,12 @@
         ready: function(callback) {
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
         

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
@@ -14,12 +14,6 @@
         searchModel: null,
         autocompleteModel: null,
         popup: null,
-        /**
-         * Ready event listeners
-         *
-         * @var {Array<Function>}
-         */
-        readyCallbacks: [],
 
         /**
          * Widget creator
@@ -652,8 +646,6 @@
             var widget = this;
             if(widget.readyState === true){
                 callback();
-            }else{
-                widget.readyCallbacks.push(callback);
             }
         },
 
@@ -662,12 +654,6 @@
          */
         _ready: function() {
             var widget = this;
-                for (var callback in widget.readyCallbacks) {
-                    if(widget.readyCallbacks.hasOwnProperty(callback)) {
-                        callback();
-                        delete(widget.readyCallbacks[callback]);
-                    }
-            }
             widget.readyState = true;
         },
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.sketch.js
@@ -186,15 +186,9 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         _ready: function(){
-            for(callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.srsselector.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.srsselector.js
@@ -236,18 +236,12 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(var callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.zoombar.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.zoombar.js
@@ -215,18 +215,12 @@ $.widget("mapbender.mbZoomBar", {
         ready: function(callback) {
             if(this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function() {
-            for(callback in this.readyCallbacks) {
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         }
 });

--- a/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
@@ -81,18 +81,12 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _exportImage: function(){

--- a/src/Mapbender/WmcBundle/Resources/public/mapbender.element.wmcloader.js
+++ b/src/Mapbender/WmcBundle/Resources/public/mapbender.element.wmcloader.js
@@ -250,18 +250,12 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         /**
          *
          */
         _ready: function(){
-            for(callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.dimensionshandler.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.dimensionshandler.js
@@ -51,16 +51,10 @@
         ready: function (callback) {
             if (this.readyState === true) {
                 callback();
-            } else {
-                this.readyCallbacks.push(callback);
             }
         },
         _ready: function() {
-        for (callback in this.readyCallbacks) {
-        callback();
-            delete(this.readyCallbacks[callback]);
-        }
-        this.readyState = true;
+            this.readyState = true;
         },
         _destroy: $.noop
     });

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -216,15 +216,9 @@
         ready: function(callback){
             if(this.readyState === true){
                 callback();
-            }else{
-                this.readyCallbacks.push(callback);
             }
         },
         _ready: function(){
-            for(callback in this.readyCallbacks){
-                callback();
-                delete(this.readyCallbacks[callback]);
-            }
             this.readyState = true;
         },
         _destroy: $.noop


### PR DESCRIPTION
Many many many Element frontend scripts have adopted a [completely dysfunctional `readyCallback` processing machinery](https://github.com/mapbender/mapbender/blob/v3.0.7.4/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js#L255).

These Elements can only successfully initialize if nobody registers a ready callback through this machinery before they finish initializing. If there is at least one deferred callback, these Elements will attempt to invoke an integer (the list index of the readyCallbacks) as a function and fail to flag themselves ready.

As per Chrome console:
```
> var cbs = [function() { console.log("Hello I am a callback"); }, function() { console.log("I am a second callback"); }];
< undefined
> for (callback in cbs) { callback(); }
< Uncaught TypeError: callback is not a function
    at <anonymous>:1:25

> for (callback in cbs) { console.log(callback); }
< 0
< 1
< undefined
```

Because they can only initialize if there are no deferred callbacks, it's safe to assume that in any currently working application, this mechanism is not used on these Elements. For this reason, deferred callback registration has not been fixed on these Elements, but has been removed entirely.

Self-managed element ready callbacks are a long-deprecated legacy mechanism. Modernish Elements should let [the ElementRegistry](https://github.com/mapbender/mapbender/blob/release/3.0.7/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js#L9) handle this.