### PR TITLE
Add new (dormant) compiler pass that can modify default form themes

### DIFF
--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RewriteFormThemeCompilerPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RewriteFormThemeCompilerPass.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RewriteFormThemeCompilerPass implements CompilerPassInterface
+{
+    /** @var string, twig template reference */
+    protected $fromTheme;
+    /** @var string, twig template reference */
+    protected $toTheme;
+
+    public function __construct($fromTheme, $toTheme)
+    {
+        $this->fromTheme = $fromTheme;
+        $this->toTheme = $toTheme;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->patchTwigThemes($container, $this->fromTheme, $this->toTheme);
+        $this->patchResourceReferenceArray($container, 'twig.form.resources', $this->fromTheme, $this->toTheme);
+    }
+
+    public static function patchTwigThemes(ContainerBuilder $container, $from, $to)
+    {
+        $definition = $container->getDefinition('twig');
+        $initializer = $definition->getArgument(1);
+        if (array_key_exists('form_themes', $initializer)) {
+            $themeConfig = &$initializer['form_themes'];
+            foreach (array_keys($themeConfig) as $index) {
+                if ($themeConfig[$index] === $from) {
+                    $themeConfig[$index] = $to;
+                }
+            }
+            $initializer['form_themes'] = $themeConfig;
+        }
+        $definition->replaceArgument(1, $initializer);
+    }
+
+    public static function patchResourceReferenceArray(ContainerBuilder $container, $parameterKey, $from, $to)
+    {
+        $parameterValue = $container->getParameter($parameterKey);
+        foreach (array_keys($parameterValue) as $index) {
+            if ($parameterValue[$index] == $from) {
+                $parameterValue[$index] = $to;
+            }
+        }
+        $container->setParameter($parameterKey, $parameterValue);
+    }
+}


### PR DESCRIPTION
Pull adds a compiler pass _class_ that can rewrite the default form theme(s). Pass accepts `from`, `to` constructor arguments.  
Pull _does_ _not_ engage this compiler pass in any way.  

This is intended to
* allow Mapbender core to wrestle control over default form theming away from FOM and Mapbender Starter; the main issue here is that rolling out theming fixes across _three_ repositories in a concerted fashion is complex and error prone
* improve project ability to model global theming changes as bundles


Example usage:  
Place into any Bundle class's `build` method (MapbenderCoreBundle works fine):
```php
$container->addCompilerPass(new RewriteFormThemeCompilerPass('FOMCoreBundle:Form:fields.html.twig', 'bootstrap_3_layout.html.twig'));
```

This makes every form in the entire Mapbender backend render in Bootstrap 3 theme. There are some layouting quirks with "extended collections", "region properties" etc. So this is not recommended for general use. It just proves that the replacement method works on a base level.