### PR TITLE
Fix/printservice cleanups

### DIFF
--- a/src/Mapbender/PrintBundle/Component/Export/Affine2DTransform.php
+++ b/src/Mapbender/PrintBundle/Component/Export/Affine2DTransform.php
@@ -1,0 +1,79 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Export;
+
+
+/**
+ * Transformation implementation for 2D coordinates using a 3x2 matrix.
+ *
+ * Currently only exposes box-to-box (translate and scale) construction.
+ *
+ * @todo: Export / print quality might benefit if we offer rotation here
+ *        but the current code does not rotate geometry. Features are
+ *        rotated after rasterization, along with the other raster layers.
+ */
+class Affine2DTransform
+{
+    /**
+     * @var float[][] 3x2 matrix
+     */
+    protected $rows;
+
+    /**
+     * @param float[][] $matrixRows
+     */
+    protected function __construct($matrixRows)
+    {
+        $this->rows = $matrixRows;
+    }
+
+    /**
+     * Construct planar box-to-box scaling and translation transformation.
+     * @param Box $from
+     * @param Box $to
+     * @return Affine2DTransform
+     */
+    public static function boxToBox(Box $from, Box $to)
+    {
+        return new static(array(
+            array(
+                $to->getWidth() / $from->getWidth(),
+                0.0,
+                ($to->left - $from->left * $to->getWidth() / $from->getWidth()),
+            ),
+            array(
+                0.0,
+                $to->getHeight() / $from->getHeight(),
+                ($to->bottom - $from->bottom * $to->getHeight() / $from->getHeight()),
+            ),
+        ));
+    }
+
+    /**
+     * @param float[] $pair numerically indexed; x at index 0, y at index 1
+     * @return float[] numerically indexed, same as input (x at index 0, y at index 1)
+     */
+    public function transformPair(array $pair)
+    {
+        // straight 2d vector x matrix
+        return array(
+            $pair[0] * $this->rows[0][0] + $pair[1] * $this->rows[0][1] + 1.0 * $this->rows[0][2],
+            $pair[0] * $this->rows[1][0] + $pair[1] * $this->rows[1][1] + 1.0 * $this->rows[1][2],
+        );
+    }
+
+    /**
+     * @param float[] $p with entries 'x' and 'y'
+     * @return float[] 2 entries 'x' and 'y'
+     */
+    public function transformXy(array $p)
+    {
+        // straight 2d vector x matrix
+        return array(
+            'x' => $p['x'] * $this->rows[0][0] + $p['y'] * $this->rows[0][1] + 1.0 * $this->rows[0][2],
+            'y' => $p['x'] * $this->rows[1][0] + $p['y'] * $this->rows[1][1] + 1.0 * $this->rows[1][2],
+        );
+    }
+}
+

--- a/src/Mapbender/PrintBundle/Component/Export/Box.php
+++ b/src/Mapbender/PrintBundle/Component/Export/Box.php
@@ -56,8 +56,9 @@ class Box
     {
         $sine = abs(sin(deg2rad($degrees)));
         $cosine = abs(cos(deg2rad($degrees)));
-        $widthScale = $cosine + $sine * $this->getHeight() / $this->getWidth();
-        $heightScale = $cosine + $sine * $this->getWidth() / $this->getHeight();
+        $aspectRatio = $this->getWidth() / $this->getHeight();
+        $widthScale = $cosine + $sine / abs($aspectRatio);
+        $heightScale = $cosine + $sine * abs($aspectRatio);
         return $this->getScaled($widthScale, $heightScale);
     }
 

--- a/src/Mapbender/PrintBundle/Component/Export/Box.php
+++ b/src/Mapbender/PrintBundle/Component/Export/Box.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Export;
+
+
+class Box
+{
+    /** @var float */
+    public $left;
+    /** @var float */
+    public $bottom;
+    /** @var float */
+    public $right;
+    /** @var float */
+    public $top;
+
+    /**
+     * @param int|float $left
+     * @param int|float $bottom
+     * @param int|float $right
+     * @param int|float $top
+     */
+    public function __construct($left, $bottom, $right, $top)
+    {
+        $this->left = floatval($left);
+        $this->bottom = floatval($bottom);
+        $this->right = floatval($right);
+        $this->top = floatval($top);
+    }
+
+    /**
+     * @return float
+     */
+    public function getWidth()
+    {
+        return $this->right - $this->left;
+    }
+
+    /**
+     * @return float
+     */
+    public function getHeight()
+    {
+        return $this->top - $this->bottom;
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Export/Box.php
+++ b/src/Mapbender/PrintBundle/Component/Export/Box.php
@@ -3,7 +3,9 @@
 
 namespace Mapbender\PrintBundle\Component\Export;
 
-
+/**
+ * Axis-aligned 2D box.
+ */
 class Box
 {
     /** @var float */
@@ -27,6 +29,54 @@ class Box
         $this->bottom = floatval($bottom);
         $this->right = floatval($right);
         $this->top = floatval($top);
+    }
+
+    /**
+     * @param float $centerX
+     * @param float $centerY
+     * @param float $width
+     * @param float $height
+     * @return Box
+     */
+    public static function fromCenterAndSize($centerX, $centerY, $width, $height)
+    {
+        $left = $centerX - 0.5 * $width;
+        $bottom = $centerY - 0.5 * $height;
+        return new static($left, $bottom, $left + $width, $bottom + $height);
+    }
+
+    /**
+     * Return a new, bigger box that can fit this box if it were rotated by $degrees degrees around its center.
+     * NOTE: all Box instances are axis aligned. Box rotation is hypothetical.
+     *
+     * @param $degrees
+     * @return Box
+     */
+    public function getExpandedForRotation($degrees)
+    {
+        $sine = abs(sin(deg2rad($degrees)));
+        $cosine = abs(cos(deg2rad($degrees)));
+        $widthScale = $cosine + $sine * $this->getHeight() / $this->getWidth();
+        $heightScale = $cosine + $sine * $this->getWidth() / $this->getHeight();
+        return $this->getScaled($widthScale, $heightScale);
+    }
+
+    /**
+     * Return a new box scaled by $widthFactor and $heightFactor, maintaining current center.
+     *
+     * @param float $widthFactor
+     * @param float $heightFactor
+     * @return Box
+     */
+    public function getScaled($widthFactor, $heightFactor)
+    {
+        $center = array(
+            ($this->right - $this->left) * 0.5 + $this->left,
+            ($this->top - $this->bottom) * 0.5 + $this->bottom,
+        );
+        $newWidth = $widthFactor * $this->getWidth();
+        $newHeight = $heightFactor * $this->getHeight();
+        return $this->fromCenterAndSize($center[0], $center[1], $newWidth, $newHeight);
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/Export/Box.php
+++ b/src/Mapbender/PrintBundle/Component/Export/Box.php
@@ -95,4 +95,23 @@ class Box
     {
         return $this->top - $this->bottom;
     }
+
+    /**
+     * Self-modifying; quantize left / right / bottom / top to integers
+     */
+    public function roundToIntegerBoundaries()
+    {
+        // base calculations on width / height and current center to minimize drift
+        $roundWidth = round($this->getWidth());
+        $roundHeight = round($this->getHeight());
+        // try to hit a half-integer at the center
+        $center = array(
+            ($this->right - $this->left) * 0.5 + $this->left,
+            ($this->top - $this->bottom) * 0.5 + $this->bottom,
+        );
+        $this->left = round($center[0] - 0.5 * $roundWidth);
+        $this->bottom = round($center[1] - 0.5 * $roundHeight);
+        $this->right = $this->left + $roundWidth;
+        $this->top = $this->bottom + $roundHeight;
+    }
 }

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mapbender\PrintBundle\Component;
 
+use Mapbender\PrintBundle\Component\Export\Affine2DTransform;
+use Mapbender\PrintBundle\Component\Export\Box;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,6 +30,9 @@ class ImageExportService
     protected $data;
     /** @var string[] plain WMS URLs */
     protected $mapRequests = array();
+
+    /** @var Affine2DTransform */
+    protected $featureTransform;
 
     public function __construct($container)
     {
@@ -69,6 +74,8 @@ class ImageExportService
         $this->mapRequests = array();
         $this->data = json_decode($content, true);
 
+        $this->featureTransform = $this->initializeFeatureTransform($this->data);
+
         foreach ($this->data['requests'] as $i => $layer) {
             if ($layer['type'] != 'wms') {
                 continue;
@@ -85,6 +92,27 @@ class ImageExportService
         $imagePath = $this->getImages();
         $this->emitImageToBrowser($imagePath);
         unlink($imagePath);
+    }
+
+    /**
+     * @param $jobData
+     * @return Affine2DTransform
+     */
+    protected function initializeFeatureTransform($jobData)
+    {
+        $map_width = $this->data['extentwidth'];
+        $map_height = $this->data['extentheight'];
+        $centerx = $this->data['centerx'];
+        $centery = $this->data['centery'];
+
+        $minX = $centerx - $map_width * 0.5;
+        $minY = $centery - $map_height * 0.5;
+        $maxX = $centerx + $map_width * 0.5;
+        $maxY = $centery + $map_height * 0.5;
+
+        $pixelBox = new Box(0, $jobData['height'], $jobData['width'], 0);
+        $projectedBox = new Box($minX, $minY, $maxX, $maxY);
+        return Affine2DTransform::boxToBox($projectedBox, $pixelBox);
     }
 
     /**
@@ -344,7 +372,7 @@ class ImageExportService
 
             $points = array();
             foreach($ring as $c) {
-                $p = $this->realWorld2mapPos($c[0], $c[1]);
+                $p = $this->featureTransform->transformPair($c);
                 $points[] = floatval($p[0]);
                 $points[] = floatval($p[1]);
             }
@@ -376,7 +404,7 @@ class ImageExportService
 
             $points = array();
             foreach($ring as $c) {
-                $p = $this->realWorld2mapPos($c[0], $c[1]);
+                $p = $this->featureTransform->transformPair($c);
                 $points[] = floatval($p[0]);
                 $points[] = floatval($p[1]);
             }
@@ -409,12 +437,8 @@ class ImageExportService
 
         for($i = 1; $i < count($geometry['coordinates']); $i++) {
 
-            $from = $this->realWorld2mapPos(
-                $geometry['coordinates'][$i - 1][0],
-                $geometry['coordinates'][$i - 1][1]);
-            $to = $this->realWorld2mapPos(
-                $geometry['coordinates'][$i][0],
-                $geometry['coordinates'][$i][1]);
+            $from = $this->featureTransform->transformPair($geometry['coordinates'][$i - 1]);
+            $to = $this->featureTransform->transformPair($geometry['coordinates'][$i]);
 
             imageline($image, $from[0], $from[1], $to[0], $to[1], $color);
         }
@@ -422,9 +446,7 @@ class ImageExportService
 
     private function drawPoint($geometry, $image)
     {
-        $c = $geometry['coordinates'];
-
-        $p = $this->realWorld2mapPos($c[0], $c[1]);
+        $p = $this->featureTransform->transformPair($geometry['coordinates']);
 
         if(isset($geometry['style']['label'])){
             // draw label with white halo
@@ -455,33 +477,6 @@ class ImageExportService
             $geometry['style']['strokeOpacity'],
             $image);
         imageellipse($image, $p[0], $p[1], 2*$radius, 2*$radius, $color);
-    }
-
-    private function realWorld2mapPos($rw_x,$rw_y)
-    {
-        $quality = 72;
-        $map_width = $this->data['extentwidth'];
-        $map_height = $this->data['extentheight'];
-        $centerx = $this->data['centerx'];
-        $centery = $this->data['centery'];
-
-        $height = $this->data['height'];
-        $width = $this->data['width'];
-
-        $minX = $centerx - $map_width * 0.5;
-        $minY = $centery - $map_height * 0.5;
-        $maxX = $centerx + $map_width * 0.5;
-        $maxY = $centery + $map_height * 0.5;
-
-        $extentx = $maxX - $minX ;
-	$extenty = $maxY - $minY ;
-
-        $pixPos_x = (($rw_x - $minX)/$extentx) * $width;
-	$pixPos_y = (($maxY - $rw_y)/$extenty) * $height;
-
-        $pixPos = array($pixPos_x, $pixPos_y);
-
-	return $pixPos;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -148,7 +148,7 @@ class ImageExportService
         // create final merged image
         $finalImageName = $this->makeTempFile('mb_imgexp_merged');
         $mergedImage = imagecreatetruecolor($width, $height);
-        $bg = ImageColorAllocate($mergedImage, 255, 255, 255);
+        $bg = imagecolorallocate($mergedImage, 255, 255, 255);
         imagefilledrectangle($mergedImage, 0, 0, $width, $height, $bg);
         imagepng($mergedImage, $finalImageName);
         foreach ($temp_names as $temp_name) {
@@ -356,7 +356,7 @@ class ImageExportService
         list($r, $g, $b) = CSSColorParser::parse($color);
 
         if(0 == $alpha) {
-            return ImageColorAllocate($image, $r, $g, $b);
+            return imagecolorallocate($image, $r, $g, $b);
         } else {
             $a = (1 - $alpha) * 127.0;
             return imagecolorallocatealpha($image, $r, $g, $b, $a);

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -173,7 +173,7 @@ class PrintService extends ImageExportService
         // create temp merged image
         $tempImageName = $this->makeTempFile('mb_print_temp');
         $tempImage = imagecreatetruecolor($neededImageWidth, $neededImageHeight);
-        $bg = ImageColorAllocate($tempImage, 255, 255, 255);
+        $bg = imagecolorallocate($tempImage, 255, 255, 255);
         imagefilledrectangle($tempImage, 0, 0, $neededImageWidth, $neededImageHeight, $bg);
         imagepng($tempImage, $tempImageName);
 
@@ -489,7 +489,7 @@ class PrintService extends ImageExportService
         // create final merged image
         $finalImageName = $this->makeTempFile('mb_print_merged');
         $finalImage = imagecreatetruecolor($ovImageWidth, $ovImageHeight);
-        $bg = ImageColorAllocate($finalImage, 255, 255, 255);
+        $bg = imagecolorallocate($finalImage, 255, 255, 255);
         imagefilledrectangle($finalImage, 0, 0, $ovImageWidth,
             $ovImageHeight, $bg);
         imagepng($finalImage, $finalImageName);
@@ -522,7 +522,7 @@ class PrintService extends ImageExportService
         $p3 = array_values($points[2]);
         $p4 = array_values($points[3]);
 
-        $red = ImageColorAllocate($image,255,0,0);
+        $red = imagecolorallocate($image,255,0,0);
         imageline ( $image, $p1[0], $p1[1], $p2[0], $p2[1], $red);
         imageline ( $image, $p2[0], $p2[1], $p3[0], $p3[1], $red);
         imageline ( $image, $p3[0], $p3[1], $p4[0], $p4[1], $red);
@@ -667,7 +667,7 @@ class PrintService extends ImageExportService
         list($r, $g, $b) = CSSColorParser::parse($color);
 
         if(0 == $alpha) {
-            return ImageColorAllocate($image, $r, $g, $b);
+            return imagecolorallocate($image, $r, $g, $b);
         } else {
             $a = (1 - $alpha) * 127.0;
             return imagecolorallocatealpha($image, $r, $g, $b, $a);
@@ -958,7 +958,7 @@ class PrintService extends ImageExportService
                 if ($legendConf == true) {
                     // add legend in legend region on first page
                     // To Be doneCell(0,0,  utf8_decode($title));
-                    $this->pdf->setXY($x,$y);
+                    $this->pdf->SetXY($x,$y);
                     $this->pdf->Cell(0,0,  utf8_decode($title));
                     $this->pdf->Image($image,
                                 $x,
@@ -985,7 +985,7 @@ class PrintService extends ImageExportService
 
                   }else{
                       // print legend on second page
-                      $this->pdf->setXY($x,$y);
+                      $this->pdf->SetXY($x,$y);
                       $this->pdf->Cell(0,0,  utf8_decode($title));
                       $this->pdf->Image($image, $x, $y + 5, ($size[0] * 25.4 / 96), ($size[1] * 25.4 / 96), 'png', '', false, 0);
 

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -56,6 +56,7 @@ class PrintService extends ImageExportService
     protected function initializeCanvasBox(array $jobData)
     {
         $rotatedBox = $this->targetBox->getExpandedForRotation(intval($jobData['rotation']));
+        $rotatedBox->roundToIntegerBoundaries();
         // re-anchor rotated box to put top left at (0,0); note: gd pixel coords are top down
         return new Box(0, abs($rotatedBox->getHeight()), abs($rotatedBox->getWidth()), 0);
     }
@@ -105,8 +106,8 @@ class PrintService extends ImageExportService
             $request = strstr($layer['url'], '&BBOX', true);
 
 
-            $width = '&WIDTH=' . abs(intval($this->canvasBox->getWidth()));
-            $height =  '&HEIGHT=' . abs(intval($this->canvasBox->getHeight()));
+            $width = '&WIDTH=' . abs($this->canvasBox->getWidth());
+            $height =  '&HEIGHT=' . abs($this->canvasBox->getHeight());
 
             $mExt = $this->mapRequestBox;
             if (!empty($layer['changeAxis'])){
@@ -165,8 +166,8 @@ class PrintService extends ImageExportService
     private function createMapImage()
     {
         $rotation = $this->rotation;
-        $neededImageWidth = abs(intval($this->canvasBox->getWidth()));
-        $neededImageHeight = abs(intval($this->canvasBox->getHeight()));
+        $neededImageWidth = abs($this->canvasBox->getWidth());
+        $neededImageHeight = abs($this->canvasBox->getHeight());
 
         $imageNames = $this->getImages($neededImageWidth,$neededImageHeight);
 

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
  */
 class PrintService extends ImageExportService
 {
-    /** @var PDF_ImageAlpha */
+    /** @var PDF_Extensions|\FPDF */
     protected $pdf;
     protected $conf;
     protected $rotation;
@@ -300,6 +300,7 @@ class PrintService extends ImageExportService
             $orientation = 'L';
         }
 
+        /** @var PDF_Extensions|\FPDF|\FPDF_TPL $pdf */
         $this->pdf = $pdf = new PDF_Extensions();
 
         $template = $this->data['template'];

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -79,14 +79,6 @@ class PrintService extends ImageExportService
             $centerx = $data['center']['x'];
             $centery = $data['center']['y'];
 
-            // switch axis for some EPSG if WMS Version 1.3.0
-            if (!empty($layer['changeAxis'])){
-                $extentWidth = $data['extent']['height'];
-                $extentHeight = $data['extent']['width'];
-                $centerx = $data['center']['y'];
-                $centery = $data['center']['x'];
-            }
-
             // switch if image is rotated
             $this->rotation = $rotation = $data['rotation'];
             if ($rotation == 0) {
@@ -125,8 +117,12 @@ class PrintService extends ImageExportService
                 $width = '&WIDTH=' . $neededImageWidth;
                 $height =  '&HEIGHT=' . $neededImageHeight;
             }
+            if (!empty($layer['changeAxis'])){
+                $request .= '&BBOX=' . $minY . ',' . $minX . ',' . $maxY . ',' . $maxX;
+            } else {
+                $request .= '&BBOX=' . $minX . ',' . $minY . ',' . $maxX . ',' . $maxY;
+            }
 
-            $request .= '&BBOX=' . $minX . ',' . $minY . ',' . $maxX . ',' . $maxY;
             $request .= $width . $height;
 
             if(!isset($this->data['replace_pattern'])){
@@ -477,8 +473,6 @@ class PrintService extends ImageExportService
         $width = '&WIDTH=' . $ovImageWidth;
         $height = '&HEIGHT=' . $ovImageHeight;
 
-        $changeAxis = false;
-
         // get images
         $tempNames = array();
         $logger = $this->getLogger();
@@ -489,19 +483,15 @@ class PrintService extends ImageExportService
             $centerx = $this->data['center']['x'];
             $centery = $this->data['center']['y'];
 
-            if (!empty($layer['changeAxis'])) {
-                $ovWidth = $this->conf['overview']['height'] * $layer['scale'] / 1000;
-                $ovHeight = $this->conf['overview']['width'] * $layer['scale'] / 1000;
-                $centerx = $this->data['center']['y'];
-                $centery = $this->data['center']['x'];
-                $changeAxis = true;
-            }
-
             $minX = $centerx - $ovWidth * 0.5;
             $minY = $centery - $ovHeight * 0.5;
             $maxX = $centerx + $ovWidth * 0.5;
             $maxY = $centery + $ovHeight * 0.5;
-            $bbox = '&BBOX=' . $minX . ',' . $minY . ',' . $maxX . ',' . $maxY;
+            if (!empty($layer['changeAxis'])) {
+                $bbox = '&BBOX=' . $minY . ',' . $minX . ',' . $maxY . ',' . $maxX;
+            } else {
+                $bbox = '&BBOX=' . $minX . ',' . $minY . ',' . $maxX . ',' . $maxY;
+            }
 
             $url = strstr($layer['url'], '&BBOX', true);
             $url .= $bbox . $width . $height;
@@ -542,38 +532,20 @@ class PrintService extends ImageExportService
 
         $image = imagecreatefrompng($finalImageName);
 
-        // add red extent rectangle
-        if (!$changeAxis) {
-            $ll_x = $this->data['extent_feature'][3]['x'];
-            $ll_y = $this->data['extent_feature'][3]['y'];
-            $ul_x = $this->data['extent_feature'][0]['x'];
-            $ul_y = $this->data['extent_feature'][0]['y'];
+        $ul_x = $this->data['extent_feature'][3]['x'];
+        $ul_y = $this->data['extent_feature'][3]['y'];
+        $ll_x = $this->data['extent_feature'][0]['x'];
+        $ll_y = $this->data['extent_feature'][0]['y'];
 
-            $lr_x = $this->data['extent_feature'][2]['x'];
-            $lr_y = $this->data['extent_feature'][2]['y'];
-            $ur_x = $this->data['extent_feature'][1]['x'];
-            $ur_y = $this->data['extent_feature'][1]['y'];
+        $ur_x = $this->data['extent_feature'][2]['x'];
+        $ur_y = $this->data['extent_feature'][2]['y'];
+        $lr_x = $this->data['extent_feature'][1]['x'];
+        $lr_y = $this->data['extent_feature'][1]['y'];
 
-            $p1 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ll_x, $ll_y);
-            $p2 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ul_x, $ul_y);
-            $p3 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ur_x, $ur_y);
-            $p4 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $lr_x, $lr_y);
-        } else {
-            $ul_x = $this->data['extent_feature'][3]['x'];
-            $ul_y = $this->data['extent_feature'][3]['y'];
-            $ll_x = $this->data['extent_feature'][0]['x'];
-            $ll_y = $this->data['extent_feature'][0]['y'];
-
-            $ur_x = $this->data['extent_feature'][2]['x'];
-            $ur_y = $this->data['extent_feature'][2]['y'];
-            $lr_x = $this->data['extent_feature'][1]['x'];
-            $lr_y = $this->data['extent_feature'][1]['y'];
-
-            $p1 = $this->realWorld2ovMapPos($ovHeight, $ovWidth, $ll_x, $ll_y);
-            $p2 = $this->realWorld2ovMapPos($ovHeight, $ovWidth, $ul_x, $ul_y);
-            $p3 = $this->realWorld2ovMapPos($ovHeight, $ovWidth, $ur_x, $ur_y);
-            $p4 = $this->realWorld2ovMapPos($ovHeight, $ovWidth, $lr_x, $lr_y);
-        }
+        $p1 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ll_x, $ll_y);
+        $p2 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ul_x, $ul_y);
+        $p3 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $ur_x, $ur_y);
+        $p4 = $this->realWorld2ovMapPos($ovWidth, $ovHeight, $lr_x, $lr_y);
 
         $red = ImageColorAllocate($image,255,0,0);
         imageline ( $image, $p1[0], $p1[1], $p2[0], $p2[1], $red);

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -59,16 +59,11 @@ class PrintService extends ImageExportService
      */
     protected function initializeCanvasBox(array $jobData)
     {
-        $rotation = intval($jobData['rotation']);
-
-        // calculate needed image size
-        $neededImageWidth = round(abs(sin(deg2rad($rotation)) * $this->imageHeight) +
-            abs(cos(deg2rad($rotation)) * $this->imageWidth));
-        $neededImageHeight = round(abs(sin(deg2rad($rotation)) * $this->imageWidth) +
-            abs(cos(deg2rad($rotation)) * $this->imageHeight));
-
-        // gd pixel coords are top down!
-        return new Box(0, $neededImageHeight, $neededImageWidth, 0);
+        // center of unrotated box irrelevant, use (0,0) for simplicity
+        $unrotatedBox = Box::fromCenterAndSize(0, 0, $this->imageWidth, $this->imageHeight);
+        $rotatedBox = $unrotatedBox->getExpandedForRotation(intval($jobData['rotation']));
+        // re-anchor rotated box to put top left at (0,0); note: gd pixel coords are top down
+        return new Box(0, abs($rotatedBox->getHeight()), abs($rotatedBox->getWidth()), 0);
     }
 
     /**
@@ -77,24 +72,12 @@ class PrintService extends ImageExportService
      */
     protected function initializeMapRequestBox(array $jobData)
     {
-        $rotation = intval($jobData['rotation']);
-
-        $extentWidth = $jobData['extent']['width'];
-        $extentHeight = $jobData['extent']['height'];
+        $width = $jobData['extent']['width'];
+        $height = $jobData['extent']['height'];
         $centerx = $jobData['center']['x'];
         $centery = $jobData['center']['y'];
-
-        $neededExtentWidth = abs(sin(deg2rad($rotation)) * $extentHeight) +
-            abs(cos(deg2rad($rotation)) * $extentWidth);
-        $neededExtentHeight = abs(sin(deg2rad($rotation)) * $extentWidth) +
-            abs(cos(deg2rad($rotation)) * $extentHeight);
-
-        $minX = $centerx - $neededExtentWidth * 0.5;
-        $minY = $centery - $neededExtentHeight * 0.5;
-        $maxX = $centerx + $neededExtentWidth * 0.5;
-        $maxY = $centery + $neededExtentHeight * 0.5;
-
-        return new Box($minX, $minY, $maxX, $maxY);
+        $unrotatedBox = Box::fromCenterAndSize($centerx, $centery, $width, $height);
+        return $unrotatedBox->getExpandedForRotation(intval($jobData['rotation']));
     }
 
     private function setup($data)

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -39,7 +39,7 @@ class PrintService extends ImageExportService
     {
         $this->setup($data);
 
-        $this->createFinalRotatedMapImage();
+        $this->createMapImage();
 
         return $this->buildPdf();
     }
@@ -156,7 +156,7 @@ class PrintService extends ImageExportService
         }
     }
 
-    private function createFinalRotatedMapImage()
+    private function createMapImage()
     {
         $rotation = $this->rotation;
         $neededImageWidth = $this->neededImageWidth;
@@ -694,7 +694,7 @@ class PrintService extends ImageExportService
 
             $points = array();
             foreach($ring as $c) {
-                $p = $this->realWorld2rotatedMapPos($c[0], $c[1]);
+                $p = $this->transformToPixelSpace($c[0], $c[1]);
                 $points[] = floatval($p[0]);
                 $points[] = floatval($p[1]);
             }
@@ -731,7 +731,7 @@ class PrintService extends ImageExportService
 
                 $points = array();
                 foreach($ring as $c) {
-                    $p = $this->realWorld2rotatedMapPos($c[0], $c[1]);
+                    $p = $this->transformToPixelSpace($c[0], $c[1]);
                     $points[] = floatval($p[0]);
                     $points[] = floatval($p[1]);
                 }
@@ -771,10 +771,10 @@ class PrintService extends ImageExportService
         imagesetthickness($image, $style['strokeWidth'] * $resizeFactor);
 
         for($i = 1; $i < count($geometry['coordinates']); $i++) {
-            $from = $this->realWorld2rotatedMapPos(
+            $from = $this->transformToPixelSpace(
                 $geometry['coordinates'][$i - 1][0],
                 $geometry['coordinates'][$i - 1][1]);
-            $to = $this->realWorld2rotatedMapPos(
+            $to = $this->transformToPixelSpace(
                 $geometry['coordinates'][$i][0],
                 $geometry['coordinates'][$i][1]);
 
@@ -797,10 +797,10 @@ class PrintService extends ImageExportService
 
         foreach($geometry['coordinates'] as $coords) {
             for($i = 1; $i < count($coords); $i++) {
-                $from = $this->realWorld2rotatedMapPos(
+                $from = $this->transformToPixelSpace(
                         $coords[$i - 1][0],
                         $coords[$i - 1][1]);
-                $to = $this->realWorld2rotatedMapPos(
+                $to = $this->transformToPixelSpace(
                         $coords[$i][0],
                         $coords[$i][1]);
                 imageline($image, $from[0], $from[1], $to[0], $to[1], $color);
@@ -814,7 +814,7 @@ class PrintService extends ImageExportService
         $c = $geometry['coordinates'];
         $resizeFactor = $this->getResizeFactor();
 
-        $p = $this->realWorld2rotatedMapPos($c[0], $c[1]);
+        $p = $this->transformToPixelSpace($c[0], $c[1]);
 
         if(isset($style['label'])){
             // draw label with halo
@@ -1094,7 +1094,7 @@ class PrintService extends ImageExportService
         return array($pixPos_x, $pixPos_y);
     }
 
-    private function realWorld2rotatedMapPos($rw_x, $rw_y)
+    private function transformToPixelSpace($projectedX, $projectedY)
     {
         $centerx  = $this->data['center']['x'];
         $centery  = $this->data['center']['y'];
@@ -1104,8 +1104,8 @@ class PrintService extends ImageExportService
         $maxY     = $centery + $this->neededExtentHeight * 0.5;
         $extentx  = $maxX - $minX;
         $extenty  = $maxY - $minY;
-        $pixPos_x = (($rw_x - $minX) / $extentx) * $this->neededImageWidth;
-        $pixPos_y = (($maxY - $rw_y) / $extenty) * $this->neededImageHeight;
+        $pixPos_x = (($projectedX - $minX) / $extentx) * $this->neededImageWidth;
+        $pixPos_y = (($maxY - $projectedY) / $extenty) * $this->neededImageHeight;
 
         return array($pixPos_x, $pixPos_y);
     }


### PR DESCRIPTION
Pull removes dual paths for rotated vs rotated by 0 degrees.  
Pull removes [confusing variable name flips in `changeAxis` situations](https://github.com/mapbender/mapbender/compare/fix/printservice-cleanups?expand=1#diff-6bcf4bd553c065e6f9870db495a80902L83) -- width does not become height on `changeAxis`; the only thing that happens differently on `changeAxis` is the [WMS `BBOX` param construction](https://github.com/mapbender/mapbender/compare/fix/printservice-cleanups?expand=1#diff-6bcf4bd553c065e6f9870db495a80902R112).  
Pull breaks out transformation from projected to pixel boxes, the boxes themselves, and the expansion to account for rotation, into a couple of new classes.  
Pull replaces [the redundant calculation of the probable size of a GD image after rotation with GD sizex/sizey calls](https://github.com/mapbender/mapbender/compare/fix/printservice-cleanups?expand=1#diff-6bcf4bd553c065e6f9870db495a80902R226).  
Pull improves IDE introspectability / reduces IDE warning clutter by amending the PDF class typehint and fixing case-mismatched function calls (legal in PHP, still).  

Apart from reducing edge drift for rotated prints (on the order of 1~2 pixels in bad cases) this change is pixel-equivalent in testing; no external API / job data format changes.