### PR TITLE
Print fixed Overview Map

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -487,8 +487,7 @@
 
                     var ovCenter = ovMap.map.getCenter();
                     var ovElement = $('.mb-element-overview').data('mapbenderMbOverview');
-                    var ovFixed = ovElement.options.fixed;
-                    if (ovElement !== undefined && ovFixed === true){
+                    if (ovElement && ovElement.options.fixed) {
                         mwidth = this.map.model.mapMaxExtent.extent.getWidth();
                         res = mwidth / ovMap.size.w;
                         scale = Math.round(OpenLayers.Util.getScaleFromResolution(res,'m'));
@@ -499,7 +498,6 @@
                     overview.url = url;
                     overview.scale = scale;
                     overview.center = {'x': ovCenter['lon'], 'y': ovCenter['lat']};
-                    overview.fixed = ovFixed;
 
                     // flag to change axis order
                     overview.changeAxis = this._changeAxis(ovMap.layers[i]);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -485,9 +485,21 @@
                     var res = mwidth / width;
                     var scale = Math.round(OpenLayers.Util.getScaleFromResolution(res,'m'));
 
+                    var ovCenter = ovMap.map.getCenter();
+                    var ovElement = $('.mb-element-overview').data('mapbenderMbOverview');
+                    var ovFixed = ovElement.options.fixed;
+                    if (ovElement !== undefined && ovFixed === true){
+                        mwidth = this.map.model.mapMaxExtent.extent.getWidth();
+                        res = mwidth / ovMap.size.w;
+                        scale = Math.round(OpenLayers.Util.getScaleFromResolution(res,'m'));
+                        ovCenter = this.map.model.mapMaxExtent.extent.centerLonLat;
+                    }
+
                     var overview = {};
                     overview.url = url;
                     overview.scale = scale;
+                    overview.center = {'x': ovCenter['lon'], 'y': ovCenter['lat']};
+                    overview.fixed = ovFixed;
 
                     // flag to change axis order
                     overview.changeAxis = this._changeAxis(ovMap.layers[i]);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -478,21 +478,12 @@
             if (undefined !== ovMap){
                 for(var i = 0; i < ovMap.layers.length; i++) {
                     var url = ovMap.layers[i].getURL(ovMap.map.getExtent());
-                    var extent = ovMap.map.getExtent();
-                    var mwidth = extent.getWidth();
+                    var mwidth = ovMap.ovmap.getExtent().getWidth();
+                    var ovCenter = ovMap.ovmap.getCenter();
                     var size = ovMap.size;
                     var width = size.w;
                     var res = mwidth / width;
                     var scale = Math.round(OpenLayers.Util.getScaleFromResolution(res,'m'));
-
-                    var ovCenter = ovMap.map.getCenter();
-                    var ovElement = $('.mb-element-overview').data('mapbenderMbOverview');
-                    if (ovElement && ovElement.options.fixed) {
-                        mwidth = this.map.model.mapMaxExtent.extent.getWidth();
-                        res = mwidth / ovMap.size.w;
-                        scale = Math.round(OpenLayers.Util.getScaleFromResolution(res,'m'));
-                        ovCenter = this.map.model.mapMaxExtent.extent.centerLonLat;
-                    }
 
                     var overview = {};
                     overview.url = url;

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -486,14 +486,14 @@ class PrintService extends ImageExportService
             // calculate needed bbox
             $ovWidth = $this->conf['overview']['width'] * $layer['scale'] / 1000;
             $ovHeight = $this->conf['overview']['height'] * $layer['scale'] / 1000;
-            $centerx = $this->data['center']['x'];
-            $centery = $this->data['center']['y'];
+            $centerx = $layer['center']['x'];
+            $centery = $layer['center']['y'];
 
             if (!empty($layer['changeAxis'])) {
                 $ovWidth = $this->conf['overview']['height'] * $layer['scale'] / 1000;
                 $ovHeight = $this->conf['overview']['width'] * $layer['scale'] / 1000;
-                $centerx = $this->data['center']['y'];
-                $centery = $this->data['center']['x'];
+                $centerx = $layer['center']['y'];
+                $centery = $layer['center']['x'];
                 $changeAxis = true;
             }
 
@@ -1184,8 +1184,8 @@ class PrintService extends ImageExportService
     private function realWorld2ovMapPos($ovWidth, $ovHeight, $rw_x, $rw_y)
     {
         $quality  = $this->data['quality'];
-        $centerx  = $this->data['center']['x'];
-        $centery  = $this->data['center']['y'];
+        $centerx  = $this->data['overview'][0]['center']['x'];
+        $centery  = $this->data['overview'][0]['center']['y'];
         $minX     = $centerx - $ovWidth * 0.5;
         $minY     = $centery - $ovHeight * 0.5;
         $maxX     = $centerx + $ovWidth * 0.5;


### PR DESCRIPTION
The printed overview map (pdf) does not 'zoom in' if the overview map element is 'fixed'.

To test this change just configure overview map as fixed and choose a print template with an overview map (a3_landscape_offical_overview)