### PR TITLE
Change check for this.popup to this.popupWindow

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -433,13 +433,10 @@
 
             if (widget.isPopUpDialog) {
 
-                if (widget.popup) {
-
-                    if (widget.popupWindow.$element) {
+                    if (widget.popupWindow && widget.popupWindow.$element) {
                         widget.popupWindow.destroy();
                         widget.popupWindow = null;
                     }
-                }
 
             }
             if (widget.callback) {


### PR DESCRIPTION
property popup is a function so it always will be true-ish. To check if the popup is already open we have to check against property popupWindow. The old code can cause errors if the legend element is used in a button group and breaks the functionality of other buttons in this group.