### PR TITLE
no * for optional fields that are required: false

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -63,8 +63,7 @@
         {% if configuration.optional_fields is not empty %}
             {% for key,field in configuration.optional_fields %}
                 {% if not field.options.required %}
-                    <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}
-                    </label>
+                    <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}</label>
                     <input type="text" class="input validationInput" name="extra[{{ key }}]">
                 {% endif %}
             {% endfor %}

--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -64,7 +64,6 @@
             {% for key,field in configuration.optional_fields %}
                 {% if not field.options.required %}
                     <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}
-                        <span class="required">*</span>
                     </label>
                     <input type="text" class="input validationInput" name="extra[{{ key }}]">
                 {% endif %}


### PR DESCRIPTION
* do not show the * after the label of a text field (optional field) in the print form if required: false is set

comment:
  label: comment
  options:
    required: false