### PR TITLE
Fix/print imgexport client inheritance

### DIFF
--- a/src/Mapbender/CoreBundle/Element/PrintClient.php
+++ b/src/Mapbender/CoreBundle/Element/PrintClient.php
@@ -155,19 +155,25 @@ class PrintClient extends Element
         return 'mapbender.mbPrintClient';
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render()
+    public function getFrontendTemplateVars()
     {
-        return $this->container->get('templating')->render(
-            'MapbenderCoreBundle:Element:printclient.html.twig',
-            array(
-                'id' => $this->getId(),
-                'title' => $this->getTitle(),
-                'configuration' => $this->getConfiguration()
-            )
+        $config = $this->getConfiguration();
+        $router = $this->container->get('router');
+        $submitUrl = $router->generate('mapbender_core_application_element', array(
+            'slug' => $this->application->getEntity()->getSlug(),
+            'id' => $this->entity->getId(),
+            'action' => 'print',
+        ));
+        return array(
+            'configuration' => $config,
+            'submitUrl' => $submitUrl,
+            'formTarget' => '_blank',
         );
+    }
+
+    public function getFrontendTemplatePath($suffix = '.html.twig')
+    {
+        return "MapbenderCoreBundle:Element:printclient{$suffix}";
     }
 
     /**
@@ -181,14 +187,16 @@ class PrintClient extends Element
         switch ($action) {
             case 'print':
                 $data = $this->preparePrintData($request, $configuration);
-                $printservice = $this->getPrintService();
+                $printService = $this->getPrintService();
 
                 $displayInline = true;
-                $filename = 'mapbender_print.pdf';
+
                 if(array_key_exists('file_prefix', $configuration)) {
                     $filename = $configuration['file_prefix'] . '_' . date("YmdHis") . '.pdf';
+                } else {
+                    $filename = 'mapbender_print.pdf';
                 }
-                $response = new Response($printservice->doPrint($data), 200, array(
+                $response = new Response($printService->doPrint($data), 200, array(
                     'Content-Type' => $displayInline ? 'application/pdf' : 'application/octet-stream',
                     'Content-Disposition' => 'attachment; filename=' . $filename
                 ));

--- a/src/Mapbender/CoreBundle/Element/PrintClient.php
+++ b/src/Mapbender/CoreBundle/Element/PrintClient.php
@@ -52,11 +52,20 @@ class PrintClient extends Element
      */
     public static function listAssets()
     {
-        return array('js' => array('mapbender.element.printClient.js',
+        return array(
+            'js' => array(
+                '@MapbenderPrintBundle/Resources/public/mapbender.element.imageExport.js',
+                'mapbender.element.printClient.js',
                 '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js'),
-            'css' => array('@MapbenderCoreBundle/Resources/public/sass/element/printclient.scss'),
-            'trans' => array('MapbenderCoreBundle:Element:printclient.json.twig'));
+                '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js',
+            ),
+            'css' => array(
+                '@MapbenderCoreBundle/Resources/public/sass/element/printclient.scss',
+            ),
+            'trans' => array(
+                'MapbenderCoreBundle:Element:printclient.json.twig',
+            ),
+        );
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -73,7 +73,6 @@
         open: function(callback){
             this.callback = callback ? callback : null;
             var self = this;
-            var me = $(this.element);
             if (this.options.type === 'dialog') {
                 if(!this.popup || !this.popup.$element){
                     this.popup = new Mapbender.Popup2({
@@ -105,13 +104,11 @@
                             }
                         });
                     this.popup.$element.on('close', $.proxy(this.close, this));
-                }else{
-                     return;
+                    this._getTemplateSize();
+                    this._updateElements(true);
+                    this._setScale();
                 }
-                me.show();
-                this._getTemplateSize();
-                this._updateElements(true);
-                this._setScale();
+                $(this.element).show();
             }
         },
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -304,23 +304,6 @@
             return data;
         },
         /**
-         * @returns {Array<Object>} sourceTreeish configuration objects
-         * @private
-         */
-        _getActiveRasterSourceDefs: function() {
-            var sourceTree = this.map.getSourceTree();
-            return sourceTree.filter(function(sourceDef) {
-                var layer = this.map.map.layersList[sourceDef.mqlid].olLayer;
-                if (0 !== layer.CLASS_NAME.indexOf('OpenLayers.Layer.')) {
-                    return false;
-                }
-                if (typeof (Mapbender.source[sourceDef.type] || {}).getPrintConfig !== 'function') {
-                    return false;
-                }
-                return true;
-            }.bind(this));
-        },
-        /**
          *
          * @param sourceDef
          * @param {number} [scale]
@@ -356,7 +339,7 @@
                 }
                 return legend;
             }
-            var sources = this._getActiveRasterSourceDefs();
+            var sources = this._getRasterSourceDefs();
             for (var i = 0; i < sources.length; ++i) {
                 var source = sources[i];
                 if (source.type === 'wms' && this._getRasterVisibilityInfo(source, scale).layers.length) {
@@ -369,7 +352,7 @@
             return legends;
         },
         _collectRasterLayerData: function() {
-            var sources = this._getActiveRasterSourceDefs();
+            var sources = this._getRasterSourceDefs();
             var scale = this._getPrintScale();
 
             var dataOut = [];

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -61,7 +61,7 @@
                 });
                 $('.printSubmit', this.element).on('click', $.proxy(this._print, this));
             }
-
+            $('form', this.element).on('submit', this._onSubmit.bind(this));
             this._trigger('ready');
             this._ready();
         },
@@ -335,13 +335,12 @@
             }));
 
             // extent feature
-            var feature_coords = new Array();
-            var feature_comp = this.feature.geometry.components[0].components;
-            for(var i = 0; i < feature_comp.length-1; i++) {
-                feature_coords[i] = new Object();
-                feature_coords[i]['x'] = feature_comp[i].x;
-                feature_coords[i]['y'] = feature_comp[i].y;
-            }
+            var feature_coords = this.feature.geometry.components[0].components.map(function(component) {
+                return {
+                    x: component.x,
+                    y: component.y
+                };
+            });
 
             $.merge(fields, $('<input />', {
                 type: 'hidden',
@@ -412,7 +411,7 @@
                         if (sources[i].type === 'wms') {
                             var ll = _getLegends(sources[i].configuration.children[0]);
                             if (ll) {
-                                legends.push(ll);
+                                legends = legends.concat(ll);
                             }
                         }
                     }
@@ -504,21 +503,15 @@
             $('div#layers', form).empty();
             fields.appendTo(form.find('div#layers'));
 
-            // Post in neuen Tab (action bei form anpassen)
-            var url =  this.elementUrl + 'print';
-
-            form.get(0).setAttribute('action', url);
-            form.attr('target', '_blank');
-            form.attr('method', 'post');
-
-            if (lyrCount === 0){
+            if(lyrCount === 0) {
                 Mapbender.info(Mapbender.trans('mb.core.printclient.info.noactivelayer'));
-            }else{
-                // we click a hidden submit button to check the required fields
-                form.find('input[type="submit"]').click();
+                return;
             }
 
-            if(this.options.autoClose){
+            form.find('input[type="submit"]').click();
+        },
+        _onSubmit: function(evt) {
+            if (this.options.autoClose){
                 this.popup.close();
             }
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -438,7 +438,7 @@
 
             return overviewLayers.length ? overviewLayers : null;
         },
-        _collectPrintData: function() {
+        _collectJobData: function() {
             var extent = this._getPrintExtent();
             var extentFeature = this.feature.geometry.components[0].components.map(function(component) {
                 return {
@@ -470,7 +470,7 @@
             }
             return data;
         },
-        _submitPrintData: function(data) {
+        _submitJob: function(jobData) {
             var form = $('form#formats', this.element);
             var fields = $();
             var appendField = function(name, value) {
@@ -480,7 +480,7 @@
                     value: value
                 }));
             };
-            _.forEach(data, function(value, key) {
+            _.forEach(jobData, function(value, key) {
                 if (value === null || typeof value === 'undefined') {
                     return;
                 }
@@ -524,13 +524,13 @@
             form.find('input[type="submit"]').click();
         },
         _print: function() {
-            var d = this._collectPrintData();
-            if (!d.layers.length) {
+            var jobData = this._collectJobData();
+            if (!jobData.layers.length) {
                 Mapbender.info(Mapbender.trans('mb.core.printclient.info.noactivelayer'));
                 return;
             }
 
-            this._submitPrintData(d);
+            this._submitJob(jobData);
         },
         _onSubmit: function(evt) {
             if (this.options.autoClose){

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -435,10 +435,17 @@
                     continue;
                 }
 
+                if (layer.features.length === 0){
+                    continue;
+                }
                 var geometries = [];
                 for(var idx = 0; idx < layer.features.length; idx++) {
                     var feature = layer.features[idx];
-                    if (!feature.onScreen(true)) continue
+                    // onScreen throws an error if geometry is not populated, see
+                    // https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Feature/Vector.js#L198
+                    if (!feature.geometry || !feature.onScreen(true)) {
+                        continue;
+                    }
 
                     if(this.feature.geometry.intersects(feature.geometry)){
                         var geometry = geojsonFormat.extract.geometry.apply(geojsonFormat, [feature.geometry]);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -397,7 +397,8 @@
                 }).map(function(feature) {
                     var geometry = geojsonFormat.extract.geometry.apply(geojsonFormat, [feature.geometry]);
                     if (feature.style !== null) {
-                        geometry.style = feature.style;
+                        // stringify => decode: makes a deep copy of the style at the moment of capture
+                        geometry.style = JSON.parse(JSON.stringify(feature.style));
                     } else {
                         geometry.style = layer.styleMap.createSymbolizer(feature, feature.renderIntent);
                     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -3,7 +3,7 @@
     /**
      * @typedef {{type:string, opacity:number, geometries: Array<Object>}} VectorLayerData~print
      */
-    $.widget("mapbender.mbPrintClient",  {
+    $.widget("mapbender.mbPrintClient",  $.mapbender.mbImageExport, {
         options: {
             style: {
                 fillColor:     '#ffffff',

--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -5,7 +5,7 @@
         <br>    
     {% endif %}
     
-    <form id="formats" action="{{ submitUrl }}" method="post" target="{{ formTarget }}>
+    <form id="formats" action="{{ submitUrl }}" method="post" target="{{ formTarget }}">
         <label class="labelInput">{{ 'mb.core.printclient.label.template' | trans }}</label>
         <div class="dropdown">
             <select name="template" class="hiddenDropdown">

--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -5,8 +5,7 @@
         <br>    
     {% endif %}
     
-    <form id="formats" action="">
-        
+    <form id="formats" action="{{ submitUrl }}" method="post" target="{{ formTarget }}>
         <label class="labelInput">{{ 'mb.core.printclient.label.template' | trans }}</label>
         <div class="dropdown">
             <select name="template" class="hiddenDropdown">

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -83,12 +83,6 @@ class ImageExportService
             $this->mapRequests[$i] = $layer['url'];
         }
 
-        if(isset($this->data['vectorLayers'])){
-            foreach ($this->data['vectorLayers'] as $idx => $layer){
-                $this->data['vectorLayers'][$idx] = json_decode($this->data['vectorLayers'][$idx], true);
-            }
-        }
-
         $imagePath = $this->getImages();
         $this->emitImageToBrowser($imagePath);
         unlink($imagePath);

--- a/src/Mapbender/PrintBundle/Element/ImageExport.php
+++ b/src/Mapbender/PrintBundle/Element/ImageExport.php
@@ -86,17 +86,25 @@ class ImageExport extends Element
         return 'MapbenderPrintBundle:ElementAdmin:imageexport.html.twig';
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render()
+    public function getFrontendTemplatePath($suffix = '.html.twig')
     {
-        return $this->container->get('templating')
-                ->render('MapbenderPrintBundle:Element:imageexport.html.twig', array(
-                    'id' => $this->getId(),
-                    'title' => $this->getTitle(),
-                    'configuration' => $this->getConfiguration()
+        return 'MapbenderPrintBundle:Element:imageexport.html.twig';
+    }
+
+    public function getFrontendTemplateVars()
+    {
+        $router = $this->container->get('router');
+        $submitUrl = $router->generate('mapbender_core_application_element', array(
+            'slug' => $this->application->getEntity()->getSlug(),
+            'id' => $this->entity->getId(),
+            'action' => 'export',
         ));
+        return array(
+            'id' => $this->getId(),
+            'title' => $this->getTitle(),
+            'submitUrl' => $submitUrl,
+            'formTarget' => '',
+        );
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
@@ -167,16 +167,14 @@
             }
         },
         _submitJob: function(jobData) {
-            var url = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/export';
-
-            var form = $('<form method="POST" action="' + url + '"  />');
+            var $form = $('form', this.element);
+            var $hiddenArea = $('.-fn-hidden-fields', $form);
+            $hiddenArea.empty();
             var submitValue = JSON.stringify(jobData);
             var $input = $('<input/>').attr('type', 'hidden').attr('name', 'data');
             $input.val(submitValue);
-            $input.appendTo(form);
-            form.appendTo($('body'));
-            form.submit();
-            form.remove();
+            $input.appendTo($hiddenArea);
+            $('.-fn-submit', $form).click();
         },
         /**
          * Should return true if the given layer needs to be included in export

--- a/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
@@ -1,9 +1,14 @@
 (function($){
 
+    /**
+     * @typedef {{type:string, opacity:number, geometries: Array<Object>}} VectorLayerData~print
+     */
     $.widget("mapbender.mbImageExport", {
         options: {},
         map: null,
         popupIsOpen: true,
+        _geometryToGeoJson: null,
+
         _create: function(){
             if(!Mapbender.checkTarget("mbImageExport", this.options.target)){
                 return;
@@ -12,6 +17,8 @@
             var me = this.element;
             this.elementUrl = Mapbender.configuration.application.urls.element + '/' + me.attr('id') + '/';
             Mapbender.elementRegistry.onElementReady(this.options.target, $.proxy(self._setup, self));
+            var olGeoJson = new OpenLayers.Format.GeoJSON();
+            this._geometryToGeoJson = olGeoJson.extract.geometry.bind(olGeoJson);
         },
         _setup: function(){
             this.map = $('#' + this.options.target).data('mapbenderMbMap');
@@ -109,43 +116,7 @@
                 }
             }
 
-            // Iterating over all vector layers, not only the ones known to MapQuery
-            var geojsonFormat = new OpenLayers.Format.GeoJSON();
-            var vectorLayers = [];
-            for(var i = 0; i < this.map.map.olMap.layers.length; i++) {
-                var layer = this.map.map.olMap.layers[i];
-                if ('OpenLayers.Layer.Vector' !== layer.CLASS_NAME || layer.visibility === false || this.layer === layer) {
-                    continue;
-                }
-
-                var geometries = [];
-                for(var idx = 0; idx < layer.features.length; idx++) {
-                    var feature = layer.features[idx];
-                    if (!feature.onScreen(true)) continue
-                        var geometry = geojsonFormat.extract.geometry.apply(geojsonFormat, [feature.geometry]);
-
-                        if(feature.style !== null){
-                            geometry.style = feature.style;
-                        }else{
-                            geometry.style = layer.styleMap.createSymbolizer(feature,feature.renderIntent);
-                        }
-                        // only visible features
-                        if(geometry.style.fillOpacity > 0 && geometry.style.strokeOpacity > 0){
-                            geometries.push(geometry);
-                        } else if (geometry.style.label !== undefined){
-                            geometries.push(geometry);
-                        }
-                }
-
-                var lyrConf = {
-                    type: 'GeoJSON+Style',
-                    opacity: 1,
-                    geometries: geometries
-                };
-
-                vectorLayers.push(JSON.stringify(lyrConf))
-            }
-
+            var vectorLayers = this._collectGeometryLayers();
             var mapExtent = this.map.map.olMap.getExtent();
 
             if(num === 0){
@@ -171,8 +142,101 @@
                 form.submit();
                 form.remove();
             }
-        }
+        },
+        /**
+         * Should return true if the given layer needs to be included in export
+         *
+         * @param {OpenLayers.Layer.Vector|OpenLayers.Layer} layer
+         * @returns {boolean}
+         * @private
+         */
+        _filterGeometryLayer: function(layer) {
+            if ('OpenLayers.Layer.Vector' !== layer.CLASS_NAME || layer.visibility === false || this.layer === layer) {
+                return false;
+            }
+            if (!(layer.features && layer.features.length)) {
+                return false;
+            }
+            return true;
+        },
+        /**
+         * Should return true if the given feature should be included in export.
+         *
+         * @param {OpenLayers.Feature.Vector} feature
+         * @returns {boolean}
+         * @private
+         */
+        _filterFeature: function(feature) {
+            // onScreen throws an error if geometry is not populated, see
+            // https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Feature/Vector.js#L198
+            if (!feature.geometry || !feature.onScreen(true)) {
+                return false;
+            }
+            return true;
+        },
+        /**
+         * Extracts and preprocesses the geometry from a feature for export backend consumption.
+         *
+         * @param {OpenLayers.Layer.Vector|OpenLayers.Layer} layer
+         * @param {OpenLayers.Feature.Vector} feature
+         * @returns {Object} geojsonish, with (non-conformant) "style" entry bolted on (native Openlayers format!)
+         * @private
+         */
+        _extractFeatureGeometry: function(layer, feature) {
+            var geometry = this._geometryToGeoJson(feature.geometry);
+            if (feature.style !== null) {
+                // stringify => decode: makes a deep copy of the style at the moment of capture
+                geometry.style = JSON.parse(JSON.stringify(feature.style));
+            } else {
+                geometry.style = layer.styleMap.createSymbolizer(feature, feature.renderIntent);
+            }
+            return geometry;
+        },
+        /**
+         * Should return true if the given feature geometry should be included in export.
+         *
+         * @param geometry
+         * @returns {boolean}
+         * @private
+         */
+        _filterFeatureGeometry: function(geometry) {
+            if (geometry.style.fillOpacity > 0 || geometry.style.strokeOpacity > 0) {
+                return true;
+            }
+            if (geometry.style.label !== undefined) {
+                return true;
+            }
+            return false;
+        },
+        /**
+         * Should return export data (sent to backend) for the given geometry layer. Given layer is guaranteed
+         * to have passsed through the _filterGeometryLayer check positively.
+         *
+         * @param {OpenLayers.Layer.Vector|OpenLayers.Layer} layer
+         * @returns VectorLayerData~export
+         * @private
+         */
+        _extractGeometryLayerData: function(layer) {
+            var geometries = layer.features
+                .filter(this._filterFeature.bind(this))
+                .map(this._extractFeatureGeometry.bind(this, layer))
+                .filter(this._filterFeatureGeometry.bind(this))
+            ;
+            return {
+                type: 'GeoJSON+Style',
+                opacity: 1,
+                geometries: geometries
+            };
+        },
+        _collectGeometryLayers: function() {
+            // Iterating over all vector layers, not only the ones known to MapQuery
+            return this.map.map.olMap.layers
+                .filter(this._filterGeometryLayer.bind(this))
+                .map(this._extractGeometryLayerData.bind(this))
+            ;
+        },
 
+        _noDanglingCommaDummy: null
     });
 
 })(jQuery);

--- a/src/Mapbender/PrintBundle/Resources/views/Element/imageexport.html.twig
+++ b/src/Mapbender/PrintBundle/Resources/views/Element/imageexport.html.twig
@@ -1,5 +1,12 @@
 <div id="{{ id }}" class="mb-element mb-element-imageexport" title="{{ title|trans }}">
+  <form action="{{ submitUrl }}" method="post" target="{{ formTarget }}">
   <p>{{ 'mb.print.imageexport.chooseformat'| trans }}</p>
   <input type="radio" value="png" name="imageformat" checked>PNG<br>
   <input type="radio" value="jpeg" name="imageformat">JPG
+    <div class="hidden -fn-hidden-fields">
+    </div>
+    <div class="hidden">
+      <input type="submit" class="-fn-submit"/>
+    </div>
+  </form>
 </div>


### PR DESCRIPTION
Completely separates job data collection from form mangling / job submission (both ImageExport and PrintClient JavaScript) to facilitate alternative submission methods (non-form Ajax etc).   

PrintClient JavaScript widget now inherits from ImageExport JavaScript widget and common logic is reused.

Job data collection has been split up into multiple methods to facilitate customization of specific portions. 

ImageExport widget JS gains the following discrete methods related to job data collection:
* `_filterGeometryLayer`
* `_filterFeature`
* `_extractFeatureGeometry`
* `_filterFeatureGeometry`
* `_extractGeometryLayerData`
* `_getRasterSourceDefs`
* `_collectRasterLayerData`
* `_collectGeometryLayers`
* `_collectJobData`


PrintClient widget JS gains / extends the following methods related to job data collection:
* `_collectOverview`
* `_collectLegends`
* `_getRasterVisibilityInfo`
* `_filterGeometryLayer`
* `_filterFeature`
* `_collectRasterLayerData`
* `_collectGeometryLayers`
* `_collectJobData`

Forms for both ImageExport and PrintClient are now rendered completely, including action url, method and target, on the server.

Collateral fixes:
* empty feature geometries are filtered out on the client and not sent to the server for rendering
* dialog-type PrintClient now updates itself when reopened to react to zoom changes properly