### PR TITLE
Promises based ElementRegistry

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -51,19 +51,10 @@ Mapbender.ElementRegistry = (function($){
      * This promise will reject if the widget constructor throws an error.
      *
      * @param {string} ident id (leading hash optional) or class name (leading '.' required)
-     * @returns {Promise|null}
+     * @returns {Promise}
      */
     ElementRegistry.prototype.waitCreated = function(ident) {
-        var matches = this.match_(ident);
-        if (matches.length > 1) {
-            console.warn("Matched multiple elements, waiting on first", ident, matches);
-        }
-        if (matches.length) {
-            return matches[0].created.promise();
-        } else {
-            console.error("No element match for ident", ident);
-            return this.rejected_.promise();
-        }
+        return this.wait_(ident, 'created');
     };
     /**
      * Return a promise that will resolve once the widget with given ident has fired
@@ -71,15 +62,27 @@ Mapbender.ElementRegistry = (function($){
      * This promise will reject if the widget constructor throws an error.
      *
      * @param {string} ident id (leading hash optional) or class name (leading '.' required)
-     * @returns {Promise|null}
+     * @returns {Promise}
      */
     ElementRegistry.prototype.waitReady = function(ident) {
+        return this.wait_(ident, 'ready');
+    };
+    /**
+     * Returns the Promise at bundleKey in the promises bundle matched by given ident.
+     * If no tracked element matches ident, returns an already rejected Promise.
+     *
+     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
+     * @param {string} bundleKey 'created' or 'ready'
+     * @returns {Promise}
+     * @private
+     */
+    ElementRegistry.prototype.wait_ = function(ident, bundleKey) {
         var matches = this.match_(ident);
         if (matches.length > 1) {
             console.warn("Matched multiple elements, waiting on first", ident, matches);
         }
         if (matches.length) {
-            return matches[0].ready.promise();
+            return matches[0][bundleKey].promise();
         } else {
             console.error("No element match for ident", ident);
             return this.rejected_.promise();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -21,6 +21,51 @@ Mapbender.ElementRegistry = (function($){
     }
 
     /**
+     * Legacy API for registering callbacks on widget ready event.
+     * @param {string|int} targetId
+     * @param {function} callback
+     * @returns {Promise<any | never>}
+     */
+    ElementRegistry.prototype.onElementReady = function(targetId, callback) {
+        return this.waitReady(targetId).then(callback);
+    };
+    /**
+     * Return an object mapping widget name (string; e.g. 'mapbenderMbMap') to widget instance.
+     * NOTE: cannot differentiate between multiple instances of the same widget type
+     * @returns {*}
+     */
+    ElementRegistry.prototype.listWidgets = function() {
+        var data = {};
+        $('.mb-element').each(function(i, el) {
+            _.assign(data, $(el).data());
+        });
+        return data;
+    };
+    /**
+     * Return a promise that will resolve once the widget with given ident has been
+     * created (=immediately after return from widget constructor call).
+     * This promise will reject if the widget constructor throws an error.
+     *
+     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
+     * @returns {Promise|null}
+     */
+    ElementRegistry.prototype.waitCreated = function(ident) {
+        return this.getPromises_(ident).created.promise();
+    };
+    /**
+     * Return a promise that will resolve once the widget with given ident has fired
+     * its ready event.
+     * This promise will reject if the widget constructor throws an error.
+     *
+     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
+     * @returns {Promise|null}
+     */
+    ElementRegistry.prototype.waitReady = function(ident) {
+        return this.getPromises_(ident).ready.promise();
+    };
+    /**
+     * Adds given dom node to tracking, assuming it will be the target of an element widget
+     * constructor.
      *
      * @param {HTMLElement|jQuery} node
      * @param {string} readyEventName
@@ -115,28 +160,6 @@ Mapbender.ElementRegistry = (function($){
         // No match => error
         throw new Error("No tracking promises bundle for given element ident " + ident);
     };
-    /**
-     * Return a promise that will resolve once the widget with given ident has been
-     * created (=immediately after return from widget constructor call).
-     * This promise will reject if the widget constructor throws an error.
-     *
-     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
-     * @returns {Promise|null}
-     */
-    ElementRegistry.prototype.waitCreated = function(ident) {
-        return this.getPromises_(ident).created.promise();
-    };
-    /**
-     * Return a promise that will resolve once the widget with given ident has fired
-     * its ready event.
-     * This promise will reject if the widget constructor throws an error.
-     *
-     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
-     * @returns {Promise|null}
-     */
-    ElementRegistry.prototype.waitReady = function(ident) {
-        return this.getPromises_(ident).ready.promise();
-    };
     ElementRegistry.prototype.markCreated = function(ident, instance) {
         var bundle = this.getPromises_(ident);
         bundle.instance = instance;
@@ -156,26 +179,6 @@ Mapbender.ElementRegistry = (function($){
         var bundle = this.getPromises_(ident);
         bundle.ready.reject();
         bundle.created.reject();
-    };
-    /**
-     * Legacy API for registering callbacks on widget ready event.
-     * @param {string|int} targetId
-     * @param {function} callback
-     * @returns {Promise<any | never>}
-     */
-    ElementRegistry.prototype.onElementReady = function(targetId, callback) {
-        return this.waitReady(targetId).then(callback);
-    };
-    /**
-     * Return an object mapping widget name (string; e.g. 'mapbenderMbMap') to widget instance.
-     * @returns {*}
-     */
-    ElementRegistry.prototype.listWidgets = function() {
-        var data = {};
-        $('.mb-element').each(function(i, el) {
-            _.assign(data, $(el).data());
-        });
-        return data;
     };
     return ElementRegistry;
 }(jQuery));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -103,6 +103,9 @@ Mapbender.ElementRegistry = (function($){
         // and we want to resolve the ready promise WITH that instance.
         $.when(bundle.created, bundle.readyEvent).then(function() {
             bundle.ready.resolveWith(null, [bundle.instance]);
+        }, function() {
+            // Also reject ready promise if created promise rejects
+            bundle.ready.reject();
         });
         // record promises bundle in id index for id based lookups
         if (this.idIndex[id_]) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -98,6 +98,9 @@ Mapbender.ElementRegistry = (function($){
             // Leading dot: treat ident as a class name
             var candidates = this.classIndex[ident.slice(1)];
             if (candidates && candidates.length) {
+                if (candidates.length > 1) {
+                    console.warn("Matched multiple elements, returning first", ident, candidates);
+                }
                 /** @todo: find a clean API to support multiple matches */
                 return this.promisesBundles[candidates[0]];
             }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -2,53 +2,181 @@
 
 window.Mapbender = Mapbender || {};
 
-Mapbender.ElementRegistry = function(){
-    var registry = this;
-    registry.readyElements = {};
-    registry.readyCallbacks = {};
-    registry.onElementReady = function(targetId, callback){
-        if(true === callback) {
-            // Register as ready
-            registry.readyElements[targetId] = true;
-            // Execute all callbacks registered so far
-            if('undefined' !== typeof registry.readyCallbacks[targetId]) {
-                for(var idx in registry.readyCallbacks[targetId]) {
-                    registry.readyCallbacks[targetId][idx]();
+Mapbender.ElementRegistry = (function($){
+    'use strict';
+
+    /**
+     * @typedef {Object} ElementRegistry~promisesBundle
+     * @property {Promise} created
+     * @property {Promise} readyEvent
+     * @property {Promise} ready
+     * @property {int} offset
+     * @property {*} instance
+     */
+
+    function ElementRegistry() {
+        this.classIndex = {};
+        this.idIndex = {};
+        this.promisesBundles = [];
+    }
+
+    /**
+     *
+     * @param {HTMLElement|jQuery} node
+     * @param {string} readyEventName
+     */
+    ElementRegistry.prototype.trackElementNode = function(node, readyEventName) {
+        var nodeId = $(node).attr('id');
+        if (!nodeId) {
+            console.error('Cannot track element node without id', node);
+            throw new Error('Cannot track element node without id');
+        }
+        var bundle = this.trackId_(nodeId);
+        this.addTrackingByClass_(bundle, node);
+        // register one-time listener for ready event, which will trigger promise
+        // resolution
+        $(node).one(readyEventName, this.markReady.bind(this, nodeId));
+    };
+    /**
+     * @param {string|int} id
+     * @returns {ElementRegistry~promisesBundle}
+     * @private
+     */
+    ElementRegistry.prototype.trackId_ = function(id) {
+        // Force id to string, strip leading hash character if any
+        var id_ = ('' + id).replace(/^#*/, '');
+        // Create a new promises bundle: one promise resolving after widget
+        // creation; another promise resolving when widget fires its ready event.
+        var bundle = {
+            offset: this.promisesBundles.length,
+            created: $.Deferred(),
+            readyEvent: $.Deferred(),
+            ready: $.Deferred()
+        };
+        // Ready promise will resolve after both create and readyEvent. We do this
+        // because the widget instance is delivered at the time of create resolution,
+        // and we want to resolve the ready promise WITH that instance.
+        $.when(bundle.created, bundle.readyEvent).then(function() {
+            bundle.ready.resolveWith(null, [bundle.instance]);
+        });
+        // record promises bundle in id index for id based lookups
+        if (this.idIndex[id_]) {
+            console.error('Cannot track same dom id twice', id_);
+            throw new Error('Cannot track same dom id twice');
+        }
+        this.idIndex[id_] = bundle.offset;
+        this.promisesBundles.push(bundle);
+        return bundle;
+    };
+    /**
+     * @param {ElementRegistry~promisesBundle} bundle
+     * @param {HTMLElement|jQuery} node
+     */
+    ElementRegistry.prototype.addTrackingByClass_ = function(bundle, node) {
+        var classNames = ($(node).attr('class') || '').split(/\s+/);
+        var mbClasses = _.uniq(classNames.filter(function(c) {
+            return !!c.match(/^mb-element-/);
+        }));
+        // record same promises bundle in class index for class-name based lookups
+        if (mbClasses.length) {
+            for (var i = 0; i < mbClasses.length; ++i) {
+                var nextClass = mbClasses[i];
+                if (!this.classIndex[nextClass]) {
+                    this.classIndex[nextClass] = [];
                 }
-                // Finally, remove readyCallback list, so they may be garbage
-                // collected if no one else is keeping them
-                delete registry.readyCallbacks[targetId];
-            }
-        } else if('function' === typeof callback) {
-            if(true === registry.readyElements[targetId]) {
-                // If target is ready already, execute callback right away
-                callback();
-            } else {
-                // Register callback for targetId for later execution
-                registry.readyCallbacks[targetId] = registry.readyCallbacks[targetId] || [];
-                registry.readyCallbacks[targetId].push(callback);
+                this.classIndex[nextClass].push(bundle.offset);
             }
         } else {
-            throw 'ElementRegistry.onElementReady callback must be function or undefined!';
+            // Warn; suppress warning for super-common .mb-button class
+            if (-1 === classNames.indexOf('mb-button')) {
+                console.warn("Tracking dom node in registry that doesn't have any mb-element-* class name", node);
+            }
         }
     };
-
-    registry.listWidgets = function(){
-        var list = {};
-        var elements = $(".mb-element");
-        $.each(elements, function(idx, el){
-            var data = $(el).data();
-            if(!data) {
-                return;
+    ElementRegistry.prototype.getPromises_ = function(ident) {
+        if (ident.length > 1 && ident[0] === '.') {
+            // Leading dot: treat ident as a class name
+            var candidates = this.classIndex[ident.slice(1)];
+            if (candidates && candidates.length) {
+                /** @todo: find a clean API to support multiple matches */
+                return this.promisesBundles[candidates[0]];
             }
-            for(var id in data) {
-                list[id] = data[id];
+        } else {
+            // Treat ident as a DOM id
+            // Force string, no leading hash
+            var id = ('' + ident).replace(/^#*/, '');
+            if (typeof this.idIndex[id] !== 'undefined') {
+                return this.promisesBundles[this.idIndex[id]];
             }
-        });
-        return list;
+        }
+        // No match => error
+        throw new Error("No tracking promises bundle for given element ident " + ident);
     };
+    /**
+     * Return a promise that will resolve once the widget with given ident has been
+     * created (=immediately after return from widget constructor call).
+     * This promise will reject if the widget constructor throws an error.
+     *
+     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
+     * @returns {Promise|null}
+     */
+    ElementRegistry.prototype.waitCreated = function(ident) {
+        return this.getPromises_(ident).created.promise();
+    };
+    /**
+     * Return a promise that will resolve once the widget with given ident has fired
+     * its ready event.
+     * This promise will reject if the widget constructor throws an error.
+     *
+     * @param {string} ident id (leading hash optional) or class name (leading '.' required)
+     * @returns {Promise|null}
+     */
+    ElementRegistry.prototype.waitReady = function(ident) {
+        return this.getPromises_(ident).ready.promise();
+    };
+    ElementRegistry.prototype.markCreated = function(ident, instance) {
+        var bundle = this.getPromises_(ident);
+        bundle.instance = instance;
+        bundle.created.resolveWith(null, [instance]);
+    };
+    ElementRegistry.prototype.markReady = function(ident) {
+        var bundle = this.getPromises_(ident);
+        bundle.readyEvent.resolve();
+    };
+    /**
+     * Notify all dependents on widget with given ident that creation has failed and ready event
+     * will never fire.
+     *
+     * @param {string|int} ident either '.class-name' or the dom id
+     */
+    ElementRegistry.prototype.markFailed = function(ident) {
+        var bundle = this.getPromises_(ident);
+        bundle.ready.reject();
+        bundle.created.reject();
+    };
+    /**
+     * Legacy API for registering callbacks on widget ready event.
+     * @param {string|int} targetId
+     * @param {function} callback
+     * @returns {Promise<any | never>}
+     */
+    ElementRegistry.prototype.onElementReady = function(targetId, callback) {
+        return this.waitReady(targetId).then(callback);
+    };
+    /**
+     * Return an object mapping widget name (string; e.g. 'mapbenderMbMap') to widget instance.
+     * @returns {*}
+     */
+    ElementRegistry.prototype.listWidgets = function() {
+        var data = {};
+        $('.mb-element').each(function(i, el) {
+            _.assign(data, $(el).data());
+        });
+        return data;
+    };
+    return ElementRegistry;
+}(jQuery));
 
-};
 Mapbender.elementRegistry = new Mapbender.ElementRegistry();
 
 /**
@@ -83,27 +211,28 @@ Mapbender.initElement = function(id, data) {
     if (!mapbenderWidget) {
         throw new Error("No such widget " + data.init);
     }
-
-    // Register for ready event to operate ElementRegistry
-    widgetElement.one(readyEvent, function(event) {
-        var elements = Mapbender.configuration.elements;
-        for (var i in elements) {
-            var conf = elements[i];
-            var widget = conf.init.split('.');
-            var widgetName = widget[1];
-            var readyEvent = widgetName.toLowerCase() + 'ready';
-            if(readyEvent === event.type) {
-                Mapbender.elementRegistry.onElementReady(i, true);
-            }
-        }
-    });
-
-    // Initialize element
-    mapbenderWidget(data.configuration, widgetId);
+    return mapbenderWidget(data.configuration, widgetId);
 };
 
 Mapbender.source = Mapbender.source || {};
 Mapbender.setup = function(){
+    $.each(Mapbender.configuration.elements, function(id, data) {
+        // Mark all elements for elementRegistry tracking before calling the constructors.
+        // This is necessary to correctly record ready events of elements that become
+        // ready immediately in their widget constructor / _create method, most notably
+        // mapbenderMbMap.
+        // @todo: fold copy&paste between this method and initElement
+        var widgetId = '#' + id;
+        var $node = $(widgetId);
+        var widgetInfo = data.init.split('.');
+        var widgetName = widgetInfo[1];
+        var readyEventName = widgetName.toLowerCase() + 'ready';
+        if ($node.length) {
+            Mapbender.elementRegistry.trackElementNode($node, readyEventName);
+        } else {
+            console.error("No matching dom node for configured element", id, data);
+        }
+    });
 
     // Initialize all elements by calling their init function with their options
     $.each(Mapbender.configuration.elements, function(id, data){
@@ -111,11 +240,13 @@ Mapbender.setup = function(){
         // NOTE: do not set undefined; undefined captures NO STACK TRACE AT ALL in some browsers
         Error.stackTraceLimit = 100;
         try {
-            Mapbender.initElement(id,data);
+            var instance = Mapbender.initElement(id, data);
+            Mapbender.elementRegistry.markCreated(id, instance);
         } catch(e) {
+            Mapbender.elementRegistry.markFailed(id);
             // NOTE: console.error produces a NEW stack trace that ends right here, and as such
             //       won't point to the origin of the Error at all.
-            console.error("Element " + id + " failed to initialize:", e.message);
+            console.error("Element " + id + " failed to initialize:", e.message, data);
             if (Mapbender.configuration.application.debug) {
                 // Log original stack trace (clickable in Chrome, unfortunately not in Firefox) separately
                 console.log(e.stack);


### PR DESCRIPTION
Switches Mapbender.ElementRegistry internal machinations to use [promises](https://promisesaplus.com/) as implemented by [jQuery.Deferred](http://api.jquery.com/jQuery.Deferred/).  

Maintains previous public API ([listWidgets](https://github.com/mapbender/mapbender/blob/697d4585f06c4e03376ad273ec096c3b3b1cc1c4/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js#L37), [onElementReady](https://github.com/mapbender/mapbender/blob/697d4585f06c4e03376ad273ec096c3b3b1cc1c4/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js#L29)) while adding new promise-returning methods.   
[waitCreated](https://github.com/mapbender/mapbender/blob/697d4585f06c4e03376ad273ec096c3b3b1cc1c4/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js#L52) returns a promise that resolves after widget construction.  
[waitReady](https://github.com/mapbender/mapbender/blob/697d4585f06c4e03376ad273ec096c3b3b1cc1c4/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js#L63) returns a promise that resolves after the widget fires its ready event.

## Benefits ##  
1) Resolve handler receives widget instance as argument
```js
Mapbender.elementRegistry.waitReady(this.options.target).then(function(mapWidget) {
    console.log("Map widget is ready", mapWidget);
    console.log("Map widget dom element:", mapWidget.element);
    console.log("Map widget options:", mapWidget.options);
   <...>
});
```

2) Can register error callbacks; either as second argument to `.then` (Promise spec) or `.fail` (jQuery API)
```js
// Errback as second argument to .then (Promises/A+)
Mapbender.elementRegistry.waitReady(this.options.target).then(function(mapWidget) {
    console.log("Map is ready", mapWidget);
}, function() {
    console.log("Map failed to initialize");
});

// Errback registered via .fail (jQuery Deferred extension)
Mapbender.elementRegistry.waitReady(this.options.target).then(function(mapWidget) {
    console.log("Map is ready", mapWidget);
}).fail(function() {
    console.log("Map failed to initialize");
});
```

3) Can separately react to widget construction before ready event comes up
```js
Mapbender.elementRegistry.waitCreated(this.options.target).then(function(targetWidget) {
    console.log("Target created", targetWidget);
    self.targetState = targetWidget.options.autoOpen;
});
Mapbender.elementRegistry.waitReady(this.options.target).then(function(targetWidget) {
    console.log("Target is now ready", targetWidget);
}, function() {
    console.log("Error in target initialization, will not become ready");
    self.targetState = false;
});
```

4) Element lifecycle events can now be mixed with other asynchronous operations in a single [`$.when`](http://api.jquery.com/jQuery.when/). This opens opportunities to start element-dependent loading operations both earlier and with greater parallelism. E.g.:
```js
$.when(
    Mapbender.elementRegistry.waitReady(this.options.target),   // map must be ready before we can draw
    this.loadStyles(),      // Ajax request; starts immediately
    this.loadFeatures()   // Ajax request; starts immediately
).then(function(mapWidget, styleResponse, featureResponse) {
    // only called after all three promises have resolved
    self.redraw(...);
}, function() {
   // called if any of the above three promises failed
});
```

5) Can alternatively wait for / register handlers on a Mapbender Element by class name
```js
Mapbender.elementRegistry.waitCreated('.mb-element-overview').then(function(overviewWidget) {
    console.log("Found an overview widget", overviewWidget);
});
```

## Motivation ##
1) Previous architecture offered no support for soft error handling in dependencies, such as GPS Element integration into other elements when browser location API is disabled.
2) Previous architecture did not support "scanning for element" / "scanning other element options" use cases without also delaying code execution until the ready event of the inspected element; impediment to implementing client-side plugin models
3) Previous architecture favoured "map ready first" approach, delaying asynchronous loads, slowing down final client application initialization
4) Previous architecture offered no support for waiting on multiple elements
