### PR TITLE
Fix/printclient controllable form field order

### DIFF
--- a/src/Mapbender/CoreBundle/Element/PrintClient.php
+++ b/src/Mapbender/CoreBundle/Element/PrintClient.php
@@ -109,6 +109,7 @@ class PrintClient extends Element
                 "title" => array("label" => 'Title', "options" => array("required" => false)),
                 "comment1" => array("label" => 'Comment 1', "options" => array("required" => false)),
                 "comment2" => array("label" => 'Comment 2', "options" => array("required" => false))),
+            'required_fields_first' => false,
             "replace_pattern" => null,
             "file_prefix" => 'mapbender'
         );

--- a/src/Mapbender/CoreBundle/Element/Type/PrintClientAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/PrintClientAdminType.php
@@ -57,6 +57,9 @@ class PrintClientAdminType extends AbstractType
             ->add('legend', 'checkbox',array('required' => false))
             ->add('legend_default_behaviour', 'checkbox',array('required' => false))
             ->add('optional_fields', new YAMLConfigurationType(), array('required' => false,'attr' => array('class' => 'code-yaml')))
+            ->add('required_fields_first', 'checkbox', array(
+                'required' => false,
+            ))
             ->add('replace_pattern', new YAMLConfigurationType(),array('required' => false,'attr' => array('class' => 'code-yaml')))
             ->add('templates', 'collection', array(
                 'type' => new PrintClientTemplateAdminType(),

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -325,6 +325,7 @@ mb:
           rotatable: Drehbar
           legend: 'Legende drucken'
           legend_default_behaviour: 'Legenden Checkbox aktiv'
+          required_fields_first: Pflichtfelder ganz oben anzeigen
       copyright:
         label:
           autoopen: 'Automatisches Öffnen'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -324,6 +324,7 @@ mb:
           rotatable: Rotatable
           legend: 'Print legend'
           legend_default_behaviour: 'Legend checkbox active'
+          required_fields_first: Display required fields first
       copyright:
         label:
           autoopen: Auto-open

--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -17,8 +17,8 @@
             <ul class="dropdownList"></ul>
         </div>
 
-        {# render required extra fields on top of the form #}
-        {% if configuration.optional_fields is not empty %}
+        {# render required extra fields on top of the form if configured #}
+        {% if configuration.optional_fields is not empty and configuration.required_fields_first %}
             {% for key,field in configuration.optional_fields %}
                 {% if field.options.required %}
                     <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}
@@ -61,9 +61,15 @@
         {# render non-required extra fields here #}
         {% if configuration.optional_fields is not empty %}
             {% for key,field in configuration.optional_fields %}
-                {% if not field.options.required %}
-                    <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}</label>
-                    <input type="text" class="input validationInput" name="extra[{{ key }}]">
+                {% if not configuration.required_fields_first or not field.options.required %}
+                    <label class="labelInput" for="extra[{{ key }}]">{{ field.label }}
+                    {% if field.options.required %}
+                        <span class="required">*</span></label>
+                        <input type="text" class="input validationInput" name="extra[{{ key }}]" required="required">
+                    {% else %}
+                        </label>
+                        <input type="text" class="input validationInput" name="extra[{{ key }}]">
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         {% endif %}

--- a/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/printclient.html.twig
@@ -6,17 +6,6 @@
     {% endif %}
     
     <form id="formats" action="{{ submitUrl }}" method="post" target="{{ formTarget }}">
-        <label class="labelInput">{{ 'mb.core.printclient.label.template' | trans }}</label>
-        <div class="dropdown">
-            <select name="template" class="hiddenDropdown">
-                {% for id, template in configuration.templates %}
-                    <option value="{{ id }}">{{ template.label }}</option>
-                {% endfor %}
-            </select>
-            <div class="dropdownValue iconDown"></div>
-            <ul class="dropdownList"></ul>
-        </div>
-
         {# render required extra fields on top of the form if configured #}
         {% if configuration.optional_fields is not empty and configuration.required_fields_first %}
             {% for key,field in configuration.optional_fields %}
@@ -28,6 +17,17 @@
                 {% endif %}
             {% endfor %}
         {% endif %}
+
+        <label class="labelInput">{{ 'mb.core.printclient.label.template' | trans }}</label>
+        <div class="dropdown">
+            <select name="template" class="hiddenDropdown">
+                {% for id, template in configuration.templates %}
+                    <option value="{{ id }}">{{ template.label }}</option>
+                {% endfor %}
+            </select>
+            <div class="dropdownValue iconDown"></div>
+            <ul class="dropdownList"></ul>
+        </div>
 
         <label class="labelInput">{{ 'mb.core.printclient.label.quality' | trans }}</label>
         <div class="dropdown">

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/printclient.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/printclient.html.twig
@@ -36,7 +36,9 @@
     {{ form_label(form.configuration.templates) }}{{ form_widget(form.configuration.templates) }}
     <hr>
     <br>
-    {{ form_label(form.configuration.optional_fields) }}{{ form_widget(form.configuration.optional_fields) }}
+    {{ form_row(form.configuration.optional_fields) }}
+    {{ form_widget(form.configuration.required_fields_first) }}<label for="{{form.configuration.required_fields_first.vars.id}}" class="labelCheck">{{'mb.core.admin.printclient.label.required_fields_first'|trans}}</label>
+    <div class="clearContainer"></div>
     {{ form_label(form.configuration.replace_pattern) }}{{ form_widget(form.configuration.replace_pattern) }}
     
 </div>


### PR DESCRIPTION
Followup to 3.0.7.5 PrintClient frontend form order change.  
PrintClient backend gains a new checkbox that controls ordering of required `optional_fields` relative to rest of the form. Default value is pre-3.0.7.5 behavior (`required` fields render together with non-required fields near the bottom of the form, before the legend checkbox).

Frontend form comparison screenshot shows new default behavior to the left, behavior with new checkbox checked on the right.

![printclient-configurable-field-order](https://user-images.githubusercontent.com/24895932/47983154-a58c7600-e0d2-11e8-8106-b1c99fa1e6e6.png)
