### PR TITLE
Fix/clean up vendorspecifics

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Source/CustomParameter.php
+++ b/src/Mapbender/CoreBundle/Component/Source/CustomParameter.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Source;
+
+
+class CustomParameter
+{
+    public $name;
+    public $default;
+    public $hidden = false;
+
+    /**
+     * Set name
+     *
+     * @param string $value
+     */
+    public function setName($value)
+    {
+        $this->name = $value;
+    }
+
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setDefault($value)
+    {
+        $this->default = $value;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHidden()
+    {
+        return $this->hidden;
+    }
+
+    /**
+     * @param $hidden
+     */
+    public function setHidden($hidden)
+    {
+        $this->hidden = $hidden;
+    }
+}

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceService.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceService.php
@@ -50,7 +50,6 @@ class WmsSourceService extends SourceService
             'transparent' => $sourceInstance->getTransparency(),
             'tiled' => $sourceInstance->getTiled(),
             'bbox' => $this->getBboxConfiguration($sourceInstance),
-            'vendorspecifics' => $this->getVendorSpecificsConfiguration($sourceInstance),
             'dimensions' => $this->getDimensionsConfiguration($sourceInstance),
             'buffer' => $buffer,
             'ratio' => $ratio,
@@ -199,18 +198,6 @@ class WmsSourceService extends SourceService
             }
         }
         return $dimensions;
-    }
-
-    public function getVendorSpecificsConfiguration(WmsInstance $sourceInstance)
-    {
-        $vendorSpecific = array();
-        foreach ($sourceInstance->getVendorspecifics() as $key => $vendorspec) {
-            $handler = new VendorSpecificHandler($vendorspec);
-            if ($vendorspec->getVstype() === VendorSpecific::TYPE_VS_SIMPLE && $handler->isVendorSpecificValueValid()) {
-                $vendorSpecific[] = $handler->getConfiguration();
-            }
-        }
-        return $vendorSpecific;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/VendorSpecific.php
+++ b/src/Mapbender/WmsBundle/Component/VendorSpecific.php
@@ -11,13 +11,6 @@ use Mapbender\CoreBundle\Component\Source\CustomParameter;
  */
 class VendorSpecific extends CustomParameter
 {
-    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
-    const TYPE_SINGLE           = 'single';
-    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
-    const TYPE_INTERVAL         = 'interval';
-    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
-    const TYPE_MULTIPLE         = 'multiple';
-
     const TYPE_VS_SIMPLE = 'simple';
     const TYPE_VS_USER = 'user';
     const TYPE_VS_GROUP = 'groups';
@@ -61,22 +54,5 @@ class VendorSpecific extends CustomParameter
             'hidden' => $this->getHidden(),
             'vstype' => $this->getVstype(),
         );
-    }
-
-    /**
-     * @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer
-     */
-    final public function getType()
-    {
-        return -1;
-    }
-
-    /**
-     * @return null
-     * @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer
-     */
-    final public function getExtent()
-    {
-        return null;
     }
 }

--- a/src/Mapbender/WmsBundle/Component/VendorSpecific.php
+++ b/src/Mapbender/WmsBundle/Component/VendorSpecific.php
@@ -2,84 +2,81 @@
 
 namespace Mapbender\WmsBundle\Component;
 
+use Mapbender\CoreBundle\Component\Source\CustomParameter;
+
 /**
  * Identifier class.
  *
  * @author Paul Schmidt
  */
-class VendorSpecific extends DimensionInst
+class VendorSpecific extends CustomParameter
 {
+    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
+    const TYPE_SINGLE           = 'single';
+    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
+    const TYPE_INTERVAL         = 'interval';
+    /** @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer */
+    const TYPE_MULTIPLE         = 'multiple';
 
     const TYPE_VS_SIMPLE = 'simple';
     const TYPE_VS_USER = 'user';
     const TYPE_VS_GROUP = 'groups';
 
-    /**
-     * ORM\Column(type="string", nullable=false)
-     */
     public $vstype;
 
     /**
-     * ORM\Column(type="string", nullable=false)
+     * @return string|null
      */
-    public    $hidden = false;
-
-    /**
-     * @var mixed|null
-     */
-    public $origextentextent;
-
     public function getVstype()
     {
         return $this->vstype;
     }
 
+    /**
+     * @param string $vstype one of the VS_TYPE_* consts
+     */
     public function setVstype($vstype)
     {
         $this->vstype = $vstype;
-        return $this;
-    }
-
-    public function getHidden()
-    {
-        return $this->hidden;
-    }
-    
-    public function setExtent($extent)
-    {
-        $this->extent = $this->origextentextent = $extent;
-        return $this;
-    }
-    
-    public function getOrigextent()
-    {
-        if(!$this->origextentextent){
-            $this->origextentextent = $this->extent;
-        }
-        return $this->origextentextent;
-    }
-
-    public function setHidden($hidden)
-    {
-        $this->hidden = $hidden;
-        return $this;
     }
 
     /**
-     * Generates a GET parameter name for this dimension.
      * @return string parameter name
      */
     public function getParameterName()
     {
         return $this->name;
     }
-    
+
+    /**
+     * @deprecated, only used (indirectly) by WmcParser110
+     * @return array
+     */
     public function getConfiguration()
     {
-        $array = parent::getConfiguration();
-        $array['hidden'] = $this->getHidden();
-        $array['vstype'] = $this->getVstype();
-        return $array;
+        return array(
+            'default' => $this->getDefault(),
+            'name' => $this->getName(),
+            '__name' => $this->getParameterName(),
+            'hidden' => $this->getHidden(),
+            'vstype' => $this->getVstype(),
+        );
     }
 
+    /**
+     * @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer
+     */
+    final public function getType()
+    {
+        return -1;
+    }
+
+    /**
+     * @return null
+     * @deprecated, remove after cleaning up extent processing from VendorSpecificTransformer
+     */
+    final public function getExtent()
+    {
+        return null;
+    }
 }

--- a/src/Mapbender/WmsBundle/Form/DataTransformer/VendorSpecificTransformer.php
+++ b/src/Mapbender/WmsBundle/Form/DataTransformer/VendorSpecificTransformer.php
@@ -14,20 +14,6 @@ use Symfony\Component\Form\DataTransformerInterface;
  */
 class VendorSpecificTransformer implements DataTransformerInterface
 {
-
-    /**
-     * Creates an instance.
-     * 
-     * @param ObjectManager $om an object manager
-     * @param string $classname an entity class name
-     */
-    public function __construct()#ObjectManager $om, $classname)
-    {
-        $a = 0;
-//        $this->om = $om;
-//        $this->classname = $classname;
-    }
-
     /**
      * Transforms an object to an array.
      *
@@ -38,13 +24,6 @@ class VendorSpecificTransformer implements DataTransformerInterface
     {
         if (!$data) {
             return null;
-        }
-        if ($data instanceof VendorSpecific && is_array($data->getExtent())) {#isset($data['extent']) && is_array($data['extent']) && $data['type'] === DimensionInst::TYPE_MULTIPLE){
-            if ($data->getType() === VendorSpecific::TYPE_MULTIPLE) {
-                $data->setExtent(implode(',', $data->getExtent()));
-            } else if ($data->getType() === VendorSpecific::TYPE_INTERVAL) {
-                $data->setExtent(implode('/', $data->getExtent()));
-            }
         }
         return ArrayObject::objectToArray($data);
     }
@@ -59,13 +38,6 @@ class VendorSpecificTransformer implements DataTransformerInterface
     {
         if (null === $data) {
             return "";
-        }
-        if (isset($data['extent']) && !is_array($data['extent'])) {
-            if($data['type'] === VendorSpecific::TYPE_MULTIPLE){
-                $data['extent'] = explode(",", $data['extent']);
-            } else if($data['type'] === VendorSpecific::TYPE_MULTIPLE){
-                $data['extent'] = explode("/", $data['extent']);
-            }
         }
         return ArrayObject::arrayToObject("Mapbender\WmsBundle\Component\VendorSpecific", $data);
     }

--- a/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
@@ -30,7 +30,6 @@ class VendorSpecificType extends AbstractType
         $resolver->setDefaults(array(
             'type' => VS::TYPE_SINGLE,
             'name' => '',
-            'extent' => '',
             'vstype' => VS::TYPE_VS_SIMPLE,
             'hidden' => false,
         ));
@@ -51,8 +50,6 @@ class VendorSpecificType extends AbstractType
             ->add('name', 'text', array(
                 'required' => true))
             ->add('default', 'text', array(
-                'required' => true,))
-            ->add('extent', 'text', array(
                 'required' => true,))
             ->add('vstype', 'choice',
                   array(

--- a/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
@@ -57,7 +57,8 @@ class VendorSpecificType extends AbstractType
             ->add('hidden', 'checkbox', array(
                 'required' => false,
             ))
-            ->addModelTransformer(new VendorSpecificTransformer());
+            ->addModelTransformer(new VendorSpecificTransformer())
+        ;
     }
 
 }

--- a/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/VendorSpecificType.php
@@ -28,7 +28,6 @@ class VendorSpecificType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'type' => VS::TYPE_SINGLE,
             'name' => '',
             'vstype' => VS::TYPE_VS_SIMPLE,
             'hidden' => false,
@@ -40,27 +39,24 @@ class VendorSpecificType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('type', 'choice',
-                      array(
-                'required' => true,
-                'choices' => array(
-                    VS::TYPE_SINGLE => VS::TYPE_SINGLE,
-                    VS::TYPE_MULTIPLE => VS::TYPE_MULTIPLE,
-                    VS::TYPE_INTERVAL => VS::TYPE_INTERVAL)))
-            ->add('name', 'text', array(
-                'required' => true))
-            ->add('default', 'text', array(
-                'required' => true,))
-            ->add('vstype', 'choice',
-                  array(
+        $builder
+            ->add('vstype', 'choice', array(
                 'required' => true,
                 'choices' => array(
                     VS::TYPE_VS_SIMPLE => VS::TYPE_VS_SIMPLE,
                     VS::TYPE_VS_USER => VS::TYPE_VS_USER,
-                    VS::TYPE_VS_GROUP => VS::TYPE_VS_GROUP)))
-            ->add('hidden', 'checkbox',
-                  array(
-                'required' => false))
+                    VS::TYPE_VS_GROUP => VS::TYPE_VS_GROUP
+                ),
+            ))
+            ->add('name', 'text', array(
+                'required' => true,
+            ))
+            ->add('default', 'text', array(
+                'required' => true,
+            ))
+            ->add('hidden', 'checkbox', array(
+                'required' => false,
+            ))
             ->addModelTransformer(new VendorSpecificTransformer());
     }
 

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.wms.dimension.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.wms.dimension.js
@@ -1,117 +1,196 @@
 var Mapbender = Mapbender || {};
-//Mapbender.IDimension = Interface({
-//    'public getOptions': function(){},
-//    'public getDefault': function(){},
-//    'public setDefault': function(val){},
-//    'public getStepsNum': function(){},
-//    'public partFromValue': function(val){},
-//    'public stepFromPart': function(part){},
-//    'public stepFromValue': function(val){},
-//    'public valueFromPart': function(part){},
-//    'public valueFromStart': function(){},
-//    'public valueFromEnd': function(){},
-//    'public innerJoin': function(another){},
-//    'public getInRange': function(min, max, value){}
-//});
-Mapbender.Dimension = function (options) {
-    if (options.type === 'interval' && options.name === 'time') {
+
+Mapbender.Dimension = function(options) {
+    if(options.type === 'interval' && options.name === 'time') {
         return new Mapbender.DimensionTime(options);
-    } else if (options.type === 'interval') {
+    } else if(options.type === 'interval') {
         return new Mapbender.DimensionScalar(options);
-    } else if (options.type === 'multiple') {
+    } else if(options.type === 'multiple') {
         return new Mapbender.DimensionScalar(options); // Add MultipleScalar ???
     } else {
         return null;
     }
 };
-Mapbender.DimensionScalar = Class({//{implements: Mapbender.IDimension}, {
-    'public object options': {},
-    'public default_': null,
-    'public number stepsNum': -1,
-    __construct: function (options, initDefault) {
-            this.options = options;
-        if (initDefault) {
-            this.setValue(this.getInRange(this.valueFromPart(0), this.valueFromPart(1),
-                    this.options['default'] === null ? options.extent[0] : options['default']));
-        }
-    },
-    'public getOptions': function () {
-        return this.options;
-    },
-    'public getDefault': function () {
-        return this.default_;
-    },
-    'public setDefault': function (val) {
-        this.default_ = val;
-    },
-    'public getStepsNum': function () {
-        if (this.stepsNum !== -1) {
-            return this.stepsNum;
-        } else if (this.options.type === 'interval') {
-            return Math.round(Math.abs(this.options.extent[1] - this.options.extent[0]) / this.options.extent[2]);
-        } else if (this.options.type === 'multiple') {
-            return this.options.extent.length;
-        }
-    },
-    'public partFromValue': function (val) {
-        if (this.options.type === 'interval') {
-            return Math.abs(val - this.options.extent[0]) / Math.abs(this.options.extent[1] - this.options.extent[0]);
-        } else if (this.options.type === 'multiple') {
-            for (var i = 0; i < this.options.extent.length; i++) {
-                if (val === this.options.extent[i]) {
-                    return i / (this.getStepsNum() + 1);
-                }
-            }
-            return 0;
-        }
-    },
-    'public stepFromPart': function (part) {
-        return Math.round(part * (this.getStepsNum()));
-    },
-    'public stepFromValue': function (val) {
-        return this.stepFromPart(this.partFromValue(val));
-    },
-    'public valueFromPart': function (part) {
-        var step = this.stepFromPart(part);
-        return this.options.extent[step];
-    },
-    'public valueFromStart': function () {
-        return this.options.extent[0];
-    },
-    'public valueFromEnd': function () {
-        return this.options.extent[this.options.extent.length - 1];
-    },
-    'public innerJoin': function (another) {
-        if (this.asc !== another.asc) {
-            return null;
-        }
-        //TODO
-    },
-    'public getInRange': function (min, max, value) {
-        var partMin = this.partFromValue(min);
-        var partMax = this.partFromValue(max);
-        if (partMin < 0 || partMax > 1) {
-            return null;
-        }
-        var partValue = this.partFromValue(value);
-        return this.valueFromPart(partValue <= partMin ? partMin : partValue >= partMax ? partMax : partValue);
-    }
-});
 
-Mapbender.DimensionFormat = function (value, numDig) {
-    var d = numDig - ('' + value).length;
-    while (d > 0) {
-        value = '0' + value;
-        d--;
-    }
-    return value;
+Mapbender.DimensionScalar  = function(){};
+Mapbender.DimensionScalar.prototype.options = {
+    default: null,
+    extend:  []
+
 };
-Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,implements: Mapbender.IDimension}, {
+
+
+Mapbender.DimensionScalar.prototype.default = null;
+Mapbender.DimensionScalar.prototype.stepsNum = -1;
+Mapbender.DimensionScalar.prototype.Types = {
+    INTERVAL: 'interval',
+    MULTIPLE: 'multiple'
+};
+Mapbender.DimensionScalar.prototype.constructor = function(options, initDefault) {
+
+    var min, max, value, hasDefaultOptions;
+
+    if(Object.prototype.toString.call(options.extent) !== '[object Array]') {
+        throw 'DimensionScalar extent option has to be type [object Array]:' + Object.prototype.toString.call(options.extent) + 'given'
+    }
+
+    if(options.extent.length < 2) {
+
+        throw 'DimensionScalar extent option needs atleast two entries'
+    }
+
+    this.options = options;
+
+    if(initDefault) {
+        max = this.valueFromPart(1);
+        min = this.valueFromPart(0);
+        hasDefaultOptions = this.options.default !== null;
+        value = !hasDefaultOptions ? options.extent[0] : options['default'];
+        this.setDefault(min, max, value);
+    }
+};
+
+Mapbender.DimensionScalar.prototype.getOptions = function() {
+    return this.options;
+};
+
+Mapbender.DimensionScalar.prototype.setOptions = function(options) {
+
+    if(Object.prototype.toString.call(options.extent) !== '[object Array]') {
+        throw 'DimensionScalar extent option has to be type [object Array]:' + Object.prototype.toString.call(options.extent) + 'given'
+    }
+    return this.options = options;
+
+};
+
+Mapbender.DimensionScalar.prototype.getDefault = function() {
+    return this.default;
+};
+
+Mapbender.DimensionScalar.prototype.setDefault = function(defaults) {
+
+    return this.default = defaults;
+
+};
+
+Mapbender.DimensionScalar.prototype.getStepsNum = function() {
+
+    if(this.stepsNum !== -1) {
+        return this.stepsNum;
+    }
+
+    switch(this.options.type){
+        case Mapbender.DimensionScalar.Types.INTERVAL :
+            return Math.round(Math.abs(this.options.extent[1] - this.options.extent[0]) / this.options.extent[2]);
+        case Mapbender.DimensionScalar.Types.MULTIPLE:
+            return this.options.extent.length;
+
+    }
+
+    return this.stepsNum;
+
+};
+
+    Mapbender.DimensionScalar.prototype.partFromValue =   function(val) {
+
+    switch(this.options.type){
+        case Mapbender.DimensionScalar.Types.INTERVAL :
+            return Math.abs(val - this.options.extent[0]) / Math.abs(this.options.extent[1] - this.options.extent[0]);
+
+        case Mapbender.DimensionScalar.Types.MULTIPLE:
+            var extent = this.options.extent;
+            _.each(extent, function(extentValue, index){
+                if(val === extentValue ){
+                    return index / (this.getStepsNum() + 1);
+                }
+            }, this);
+
+    }
+
+    return 0;
+
+};
+
+Mapbender.DimensionScalar.prototype.stepFromPart =  function(part) {
+    return Math.round(part * (this.getStepsNum()));
+};
+
+
+
+Mapbender.DimensionScalar.prototype.stepFromValue =  function(val) {
+    return this.stepFromPart(this.partFromValue(val));
+};
+
+
+Mapbender.DimensionScalar.prototype.valueFromPart =    function(part) {
+    var step = this.stepFromPart(part);
+    return this.options.extent[step];
+};
+
+
+Mapbender.DimensionScalar.prototype.valueFromStart = function() {
+    return this.options.extent[0];
+};
+
+
+Mapbender.DimensionScalar.prototype.valueFromEnd = function() {
+    return this.options.extent[this.options.extent.length - 1];
+};
+Mapbender.DimensionScalar.prototype.innerJoin = function() {
+    //Todo
+    console.warn('DimensionScalar.innerJoin() is not implemented yet!');
+    return null;
+};
+
+Mapbender.DimensionScalar.prototype.getInRange = function(min, max, value) {
+    var partMin = this.partFromValue(min);
+    var partMax = this.partFromValue(max);
+    if(partMin < 0 || partMax > 1) {
+        return null;
+    }
+    var partValue = this.partFromValue(value);
+    var isPartValueSmallerOrEqualsPartMin = partValue <= partMin;
+    var isPartValueGreaterOrEqulasPartMax = partValue >= partMax;
+
+    if(isPartValueSmallerOrEqualsPartMin){
+        return this.valueFromPart(partMin);
+    }
+    if(isPartValueGreaterOrEqulasPartMax){
+        return this.valueFromPart(partMax);
+    }
+
+    return this.valueFromPart(partValue);
+
+
+};
+
+
+
+
+
+
+
+Mapbender.DimensionFormat = function(value, numDig) {
+
+    return value.toLocaleString('en', {minimumIntegerDigits:numDig,useGrouping:false});
+};
+
+
+
+
+Mapbender.DimensionTime = function(){};
+
+Mapbender.DimensionTime
+
+
+
+
+Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar}, {//,implements: Mapbender.IDimension}, {
     'private object start': null,
-    'private object end': null,
-    'private object step': null,
-    'private boolean asc': true,
-    __construct: function (options) {
+    'private object end':   null,
+    'private object step':  null,
+    'private boolean asc':  true,
+    __construct:            function(options) {
         options.extent[0] = '' + options.extent[0];
         options.extent[1] = '' + options.extent[1];
         this['super']('__construct', options, false);
@@ -119,29 +198,28 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
         this.end = new TimeISO8601(options.extent[1]);
         this.step = new PeriodISO8601(options.extent[2]);
         this.asc = this.end.getTime().getTime() > this.start.getTime().getTime();
-        this.setDefault(this.getInRange(this.valueFromPart(0), this.valueFromPart(1),
-                this.options['default'] === null ? options.extent[0] : options['default']));
+        this.setDefault(this.getInRange(this.valueFromPart(0), this.valueFromPart(1), this.options['default'] === null ? options.extent[0] : options['default']));
     },
-    'public getStepsNum': function () {
-        if (this.stepsNum !== -1) {
+    'public getStepsNum':   function() {
+        if(this.stepsNum !== -1) {
             return this.stepsNum;
         } else {
-            if (this.step.getType() === 'year') {
+            if(this.step.getType() === 'year') {
                 this.stepsNum = Math.floor(Math.abs(this.end.getYear() - this.start.getYear()) / this.step.getYears());
-            } else if (this.step.getType() === 'msec') {
+            } else if(this.step.getType() === 'msec') {
                 var stepTst = this.step.asMsec();
                 this.stepsNum = Math.floor(Math.abs(this.end.getTime().getTime() - this.start.getTime().getTime()) / stepTst);
-            } else if (this.step.getType() === 'month') {
+            } else if(this.step.getType() === 'month') {
                 var startMonth = (this.start.getYear() * 12 + this.start.getMonth());
                 var endMonth = (this.end.getYear() * 12 + this.end.getMonth());
                 var stepMonth = (this.step.getYears() * 12 + this.step.getMonths());
                 this.stepsNum = Math.floor(Math.abs(endMonth - startMonth) / stepMonth);
-            } else if (this.step.getType() === 'date') {
+            } else if(this.step.getType() === 'date') {
                 /* TODO optimize? */
                 var stepTime = new TimeISO8601(this.start.getTime().toJSON());
                 this.stepsNum = 0;
                 var endtime = this.end.getTime().getTime();
-                if (this.asc) {
+                if(this.asc) {
                     while (stepTime.time.getTime() <= endtime) {
                         this.stepsNum++;
                         stepTime.add(this.step);
@@ -156,26 +234,26 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             return this.stepsNum;
         }
     },
-    'public partFromValue': function (isoDate) {
+    'public partFromValue': function(isoDate) {
         var givenTime = new TimeISO8601(isoDate);
-        if (this.step.getType() === 'year') {
+        if(this.step.getType() === 'year') {
             var part = (givenTime.getYear() - this.start.getYear()) / (this.end.getYear() - this.start.getYear());
             return part;
-        } else if (this.step.getType() === 'msec') {
+        } else if(this.step.getType() === 'msec') {
             var part = (givenTime.time.getTime() - this.start.getTime().getTime()) / (this.end.getTime().getTime() - this.start.getTime().getTime());
             return part;
-        } else if (this.step.getType() === 'month') {
+        } else if(this.step.getType() === 'month') {
             var startMonth = (this.start.getYear() * 12 + this.start.getMonth());
             var endMonth = (this.end.getYear() * 12 + this.end.getMonth());
             var timeMonth = (givenTime.getYear() * 12 + givenTime.getMonth());
             var part = (timeMonth - startMonth) / (endMonth - startMonth);
             return part;
-        } else if (this.step.getType() === 'date') {
+        } else if(this.step.getType() === 'date') {
             /* TODO optimize? */
             var stepTime = new TimeISO8601(this.start.getTime().toJSON());
             var stepsNum = 0;
             var endtime = givenTime.time.getTime();
-            if (this.asc) {
+            if(this.asc) {
                 while (stepTime.time.getTime() <= endtime) {
                     stepsNum++;
                     stepTime.add(this.step);
@@ -189,49 +267,51 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             return stepsNum / this.stepsNum;
         }
     },
-    stepFromPart: function (part) {
-//        if (this.step.getType() === 'msec') {
-//            return Math.round(part * (this.getStepsNum()));
-//        } else if (this.step.getType() === 'month') {
-//            return Math.round(part * (this.getStepsNum()));
-//        } else if (this.step.getType() === 'date') {
-            return Math.round(part * (this.getStepsNum()));/* ??? */
-//        }
+    stepFromPart:           function(part) {
+        //        if (this.step.getType() === 'msec') {
+        //            return Math.round(part * (this.getStepsNum()));
+        //        } else if (this.step.getType() === 'month') {
+        //            return Math.round(part * (this.getStepsNum()));
+        //        } else if (this.step.getType() === 'date') {
+        return Math.round(part * (this.getStepsNum()));
+        /* ??? */
+        //        }
     },
-    stepFromValue: function (value) {
-//        if (this.step.getType() === 'msec') {
-//            return this.stepFromPart(this.partFromValue(value));
-//        } else if (this.step.getType() === 'month') {
-//            return this.stepFromPart(this.partFromValue(value));
-//        } else if (this.step.getType() === 'date') {
-            return this.stepFromPart(this.partFromValue(value));/* ??? */
-//        }
+    stepFromValue:          function(value) {
+        //        if (this.step.getType() === 'msec') {
+        //            return this.stepFromPart(this.partFromValue(value));
+        //        } else if (this.step.getType() === 'month') {
+        //            return this.stepFromPart(this.partFromValue(value));
+        //        } else if (this.step.getType() === 'date') {
+        return this.stepFromPart(this.partFromValue(value));
+        /* ??? */
+        //        }
     },
-    valueFromPart: function (part) {
+    valueFromPart:          function(part) {
         var step = this.stepFromPart(part);
         var time;
-        if (this.step.getType() === 'year') {
+        if(this.step.getType() === 'year') {
             var years;
-            if (this.asc) {
+            if(this.asc) {
                 years = this.start.getYear() + step * this.step.getYears();
             } else {
                 years = this.start.getYear() - step * this.step.getYears();
             }
             time = new TimeISO8601(Mapbender.DimensionFormat('' + years, 4));
             return time.toString();
-        } else if (this.step.getType() === 'msec') {
+        } else if(this.step.getType() === 'msec') {
             var stepTst = this.step.asMsec();//msecs
-            if (this.asc) {
+            if(this.asc) {
                 time = new TimeISO8601(new Date(this.start.getTime().getTime() + step * stepTst));
             } else {
                 time = new TimeISO8601(new Date(this.start.getTime().getTime() - step * stepTst));
             }
             return time.toString();
-        } else if (this.step.getType() === 'month') {
+        } else if(this.step.getType() === 'month') {
             var startMonth = (this.start.getYear() * 12 + this.start.getMonth());
             var stepMonth = (this.step.getYears() * 12 + this.step.getMonths());
             var months;
-            if (this.asc) {
+            if(this.asc) {
                 months = startMonth + step * stepMonth;
             } else {
                 months = startMonth - step * stepMonth;
@@ -239,11 +319,11 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             var years = Math.floor(months / 12);
             time = new TimeISO8601(Mapbender.DimensionFormat(years, 4) + "-" + Mapbender.DimensionFormat(months - years * 12 + 1, 2));
             return time.toString();
-        } else if (this.step.getType() === 'date') {
+        } else if(this.step.getType() === 'date') {
             /* TODO optimize? */
             var tempStep = 0;
             var stepTime = new TimeISO8601(this.start.getTime().toJSON());
-            if (this.asc) {
+            if(this.asc) {
                 while (tempStep !== step) {
                     stepTime.add(this.step);
                     tempStep++;
@@ -257,25 +337,26 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             return stepTime.toString();
         }
     },
-    valueFromStart: function () {
+    valueFromStart:         function() {
         return this.start.getTime().toJSON();
     },
-    valueFromEnd: function () {
+    valueFromEnd:           function() {
         return this.end.getTime().toJSON();
     },
-    intervalAsMonth: function (absolut) {
-        if (this.step.getType() === 'month') {
+    intervalAsMonth:        function(absolut) {
+        if(this.step.getType() === 'month') {
             var startMonth = this.start.getYear() * 12 + this.start.getMonth();
             var endMonth = this.end.getYear() * 12 + this.end.getMonth();
             return absolut ? Math.abs(endMonth - startMonth) : endMonth - startMonth;
         }
     },
-    innerJoin: function (another) {
-        if (this.asc !== another.asc || !this.step.equals(another.step)) {
+    innerJoin:              function(another) {
+        if(this.asc !== another.asc || !this.step.equals(another.step)) {
             return null;
         }
         var start, end;
         var options = $.extend(true, {}, this.options);
+
         function joinOptions(opts, one, two, startStr, endStr) {
             opts.extent = [startStr, endStr, one.step.toString()];
             opts.origextent = opts.extent;
@@ -286,13 +367,14 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             opts.units = one.options.units === two.options.units ? one.options.units : null;
             return opts;
         }
-        if (this.step.getType() === 'year') {
+
+        if(this.step.getType() === 'year') {
             var testMin = Math.abs(this.start.getYear() - another.start.getYear()) / this.step.getYears();
             var testMax = Math.abs(this.end.getYear() - another.end.getYear()) / this.step.getYears();
-            if (testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
+            if(testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
                 return null;
             }
-            if (this.asc) {
+            if(this.asc) {
                 start = this.start.getYear() >= another.start.getYear() ? this.start : another.start;
                 end = this.end.getYear() <= another.end.getYear() ? this.end : another.end;
             } else {
@@ -302,13 +384,13 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             options = joinOptions(options, this, another, start.toString(), end.toString());
             var joined = Mapbender.Dimension(options);
             return joined;
-        } else if (this.step.getType() === 'msec') {
+        } else if(this.step.getType() === 'msec') {
             var testMin = Math.abs(this.start.getTime().getTime() - another.start.getTime().getTime()) / this.step.asMsec();
             var testMax = Math.abs(this.end.getTime().getTime() - another.end.getTime().getTime()) / this.step.asMsec();
-            if (testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
+            if(testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
                 return null;
             }
-            if (this.asc) {
+            if(this.asc) {
                 start = this.start.getTime().getTime() >= another.start.getTime().getTime() ? this.start : another.start;
                 end = this.end.getTime().getTime() <= another.end.getTime().getTime() ? this.end : another.end;
             } else {
@@ -318,7 +400,7 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             options = joinOptions(options, this, another, start.toString(), end.toString());
             var joined = Mapbender.Dimension(options);
             return joined;
-        } else if (this.step.getType() === 'month') {
+        } else if(this.step.getType() === 'month') {
             var thisStartMonth = (this.start.getYear() * 12 + this.start.getMonth());
             var anotherStartMonth = (another.start.getYear() * 12 + another.start.getMonth());
             var thisEndMonth = (this.end.getYear() * 12 + this.end.getMonth());
@@ -327,11 +409,11 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
 
             var testMin = Math.abs(thisStartMonth - anotherStartMonth) / stepMonth;
             var testMax = Math.abs(thisEndMonth - anotherEndMonth) / stepMonth;
-            if (testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
+            if(testMin !== parseInt(testMin) || testMax !== parseInt(testMax)) {
                 return null;
             }
 
-            if (this.asc) {
+            if(this.asc) {
                 start = this.start.getTime().getTime() >= another.start.getTime().getTime() ? this.start : another.start;
                 end = this.end.getTime().getTime() <= another.end.getTime().getTime() ? this.end : another.end;
             } else {
@@ -341,17 +423,17 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             options = joinOptions(options, this, another, start.toString(), end.toString());
             var joined = Mapbender.Dimension(options);
             return joined;
-        } else if (this.step.getType() === 'date') {
+        } else if(this.step.getType() === 'date') {
             var joinStart, joinEnd;
-            if (this.asc) {
-                if (this.start.getTime().getTime() >= another.start.getTime().getTime()) {
+            if(this.asc) {
+                if(this.start.getTime().getTime() >= another.start.getTime().getTime()) {
                     joinStart = this.start;
                     start = another.start;
                 } else {
                     joinStart = another.start;
                     start = this.start;
                 }
-                if (this.end.getTime().getTime() >= another.end.getTime().getTime()) {
+                if(this.end.getTime().getTime() >= another.end.getTime().getTime()) {
                     joinEnd = another.end;
                     end = this.end;
                 } else {
@@ -359,14 +441,14 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
                     end = another.end;
                 }
             } else {
-                if (this.start.getTime().getTime() >= another.start.getTime().getTime()) {
+                if(this.start.getTime().getTime() >= another.start.getTime().getTime()) {
                     joinStart = another.start;
                     start = this.start;
                 } else {
                     joinStart = this.start;
                     start = another.start;
                 }
-                if (this.end.getTime().getTime() >= another.end.getTime().getTime()) {
+                if(this.end.getTime().getTime() >= another.end.getTime().getTime()) {
                     joinEnd = this.end;
                     end = another.end;
                 } else {
@@ -374,7 +456,7 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
                     end = this.end;
                 }
             }
-//            var endtime = end.time.getTime();
+            //            var endtime = end.time.getTime();
             var joinStartTime = joinStart.time.getTime();
             var joinEndTime = joinEnd.time.getTime();
             var stepTime = start;
@@ -384,26 +466,26 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
             var stepsNum = 0;
             while (true) {
                 stepSt = stepTime.time.getTime();
-                if (stepSt === joinStartTime) {
+                if(stepSt === joinStartTime) {
                     startOk = true;
                 }
-                if (stepSt === joinEndTime) {
+                if(stepSt === joinEndTime) {
                     endOk = true;
                 }
-                if (this.asc) {
-                    if (stepSt >= joinEndTime || (startOk === true && endOk === true)) {
+                if(this.asc) {
+                    if(stepSt >= joinEndTime || (startOk === true && endOk === true)) {
                         break;
                     }
                     stepTime.add(this.step);
                 } else {
-                    if (stepSt <= joinEndTime || (startOk === true && endOk === true)) {
+                    if(stepSt <= joinEndTime || (startOk === true && endOk === true)) {
                         break;
                     }
                     stepTime.substract(this.step);
                 }
                 stepsNum++;
             }
-            if (startOk !== true || endOk !== true || stepsNum === 0) {
+            if(startOk !== true || endOk !== true || stepsNum === 0) {
                 return null;
             }
             options = joinOptions(options, this, another, start.toString(), end.toString());
@@ -414,16 +496,16 @@ Mapbender.DimensionTime = Class({'extends': Mapbender.DimensionScalar},{//,imple
 });
 
 TimeStr = Class({
-    'public string years': null,
+    'public string years':  null,
     'public string months': null,
-    'public string days': null,
-    'public string hours': null,
-    'public string mins': null,
-    'public string secs': null,
-    'public string msecs': null,
-    'public boolean vC': false,
-    'public boolean utc': false,
-    __construct: function (datetimeStr) {
+    'public string days':   null,
+    'public string hours':  null,
+    'public string mins':   null,
+    'public string secs':   null,
+    'public string msecs':  null,
+    'public boolean vC':    false,
+    'public boolean utc':   false,
+    __construct:            function(datetimeStr) {
         var datetimeStr_ = '' + datetimeStr;
         this.years = null;
         this.months = null;
@@ -433,7 +515,7 @@ TimeStr = Class({
         this.secs = null;
         this.msecs = null;
         var dtStr;
-        if (datetimeStr_.indexOf('-') === 0) {
+        if(datetimeStr_.indexOf('-') === 0) {
             this.vC = true;
             dtStr = datetimeStr_.substr(1);
         } else {
@@ -443,14 +525,14 @@ TimeStr = Class({
         var help = dtStr.split('T');
         var ymd = [];
         var hmsm = [];
-        if (help.length === 2) {
+        if(help.length === 2) {
             ymd = help[0].split('-');
             hmsm = help[1].split(':');
-        } else if (help[0].indexOf('-') !== -1) {
+        } else if(help[0].indexOf('-') !== -1) {
             ymd = help[0].split('-');
-        } else if (help[0].indexOf(':') !== -1) {
+        } else if(help[0].indexOf(':') !== -1) {
             hmsm = help[0].split(':');
-        } else if (help.length === 1) {
+        } else if(help.length === 1) {
             ymd = help;
         }
         try {
@@ -485,7 +567,7 @@ TimeStr = Class({
         } catch (e) {
         }
     },
-    toISOString: function () {
+    toISOString:            function() {
         var res = (this.vC ? "-" : "") + this.years;
         res += "-" + (this.months ? this.months : "01");
         res += "-" + (this.days ? this.days : "01") + "T";
@@ -498,31 +580,32 @@ TimeStr = Class({
 });
 
 TimeISO8601 = Class({
-    'public boolean utc': false,
-    'public object time': null,
+    'public boolean utc':    false,
+    'public object time':    null,
     'public object timeStr': null,
-    __construct: function (date) {
+    __construct:             function(date) {
         function convertDateFromISO(s) {
             s = s.split(/\D/);
             return new Date(Date.UTC(s[0], --s[1] || '', s[2] || '', s[3] || '', s[4] || '', s[5] || '', s[6] || ''))
         }
-        if (typeof date === "object") {
+
+        if(typeof date === "object") {
             this.time = date;
             this.timeStr = new TimeStr(this.time.toJSON());
             this.utc = this.timeStr.isUtc();
-        } else if (date === 'current') {
+        } else if(date === 'current') {
             this.time = new Date();
             this.timeStr = new TimeStr(this.time.toJSON());
             this.utc = this.timeStr.isUtc();
-        } else if (!isNaN(new Date(date).getFullYear())) {
+        } else if(!isNaN(new Date(date).getFullYear())) {
             this.timeStr = new TimeStr(date);
             this.utc = this.timeStr.isUtc();
             this.time = new Date(date);
             var a = 0;
-        } else if (typeof date === 'string') {
+        } else if(typeof date === 'string') {
             this.timeStr = new TimeStr(new TimeStr(date).toISOString());
             this.utc = this.timeStr.isUtc();
-            if (date.indexOf('-') === 0) { // vC.
+            if(date.indexOf('-') === 0) { // vC.
                 this.timeStr = new TimeStr(new TimeStr(date).toISOString());
                 this.utc = this.timeStr.isUtc();
                 this.time = new Date(date);
@@ -535,82 +618,82 @@ TimeISO8601 = Class({
             this.time = null;
         }
     },
-    getYear: function () {
+    getYear:                 function() {
         return this.time.getFullYear();
     },
-    getMonth: function () {
+    getMonth:                function() {
         return this.time.getMonth();
     },
-    getDate: function () {
+    getDate:                 function() {
         return this.time.getDate();
     },
-    getHours: function () {
+    getHours:                function() {
         return this.time.getHours();
     },
-    getMinutes: function () {
+    getMinutes:              function() {
         return this.time.getMinutes();
     },
-    getSeconds: function () {
+    getSeconds:              function() {
         return this.time.getSeconds();
     },
-    getMilliseconds: function () {
+    getMilliseconds:         function() {
         return this.time.getMilliseconds();
     },
-    isValid: function () {
+    isValid:                 function() {
         return !isNaN(this.time.getFullYear());
     },
-    add: function (period) {
-        if (period.msecs) {
+    add:                     function(period) {
+        if(period.msecs) {
             this.time.setMilliseconds(this.time.getMilliseconds() + period.msecs);
         }
-        if (period.secs) {
+        if(period.secs) {
             this.time.setSeconds(this.time.getSeconds() + period.secs);
         }
-        if (period.mins) {
+        if(period.mins) {
             this.time.setMinutes(this.time.getMinutes() + period.mins);
         }
-        if (period.h) {
+        if(period.h) {
             this.time.setHours(this.time.getHours() + period.h);
         }
-        if (period.d) {
+        if(period.d) {
             this.time.setDate(this.time.getDate() + period.d);
         }
-        if (period.m) {
+        if(period.m) {
             this.time.setMonth(this.time.getMonth() + period.m);
         }
-        if (period.y) {
+        if(period.y) {
             this.time.setFullYear(this.time.getFullYear() + period.y);
         }
     },
-    substract: function (period) {
-        if (period.msecs) {
+    substract:               function(period) {
+        if(period.msecs) {
             this.time.setMilliseconds(this.time.getMilliseconds() - period.msecs);
         }
-        if (period.secs) {
+        if(period.secs) {
             this.time.setSeconds(this.time.getSeconds() - period.secs);
         }
-        if (period.mins) {
+        if(period.mins) {
             this.time.setMinutes(this.time.getMinutes() - period.mins);
         }
-        if (period.h) {
+        if(period.h) {
             this.time.setHours(this.time.getHours() - period.h);
         }
-        if (period.d) {
+        if(period.d) {
             this.time.setDate(this.time.getDate() - period.d);
         }
-        if (period.m) {
+        if(period.m) {
             this.time.setMonth(this.time.getMonth() - period.m);
         }
-        if (period.y) {
+        if(period.y) {
             this.time.setFullYear(this.time.getFullYear() - period.y);
         }
     },
-    toString: function () {
+    toString:                function() {
         var value = this.timeStr.isVc() ? '-' : '';
         value += this.timeStr.getYears() ? Mapbender.DimensionFormat(this.getYear(), 4) : '';
         value += this.timeStr.getMonths() ? ('-' + Mapbender.DimensionFormat(this.getMonth() + 1, 2)) : '';
         value += this.timeStr.getDays() ? ('-' + Mapbender.DimensionFormat(this.getDate(), 2)) : '';
-        if (this.timeStr.getHours()) {
+        if(this.timeStr.getHours()) {
             value += this.timeStr.getHours() ? ('T' + Mapbender.DimensionFormat(this.getHours(), 2)) : '';
             value += this.timeStr.getMins() ? (':' + Mapbender.DimensionFormat(this.getMinutes(), 2)) : '';
             value += this.timeStr.getSecs() ? (':' + Mapbender.DimensionFormat(this.getSeconds(), 2)) : '';
@@ -621,39 +704,38 @@ TimeISO8601 = Class({
     }
 });
 
-
 PeriodISO8601 = Class({
-    'public number years': null,
+    'public number years':  null,
     'public number months': null,
-    'public number days': null,
-    'public number hours': null,
-    'public number mins': null,
-    'public number secs': null,
-    __construct: function (datetimeStr) {
+    'public number days':   null,
+    'public number hours':  null,
+    'public number mins':   null,
+    'public number secs':   null,
+    __construct:            function(datetimeStr) {
         this.years = null;
         this.months = null;
         this.days = null;
         this.hours = null;
         this.mins = null;
         this.secs = null;
-        if (datetimeStr.indexOf('P') === 0) {
+        if(datetimeStr.indexOf('P') === 0) {
             var str = datetimeStr.substr(1);
             var tmp, y = 0, m = 0, d = 0, h = 0, mins = 0, secs = 0;
 
-            if (str.indexOf('T') !== -1) {
+            if(str.indexOf('T') !== -1) {
                 tmp = str.split('T');
                 str = tmp[1];
-                if (str.indexOf('H') !== -1) {
+                if(str.indexOf('H') !== -1) {
                     tmp = str.split('H');
                     this.hours = parseInt(tmp[0]);
                     str = tmp[1];
                 }
-                if (str.indexOf('M') !== -1) {
+                if(str.indexOf('M') !== -1) {
                     tmp = str.split('M');
                     this.mins = parseInt(tmp[0]);
                     str = tmp[1];
                 }
-                if (str.indexOf('S') !== -1) {
+                if(str.indexOf('S') !== -1) {
                     tmp = str.split('S');
                     this.secs = parseInt(tmp[0]);
                     str = tmp[1];
@@ -661,85 +743,84 @@ PeriodISO8601 = Class({
                 str = tmp[0];
             }
 
-            if (str.indexOf('Y') !== -1) {
+            if(str.indexOf('Y') !== -1) {
                 tmp = str.split('Y');
                 this.years = parseInt(tmp[0]);
                 str = tmp[1];
             }
-            if (str.indexOf('M') !== -1) {
+            if(str.indexOf('M') !== -1) {
                 tmp = str.split('M');
                 this.months = parseInt(tmp[0]);
                 str = tmp[1];
             }
-            if (str.indexOf('D') !== -1) {
+            if(str.indexOf('D') !== -1) {
                 tmp = str.split('D');
                 this.days = parseInt(tmp[0]);
                 str = tmp[1];
             }
         }
     },
-    'public getType': function () {
-        if (this.years === null && this.months === null) {
+    'public getType':       function() {
+        if(this.years === null && this.months === null) {
             return 'msec';
-        } else if (this.years !== null && this.months === null && this.days === null && this.hours === null && this.mins === null && this.secs === null) {
+        } else if(this.years !== null && this.months === null && this.days === null && this.hours === null && this.mins === null && this.secs === null) {
             return 'year';
-        } else if (this.days === null && this.hours === null && this.mins === null && this.secs === null) {
+        } else if(this.days === null && this.hours === null && this.mins === null && this.secs === null) {
             return 'month';
         } else {
             return 'date';
         }
     },
-    'public added': function (period) {
+    'public added':         function(period) {
         var newPeriod = new PeriodISO8601(this.toString());
-        if (period.secs) {
+        if(period.secs) {
             newPeriod.secs = (newPeriod.secs ? newPeriod.secs : 0) + period.secs;
             var temp = newPeriod.secs / 60;
-            if (temp >= 1) {
+            if(temp >= 1) {
                 newPeriod.mins = (newPeriod.mins ? newPeriod.mins : 0) + Math.floor(temp);
                 newPeriod.secs = newPeriod.secs - Math.floor(temp) * 60;
             }
         }
-        if (period.mins) {
+        if(period.mins) {
             newPeriod.mins = (newPeriod.mins ? newPeriod.mins : 0) + period.mins;
         }
-        if (newPeriod.mins) {
+        if(newPeriod.mins) {
             var temp = newPeriod.mins / 60;
-            if (temp >= 1) {
+            if(temp >= 1) {
                 newPeriod.hours = (newPeriod.hours ? newPeriod.hours : 0) + Math.floor(temp);
                 newPeriod.mins = newPeriod.mins - Math.floor(temp) * 60;
             }
         }
-        if (period.hours) {
+        if(period.hours) {
             newPeriod.hours = (newPeriod.hours ? newPeriod.hours : 0) + period.hours;
         }
-        if (newPeriod.hours) {
+        if(newPeriod.hours) {
             var temp = newPeriod.hours / 24;
-            if (temp >= 1) {
+            if(temp >= 1) {
                 newPeriod.days = (newPeriod.days ? newPeriod.days : 0) + Math.floor(temp);
                 newPeriod.hours = newPeriod.hours - Math.floor(temp) * 24;
             }
         }
-        if (period.days) {
+        if(period.days) {
             newPeriod.days = (newPeriod.days ? newPeriod.days : 0) + period.days;
         }
 
-
-        if (period.months) {
+        if(period.months) {
             newPeriod.months = (newPeriod.months ? newPeriod.months : 0) + period.months;
         }
-        if (newPeriod.months) {
+        if(newPeriod.months) {
             var temp = newPeriod.months / 12;
-            if (temp >= 1) {
+            if(temp >= 1) {
                 newPeriod.years = (newPeriod.years ? newPeriod.years : 0) + Math.floor(temp);
                 newPeriod.months = newPeriod.months - Math.floor(temp) * 12;
             }
         }
-        if (period.years) {
+        if(period.years) {
             newPeriod.years = (newPeriod.years ? newPeriod.years : 0) + period.years;
         }
         return newPeriod;
     },
-    'public toString': function () {
+    'public toString':      function() {
         var time = this.hours > 0 ? this.hours + 'H' : '';
         time += this.mins > 0 ? this.mins + 'M' : '';
         time += this.secs > 0 ? this.secs + 'S' : '';
@@ -749,15 +830,15 @@ PeriodISO8601 = Class({
         date += this.days > 0 ? this.days + 'D' : '';
         return (date.length + time.length) > 0 ? 'P' + (date + time) : '';
     },
-    'public equals': function (period) {
-        if (this.years !== period.years || this.months !== period.months || this.days !== period.days || this.hours !== period.hours || this.mins !== period.mins || this.secs !== period.secs) {
+    'public equals':        function(period) {
+        if(this.years !== period.years || this.months !== period.months || this.days !== period.days || this.hours !== period.hours || this.mins !== period.mins || this.secs !== period.secs) {
             return false;
         } else {
             return true;
         }
     },
-    'public asMsec': function () {
-        if (this.getType() === 'msec') {
+    'public asMsec':        function() {
+        if(this.getType() === 'msec') {
             var stepTst = this.secs ? this.secs : 0;// secs
             stepTst += this.mins ? this.mins * 60 : 0;// secs
             stepTst += this.hours ? this.hours * 3600 : 0;// secs
@@ -767,8 +848,8 @@ PeriodISO8601 = Class({
             return null;
         }
     },
-    'public asMonth': function (timeStart, timeEnd) {
-        if (this.getType() === 'month') {
+    'public asMonth':       function(timeStart, timeEnd) {
+        if(this.getType() === 'month') {
             return this.years * 12 + this.months;
         } else {
             return null;


### PR DESCRIPTION
Separates VendorSpecific from Dimension inheritance chain.  
Removes unevaluated, functionless attributes extent / origextent / origextentextent (srsly) and `type` (single / interval / multiple) from VendorSpecific class, along with the related backend form fields and processing.

Cherry-picks 467ed5466c755467b51983349686eb828465ec4e from feature/refactorDimension and continues removal of JOII dependencies from mapbender.wms.dimension.js JavaScript classes.
