### PR TITLE
Fix/bad asset caching on protected element

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -276,18 +276,14 @@ class Application implements IAssetDependent
             $assets[] = new StringAsset($appLoaderContent);
         }
 
-        return $assets;
-    }
-
-    /**
-     * @return StringAsset
-     */
-    public function getCustomCssAsset()
-    {
-        $entity = $this->getEntity();
-        if ($entity->getCustomCss()) {
-            return new StringAsset($entity->getCustomCss());
+        if ($type === 'css') {
+            $customCss = $this->getEntity()->getCustomCss();
+            if ($customCss) {
+                $assets[] = new StringAsset($customCss);
+            }
         }
+
+        return $assets;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -136,6 +136,19 @@ class Application implements IAssetDependent
     }
 
     /**
+     *
+     * @return string[]
+     */
+    public function getValidAssetTypes()
+    {
+        return array(
+            'js',
+            'css',
+            'trans',
+        );
+    }
+
+    /**
      * Lists assets.
      *
      * @return array
@@ -168,7 +181,7 @@ class Application implements IAssetDependent
      */
     public function getAssetGroup($type)
     {
-        if ($type !== 'css' && $type !== 'js' && $type !== 'trans') {
+        if (!\in_array($type, $this->getValidAssetTypes(), true)) {
             throw new \RuntimeException('Asset type \'' . $type .
                 '\' is unknown.');
         }
@@ -176,95 +189,96 @@ class Application implements IAssetDependent
         // Add all assets to an asset manager first to avoid duplication
         //$assets = new LazyAssetManager($this->container->get('assetic.asset_factory'));
         $assets            = array();
-        $translations      = array();
-        $layerTranslations = array();
         $templating        = $this->container->get('templating');
-        $_assets           = $this->getAssets();
+        $appTemplate = $this->getTemplate();
 
-        foreach ($_assets[ $type ] as $asset) {
-            $this->addAsset($assets, $type, $asset);
+        $ownAssets = $this->getAssets();
+        if (!empty($ownAssets[$type])) {
+            $assets = array_merge($assets, $ownAssets[$type]);
         }
+        $assetSources = array(
+            array(
+                'object' => $appTemplate,
+                'assets' => array(
+                    $type => $appTemplate->getAssets($type),
+                ),
+            ),
+        );
 
-        // Load all elements assets
-        foreach ($this->getTemplate()->getAssets($type) as $asset) {
-            if ($type === 'trans') {
-                $elementTranslations = json_decode($templating->render($asset), true);
-                $translations        = array_merge($translations, $elementTranslations);
-            } else {
-                $file = $this->getReference($this->template, $asset);
-                $this->addAsset($assets, $type, $file);
-            }
-        }
-
-        /** @var Element[] $elements */
-        foreach ($this->getElements() as $region => $elements) {
+        // Collect asset definitions from elements configured in the application
+        foreach ($this->getElements() as $regionName => $elements) {
             foreach ($elements as $element) {
-                $element_assets = $element->getAssets();
-                if (isset($element_assets[ $type ])) {
-                    foreach ($element_assets[ $type ] as $asset) {
-                        if ($type === 'trans') {
-                            $elementTranslations = json_decode($templating->render($asset), true);
-                            $translations        = array_merge($translations, $elementTranslations);
-                        } else {
-                            $this->addAsset($assets, $type, $this->getReference($element, $asset));
-                        }
-                    }
-                }
+                $assetSources[] = array(
+                    'object' => $element,
+                    'assets' => $element->getAssets(),
+                );
             }
         }
 
-        // Load all layer assets
+        // Collect all layer asset definitions
         foreach ($this->entity->getLayersets() as $layerset) {
             foreach ($this->filterActiveSourceInstances($layerset) as $layer) {
-                $layer_assets = $layer->getAssets();
-                if (isset($layer_assets[ $type ])) {
-                    foreach ($layer_assets[ $type ] as $asset) {
-                        if ($type === 'trans') {
-                            if (!isset($layerTranslations[ $asset ])) {
-                                $layerTranslations[ $asset ] =
-                                    json_decode($templating->render($asset), true);
-                            }
-                        } else {
-                            $this->addAsset($assets, $type, $this->getReference($layer, $asset));
+                $assetSources[] = array(
+                    'object' => $layer,
+                    'assets' => $layer->getAssets(),
+                );
+            }
+        }
+
+        // Load the late template assets last, so they can overwrite element and layer assets
+        $assetSources[] = array(
+            'object' => $appTemplate,
+            'assets' => array(
+                $type => $appTemplate->getLateAssets($type),
+            ),
+        );
+
+        if ($type === 'trans') {
+            // mimic old behavior: ONLY for trans assets, avoid processing repeated inputs
+            $transAssetInputs = array();
+            $translations = array();
+            foreach ($assetSources as $assetSource) {
+                if (!empty($assetSource['assets'][$type])) {
+                    foreach (array_unique($assetSource['assets'][$type]) as $transAsset) {
+                        $transAssetInputs[$transAsset] = $transAsset;
+                    }
+                }
+            }
+            foreach ($transAssetInputs as $transAsset) {
+                $renderedTranslations = json_decode($templating->render($transAsset), true);
+                $translations         = array_merge($translations, $renderedTranslations);
+            }
+            $assets[] = new StringAsset('Mapbender.i18n = ' . json_encode($translations, JSON_FORCE_OBJECT) . ';');
+        } else {
+            $assetRefs = array();
+            foreach ($assetSources as $assetSource) {
+                if (!empty($assetSource['assets'][$type])) {
+                    foreach ($assetSource['assets'][$type] as $asset) {
+                        $assetRef = $this->getReference($assetSource['object'], $asset);
+                        if (!array_key_exists($assetRef, $assetRefs)) {
+                            $assets[] = $assetRef;
+                            $assetRefs[$assetRef] = true;
                         }
                     }
                 }
             }
         }
-        foreach ($layerTranslations as $key => $value) {
-            $translations = array_merge($translations, $value);
-        }
-        if ($type === 'trans') {
-            $transAsset = new StringAsset('Mapbender.i18n = ' . json_encode($translations, JSON_FORCE_OBJECT) . ';');
-            $this->addAsset($assets, $type, $transAsset);
-        }
 
-        // Load the late template assets last, so it can easily overwrite element
-        // and layer assets for application specific styling for example
-        foreach ($this->getTemplate()->getLateAssets($type) as $asset) {
-            if ($type === 'trans') {
-                $elementTranslations = json_decode($templating->render($asset), true);
-                $translations        = array_merge($translations, $elementTranslations);
-            } else {
-                $file = $this->getReference($this->template, $asset);
-                $this->addAsset($assets, $type, $file);
+        // Append `extra_assets` references (only occurs in YAML application, see ApplicationYAMLMapper)
+        $extraYamlAssets = $this->getEntity()->getExtraAssets();
+        if (is_array($extraYamlAssets) && array_key_exists($type, $extraYamlAssets)) {
+            foreach ($extraYamlAssets[$type] as $asset) {
+                $assets[] = trim($asset);
             }
         }
 
-        // Load extra assets given by application
-        $extra_assets = $this->getEntity()->getExtraAssets();
-        if (is_array($extra_assets) && array_key_exists($type, $extra_assets)) {
-            foreach ($extra_assets[ $type ] as $asset) {
-                $asset = trim($asset);
-                $this->addAsset($assets, $type, $asset);
-            }
-        }
-
+        // add client initialization last, so everything is already in place
         if ($type === 'js') {
-            $app_loader = new StringAsset($templating->render(
-                '@MapbenderCoreBundle/Resources/views/application.config.loader.js.twig',
-                array('application' => $this)));
-            $this->addAsset($assets, $type, $app_loader);
+            $appLoaderTemplate = '@MapbenderCoreBundle/Resources/views/application.config.loader.js.twig';
+            $appLoaderContent = $templating->render($appLoaderTemplate, array(
+                'application' => $this,
+            ));
+            $assets[] = new StringAsset($appLoaderContent);
         }
 
         return $assets;
@@ -279,18 +293,6 @@ class Application implements IAssetDependent
         if ($entity->getCustomCss()) {
             return new StringAsset($entity->getCustomCss());
         }
-    }
-
-    /**
-     * @param $manager
-     * @param $type
-     * @param $reference
-     * @return array
-     */
-    private function addAsset(&$manager, $type, $reference)
-    {
-        $manager[] = $reference;
-        return $manager;
     }
 
     /**
@@ -361,6 +363,9 @@ class Application implements IAssetDependent
         } elseif ($firstChar == ".") {
             return $file;
         } elseif ($firstChar !== '@') {
+            if (!$object) {
+                throw new \RuntimeException("Can't resolve asset path $file with empty object context");
+            }
             $namespaces = explode('\\', get_class($object));
             $bundle     = sprintf('%s%s', $namespaces[0], $namespaces[1]);
             return sprintf('@%s/Resources/public/%s', $bundle, $file);

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -122,17 +122,12 @@ class Application implements IAssetDependent
     /**
      * Render the application
      *
-     * @param string  $format Output format, defaults to HTML
-     * @param boolean $html   Whether to render the HTML itself
-     * @param boolean $css    Whether to include the CSS links
-     * @param boolean $js     Whether to include the JavaScript
-     * @param bool    $trans
      * @return string $html The rendered HTML
      */
-    public function render($format = 'html', $html = true, $css = true, $js = true, $trans = true)
+    public function render()
     {
         $template = $this->getTemplate();
-        return $template->render($format, $html, $css, $js, $trans);
+        return $template->render();
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
@@ -36,15 +36,21 @@ class ApplicationService
     }
 
     /**
-     * Returns the list of Elements from the given Application that are enabled and granted for the current user
+     * Returns the list of Elements from the given Application that are enabled and (optionally) granted for
+     * the current user.
+     *
      * @param ApplicationEntity $entity
+     * @param bool $requireGrant return only VIEW-granted entries (default true)
      * @return ElementComponent[]
      */
-    public function getActiveElements(ApplicationEntity $entity)
+    public function getActiveElements(ApplicationEntity $entity, $requireGrant = true)
     {
         $elements    = array();
         foreach ($entity->getElements() as $elementEntity) {
-            if (!$elementEntity->getEnabled() || !$this->isElementGranted($elementEntity)) {
+            if (!$elementEntity->getEnabled()) {
+                continue;
+            }
+            if ($requireGrant && !$this->isElementGranted($elementEntity)) {
                 continue;
             }
             $elementComponent = $this->makeElementComponent($entity, $elementEntity);

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -18,6 +18,7 @@ use OwsProxy3\CoreBundle\Component\ProxyQuery;
 use OwsProxy3\CoreBundle\Component\Utils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,41 +55,39 @@ class ApplicationController extends Controller
      * date and this controller will be used during development mode.
      *
      * @Route("/application/{slug}/assets/{type}", requirements={"type" = "js|css|trans"})
+     * @param Request $request
      * @param string $slug Application slug name
      * @param string $type Asset type
      * @return Response
      */
-    public function assetsAction($slug, $type)
+    public function assetsAction(Request $request, $slug, $type)
     {
-        $response         = new Response();
-        $request          = $this->getRequest();
-        $env              = $this->container->get("kernel")->getEnvironment();
-        $isProduction     = $env == "prod";
-        $cacheFile        = $this->getCachedAssetPath($slug, $env, $type);
-        $needCache        = $isProduction && !file_exists($cacheFile);
-        $modificationDate = new \DateTime();
-        $appEntity        = $this->get('mapbender')->getApplicationEntity($slug);
+        $isProduction = $this->isProduction();
+        $cacheFile        = $this->getCachedAssetPath($slug, $type);
+        $application = $this->getApplication($slug);
 
-        $response->headers->set('Content-Type', $this->getMimeType($type));
+        $headers = array(
+            'Content-Type' => $this->getMimeType($type),
+        );
 
-
-        if ($isProduction && !$needCache) {
+        $useCached = $isProduction && file_exists($cacheFile);
+        if ($useCached) {
+            $appEntity = $application->getEntity();
+            $isAppDbBased = $appEntity->getSource() === ApplicationEntity::SOURCE_DB;
             $modificationTs = filectime($cacheFile);
-            $isAppDbBased   = $appEntity->getSource() === ApplicationEntity::SOURCE_DB;
-            $modificationDate->setTimestamp($modificationTs);
+            // Always reuse cache entry for YAML applications
+            // Check the update timestamp only for DB applications,
+            $useCached = !$isAppDbBased || ($appEntity->getUpdated()->getTimestamp() < $modificationTs);
 
-            if (!$isAppDbBased || ($isAppDbBased && $appEntity->getUpdated() < $modificationDate)) {
-                $response->setLastModified($modificationDate);
-                $response->headers->set('X-Asset-Modification-Time', $modificationDate->format('c'));
-                if ($response->isNotModified($request)) {
-                    return $response;
-                }
-                $response->setContent(file_get_contents($cacheFile));
+            if ($useCached) {
+                $response = new BinaryFileResponse($cacheFile, 200, $headers);
+                // allow file timestamp to be read again correctly for 'Last-Modified' header
+                clearstatcache();
+                $response->isNotModified($request);
                 return $response;
             }
         }
 
-        $application = $this->getApplication($slug);
         $refs = $application->getAssetGroup($type);
         if ($type == "css") {
             $sourcePath = $request->getBasePath();
@@ -105,11 +104,12 @@ class ApplicationController extends Controller
             $content = $assets->dump();
         }
 
-        if ($isProduction && $needCache) {
+        if ($isProduction) {
             file_put_contents($cacheFile, $content);
+            return new BinaryFileResponse($cacheFile, 200, $headers);
+        } else {
+            return new Response($content, 200, $headers);
         }
-
-        return $response->setContent($content);
     }
 
     /**
@@ -137,61 +137,34 @@ class ApplicationController extends Controller
      * Main application controller.
      *
      * @Route("/application/{slug}.{_format}", defaults={ "_format" = "html" })
+     * @param Request $request
      * @param string $slug Application
      * @return Response
      */
-    public function applicationAction($slug)
+    public function applicationAction(Request $request, $slug)
     {
-        $env          = $this->container->get("kernel")->getEnvironment();
-        $isProduction = $env == "prod";
-        $response     = new Response();
         $session      = $this->get("session");
         $application  = $this->getApplication($slug);
+        $appEntity = $application->getEntity();
+        // @todo: figure out why YAML applications should be excluded from html caching; they do use asset caching
+        $useCache = $this->isProduction() && ($appEntity->getSource() === ApplicationEntity::SOURCE_DB);
+        $session->set("proxyAllowed", true); // @todo: ...why?
 
-        if ($isProduction) {
-
-            // Render YAML application
-            if ($application->getEntity()->getSource() !== ApplicationEntity::SOURCE_DB) {
-                $session->set("proxyAllowed", true);
-                $response->setContent($application->render());
-                return $response;
-            }
-
-            $cacheFile        = $this->getCachedAssetPath($slug . "-" . session_id(), $env, "html");
-            $hasCache         = is_file($cacheFile);
-            // If no cache or DB application is update, but cache is deprecated
-            if (!$hasCache || $application->getEntity()->getUpdated()->getTimestamp() > filectime($cacheFile)) {
+        if ($useCache) {
+            $cacheFile = $this->getCachedAssetPath($slug . "-" . session_id(), "html");
+            $cacheValid = is_readable($cacheFile) && $appEntity->getUpdated()->getTimestamp() < filectime($cacheFile);
+            if (!$cacheValid) {
                 $content = $application->render();
                 file_put_contents($cacheFile, $content);
-                $session->set("proxyAllowed", true);
-                $response->setContent($content);
-
-                // Update application and remove assets cache
-                if($hasCache){
-                    foreach(array(
-                                $this->getCachedAssetPath($slug,$env,'css'),
-                                $this->getCachedAssetPath($slug,$env,'js')) as $assetFileSrc){
-                        if(is_file($assetFileSrc)){
-                            unlink($assetFileSrc);
-                        }
-                    }
-                }
-            } else {
-                $modificationDate = new \DateTime();
-                $modificationDate->setTimestamp(filectime($cacheFile));
-                $response->setLastModified($modificationDate);
-                $response->headers->set('X-Asset-Modification-Time', $modificationDate->format('c'));
-                if ($response->isNotModified($this->getRequest())) {
-                    return $response;
-                }
-                $response->setContent(file_get_contents($cacheFile));
+                // allow file timestamp to be read again correctly for 'Last-Modified' header
+                clearstatcache();
             }
+            $response = new BinaryFileResponse($cacheFile);
+            $response->isNotModified($request);
+            return $response;
         } else {
-            $session->set("proxyAllowed", true);
-            $response->setContent($application->render());
+            return new Response($application->render());
         }
-
-        return $response;
     }
 
     /**
@@ -220,9 +193,10 @@ class ApplicationController extends Controller
     }
 
     /**
-     * Main application controller.
      *
      * @Route("/application/{slug}/config")
+     * @param string $slug
+     * @return Response
      */
     public function configurationAction($slug)
     {
@@ -332,8 +306,12 @@ class ApplicationController extends Controller
      * @see InstanceTunnelService
      *
      * @Route("/application/{slug}/instance/{instanceId}/tunnel")
+     * @param Request $request
+     * @param string $slug
+     * @param string $instanceId
+     * @return Response
      */
-    public function instanceTunnelAction($slug, $instanceId)
+    public function instanceTunnelAction(Request $request, $slug, $instanceId)
     {
         // @todo: instance tunnel handling should move into a service component in WmsBundle
         /** @var \Mapbender\CoreBundle\Entity\SourceInstance $instance */
@@ -352,8 +330,6 @@ class ApplicationController extends Controller
 //        $this->denyAccessUnlessGranted('VIEW', new ObjectIdentity('class', 'Mapbender\CoreBundle\Entity\Source'));
 //        $this->denyAccessUnlessGranted('VIEW', $source);
         $headers     = array();
-        /** @var Request $request */
-        $request = $this->get("request");
         $postParams  = $request->request->all();
         $getParams   = $request->query->all();
         $user        = $source->getUsername() ? $source->getUsername() : null;
@@ -386,9 +362,8 @@ class ApplicationController extends Controller
         $browserResponse = $proxy->handle();
         $response        = new Response();
 
-        $cookies_req = $this->get("request")->cookies;
         Utils::setHeadersFromBrowserResponse($response, $browserResponse);
-        foreach ($cookies_req as $key => $value) {
+        foreach ($request->cookies as $key => $value) {
             $response->headers->removeCookie($key);
             $response->headers->setCookie(new Cookie($key, $value));
         }
@@ -398,13 +373,12 @@ class ApplicationController extends Controller
 
     /**
      * @param $slug
-     * @param $env
      * @param $type
      * @return string
      */
-    public function getCachedAssetPath($slug, $env, $type)
+    protected function getCachedAssetPath($slug, $type)
     {
-        return $this->container->getParameter('kernel.root_dir') . "/cache/" . $env . "/" . $slug . ".min." . $type;
+        return $this->container->getParameter('kernel.cache_dir') . "/{$slug}.min.{$type}";
     }
 
     /**
@@ -420,5 +394,21 @@ class ApplicationController extends Controller
             'js'    => 'application/javascript',
             'trans' => 'application/javascript');
         return $types[$type];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getKernelEnvironment()
+    {
+        return $this->container->get('kernel')->getEnvironment();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isProduction()
+    {
+        return $this->getKernelEnvironment() == "prod";
     }
 }

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -97,7 +97,7 @@ class ApplicationController extends Controller
                 $refs[] = $custom;
             }
             /** @todo: use route to assets action, not REQUEST_URI, so this can move away from here */
-            $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), empty($sourcePath) ? "." : $sourcePath);
+            $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), $sourcePath ?: ".");
             $content = $factory->compile();
         } else {
             $cache   = new ApplicationAssetCache($this->container, $refs, $type);

--- a/src/Mapbender/CoreBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/CoreBundle/Controller/ApplicationController.php
@@ -90,13 +90,9 @@ class ApplicationController extends Controller
 
         $refs = $application->getAssetGroup($type);
         if ($type == "css") {
-            $sourcePath = $request->getBasePath();
-            $custom     = $application->getCustomCssAsset();
-            if ($custom) {
-                $refs[] = $custom;
-            }
             /** @todo: use route to assets action, not REQUEST_URI, so this can move away from here */
-            $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), $sourcePath ?: ".");
+            $sourcePath = $request->getBasePath() ?: '.';
+            $factory = new AssetFactory($this->container, $refs, 'css', $request->server->get('REQUEST_URI'), $sourcePath);
             $content = $factory->compile();
         } else {
             $cache   = new ApplicationAssetCache($this->container, $refs, $type);


### PR DESCRIPTION
Prevents incomplete entries in application asset cache if user that triggers asset cache rebuild has missing grants on some Elements in the Application.  
Cached assets now include all elements, ignoring grants.  

Non-granted Elements are (still, same as before) suppressed from configuration and HTML markup rendering, so a non-granted element will not initialize in the restricted user's browser.
