### PR TITLE
Fix/611 redundant group layer legends print

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -284,6 +284,9 @@
             var scale = this._getPrintScale();
             function _getLegends(layer) {
                 var legend = {};
+                if (!layer.options.treeOptions.selected) {
+                    return legend;
+                }
                 if (layer.children) {
                     for (var i = 0; i < layer.children.length; i++) {
                         _.assign(legend, _getLegends(layer.children[i]));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -285,15 +285,23 @@
             function _getLegends(layer) {
                 var legend = {};
                 if (!layer.options.treeOptions.selected) {
-                    return legend;
+                    return false;
                 }
                 if (layer.children) {
+                    var childrenActive = false;
                     for (var i = 0; i < layer.children.length; i++) {
-                        _.assign(legend, _getLegends(layer.children[i]));
+                        var childLegends = _getLegends(layer.children[i]);
+                        if (childLegends !== false) {
+                            _.assign(legend, childLegends);
+                            childrenActive = true;
+                        }
+                    }
+                    if (!childrenActive) {
+                        return false;
                     }
                 }
                 // Only include the legend for a "group" / non-leaf layer if we haven't collected any
-                // legend images from leaf layers yet.
+                // legend images from leaf layers yet, but at least one leaf layer is actually active
                 if (!Object.keys(legend).length) {
                     if (layer.options.legend && layer.options.legend.url && layer.options.treeOptions.selected) {
                         legend[layer.options.title] = layer.options.legend.url;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -284,12 +284,16 @@
             var scale = this._getPrintScale();
             function _getLegends(layer) {
                 var legend = {};
-                if (layer.options.legend && layer.options.legend.url && layer.options.treeOptions.selected) {
-                    legend[layer.options.title] = layer.options.legend.url;
-                }
                 if (layer.children) {
                     for (var i = 0; i < layer.children.length; i++) {
                         _.assign(legend, _getLegends(layer.children[i]));
+                    }
+                }
+                // Only include the legend for a "group" / non-leaf layer if we haven't collected any
+                // legend images from leaf layers yet.
+                if (!Object.keys(legend).length) {
+                    if (layer.options.legend && layer.options.legend.url && layer.options.treeOptions.selected) {
+                        legend[layer.options.title] = layer.options.legend.url;
                     }
                 }
                 return legend;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.printClient.js
@@ -306,7 +306,7 @@
                 var source = sources[i];
                 if (source.type === 'wms' && this._getRasterVisibilityInfo(source, scale).layers.length) {
                     var ll = _getLegends(sources[i].configuration.children[0]);
-                    if (ll) {
+                    if (ll && Object.keys(ll).length) {
                         legends = legends.concat(ll);
                     }
                 }


### PR DESCRIPTION
Fixes #611.  
Redundant group layer legends are no longer included in print _unless_ the group layer legend is the only available legend (i.e. no leaf or child layer provides its own legend graphic) _and_ at least one child layer is active.    

Collateral: suppress printing of legend image for deactivated source layers in general.

Collateral: suppress redundant empty object in internal job format for sources that have no legend images at all.  
