### PR TITLE
Change twig url function to path

### DIFF
--- a/src/Mapbender/ManagerBundle/Resources/views/Application/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/edit.html.twig
@@ -69,7 +69,7 @@
     <div class="clearContainer"></div>
     <div class="right">
         <input type="submit" value="{{ 'mb.manager.admin.application.save' | trans }}" class="button"/>
-        <a href="{{ url('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.cancel' | trans}}</a>
+        <a href="{{ path('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.cancel' | trans}}</a>
     </div>
     <div class="clearContainer"></div>
     {{ form_row(form._token) }}

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/export-form.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/export-form.html.twig
@@ -9,7 +9,7 @@
   <div class="clearContainer"></div>
   <div class="right">
     <input type="submit" value="{{ 'mb.manager.admin.application.export.btn.export' | trans }}" class="button"/>
-    <a href="{{ url('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.export.btn.cancel' | trans}}</a>
+    <a href="{{ path('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.export.btn.cancel' | trans}}</a>
   </div>
   <div class="clearContainer"></div>
   {{ form_row(form._token) }}

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
@@ -20,7 +20,7 @@
             <th>{{ 'mb.manager.admin.element.title' | trans }}</th>
             <th class="type">{{ 'mb.manager.admin.element.type' | trans }}</th>
             <th class="iconColumn">
-              <a href="{{ url('mapbender_manager_element_select', { 'slug': application.slug, 'region': region }) }}" class="iconAdd iconSmall addElement" title="{{'mb.manager.admin.element.add'|trans}} {{region}}"></a>
+              <a href="{{ path('mapbender_manager_element_select', { 'slug': application.slug, 'region': region }) }}" class="iconAdd iconSmall addElement" title="{{'mb.manager.admin.element.add'|trans}} {{region}}"></a>
             </th>
           </tr>
         </thead>

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-layersets.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-layersets.html.twig
@@ -28,10 +28,10 @@
                 <td class="typeColumn description">{{ instance.source.type }}</td>
                 <td class="iconColumn">
                   <div class="checkWrapper left iconCheckbox iconSmall {% if instance.enabled %}iconCheckboxActive{% endif %}" title="{{"mb.manager.admin.instance.show_hide"|trans}} {{instance.title}}">
-                    <input class="checkbox" data-url="{{ url('mapbender_manager_repository_instanceenabled', {'slug': application.slug,'layersetId': layerset.id, 'instanceId': instance.id})}}" data-id="{{ instance.id }}" type="checkbox" {% if instance.enabled %} checked="checked" {% endif %}>
+                    <input class="checkbox" data-url="{{ path('mapbender_manager_repository_instanceenabled', {'slug': application.slug,'layersetId': layerset.id, 'instanceId': instance.id})}}" data-id="{{ instance.id }}" type="checkbox" {% if instance.enabled %} checked="checked" {% endif %}>
                   </div>
-                  <a class="iconEdit iconSmall editInstance" title="{{"mb.manager.admin.instance.edit"|trans}} {{instance.title}}" href="{{ url("mapbender_manager_repository_instance",{"slug": application.slug, "instanceId": instance.id})  }}"></a>
-                  <span class="iconRemove iconSmall removeInstance" title="{{"mb.manager.admin.instance.delete.title"|trans}} {{instance.title}}" data-id="{{ layerset.id }}" data-slug="{{ application.slug }}" data-url="{{ url("mapbender_manager_application_deleteinstance",{"slug": application.slug, 'layersetId': layerset.id, "instanceId": instance.id}) }}"></span>
+                  <a class="iconEdit iconSmall editInstance" title="{{"mb.manager.admin.instance.edit"|trans}} {{instance.title}}" href="{{ path("mapbender_manager_repository_instance",{"slug": application.slug, "instanceId": instance.id})  }}"></a>
+                  <span class="iconRemove iconSmall removeInstance" title="{{"mb.manager.admin.instance.delete.title"|trans}} {{instance.title}}" data-id="{{ layerset.id }}" data-slug="{{ application.slug }}" data-url="{{ path("mapbender_manager_application_deleteinstance",{"slug": application.slug, 'layersetId': layerset.id, "instanceId": instance.id}) }}"></span>
                 </td>
               </tr>
             {% else %}

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/import-form.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/import-form.html.twig
@@ -6,7 +6,7 @@
   </div>
   <div class="right">
     <input type="submit" value="{{ 'mb.manager.admin.application.import.btn.import' | trans }}" class="button"/>
-    <a href="{{ url('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.import.btn.cancel' | trans}}</a>
+    <a href="{{ path('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.import.btn.cancel' | trans}}</a>
   </div>
   <div class="clearContainer"></div>
   {{ form_row(form._token) }}

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/new.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/new.html.twig
@@ -44,7 +44,7 @@
 
     <div class="right">
       <input type="submit" value="{{ 'mb.manager.admin.application.btn.create' | trans }}" class="button"/>
-      <a href="{{ url('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.btn.cancel' | trans}}</a>
+      <a href="{{ path('mapbender_manager_application_index') }}" class="button critical">{{ 'mb.manager.admin.application.btn.cancel' | trans}}</a>
     </div>
 
     <div class="clearContainer"></div>


### PR DESCRIPTION
Url generates absoulte urls which can cause errors  behind a reverse proxy. Path instead generates relative paths which are safe to use