### PR TITLE
Change the font-awesome path for font awesome version 5

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_icons.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_icons.scss
@@ -1,4 +1,4 @@
-@import url("components/font-awesome/css/font-awesome.min.css");
+@import url("components/font-awesome/font-awesome-built.css");
 [class^="icon"],
 [class*=" icon"],
 .icon {


### PR DESCRIPTION
After the new font-awesome version has been released via "mapbender / vis-ui.js", the path for font-awesome in the icons.scss must be adjusted. After this adjustment the new version 5 will be loaded.


