### PR TITLE
[RFC] Revert Template class magic

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
+++ b/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Application\Template;
+
+
+interface IApplicationTemplateAssetDependencyInterface
+{
+    /**
+     * Should return the list of assets of given $type that are required for the template to function.
+     *
+     * Supportable $type values are 'css', 'js', 'trans'.
+     *
+     * 'js' and 'css' entries should be either
+     * 1) bundle-qualified paths starting with '@'; e.g:
+     *    '@SpecialTemplateBundle/Resources/public/template/special-template.css'
+     * 2) web-root-anchored paths starting with '/'; e.g:
+     *    '/components/underscore/underscore-min.js'
+     *
+     * 'trans' entries are expected to name .json.twig files and must be
+     * twig-compatible (e.g. Somebundle:[optional-subpath under Resources/views:]translations.json.twig
+     *
+     * (unqualified bundle-local resource paths are technically possible but highly discouraged because they break
+     *  inheritance)
+     *
+     * @param string $type one of 'css', 'js' or 'trans'
+     * @return string[]
+     */
+    public function getAssets($type);
+
+
+    /**
+     * Should return 'late' assets, to be loaded at the very end, particularly after all Element assets.
+     * Semantics are the same as for @see getAssets
+     *
+     * @param string $type one of 'css', 'js' or 'trans'
+     * @return string[]
+     */
+    public function getLateAssets($type);
+}

--- a/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateInterface.php
+++ b/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Mapbender\CoreBundle\Component\Application\Template;
+
+/**
+ * Workaround for PHP<7 not allowing abstract static functions to be declared outside of interfaces.
+ */
+interface IApplicationTemplateInterface
+{
+    /**
+     * Should return the displayable title of the template. Listed in backend for
+     * 1) template choice when creating new Application
+     * 2) Application settings display
+     *
+     * @return string
+     */
+    public static function getTitle();
+
+
+    /**
+     * Should return the list of regions in the template that can be popuplated with Element output.
+     *
+     * @return string[]
+     */
+    public static function getRegions();
+}

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -39,10 +39,6 @@ abstract class Template
     /**  @var array Region names */
     protected static $regions = array();
 
-    protected static $css          = array();
-    protected static $js           = array();
-    protected static $translations = array();
-
     /**
      * Template constructor.
      *
@@ -74,11 +70,7 @@ abstract class Template
      */
     static public function listAssets()
     {
-        return array(
-            'css'   => static::$css,
-            'js'    => static::$js,
-            'trans' => static::$translations
-        );
+        return array();
     }
 
     /**
@@ -213,17 +205,6 @@ abstract class Template
     public function getTwigTemplate()
     {
         return $this->twigTemplate;
-    }
-
-    /**
-     * Add and merge unique assets
-     *
-     * @param       $type
-     * @param array $assets
-     */
-    public static function addAndMergeUniqueAssets($type, array $assets)
-    {
-        static::${$type} = array_values(array_unique(array_merge(static::${$type}, $assets)));
     }
 }
 

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -7,11 +7,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Base class for all application templates.
  *
  * @author Christian Wygoda
- * @author Andriy Oblivantsev
  */
 abstract class Template
 {
-    /** @var ContainerInterface */
     protected $container;
 
     /** @var Application */
@@ -20,24 +18,6 @@ abstract class Template
     /** @var string Bundle public resource path */
     protected static $resourcePath;
 
-    /** @var string Application title */
-    protected static $title;
-
-    /** @var string Application TWIG template path */
-    protected $twigTemplate;
-
-    /** @var array Late assets */
-    protected $lateAssets = array(
-        'js'    => array(),
-        'css'   => array(),
-        'trans' => array(),
-    );
-
-    /** @var array Region properties */
-    protected static $regionsProperties = array();
-
-    /**  @var array Region names */
-    protected static $regions = array();
 
     /**
      * Template constructor.
@@ -62,7 +42,7 @@ abstract class Template
      */
     static public function getTitle()
     {
-        return static::$title;
+        throw new \RuntimeException('getTitle must be implemented in subclasses');
     }
 
     /**
@@ -107,13 +87,12 @@ abstract class Template
     /**
      * Get assets for late including. These will be appended to the asset output last.
      * Remember to list them in listAssets!
-     *
      * @param string $type Asset type to list, can be 'css' or 'js'
      * @return array
      */
     public function getLateAssets($type)
     {
-        return $this->lateAssets[ $type ];
+        return array();
     }
 
     /**
@@ -123,16 +102,16 @@ abstract class Template
      */
     static public function getRegions()
     {
-        return static::$regions;
+        throw new \RuntimeException('getTitle must be implemented in subclasses');
     }
 
     /**
      * Render the application
      *
-     * @param string  $format Output format, defaults to HTML
-     * @param boolean $html   Whether to render the HTML itself
-     * @param boolean $css    Whether to include the CSS links
-     * @param boolean $js     Whether to include the JavaScript
+     * @param string $format Output format, defaults to HTML
+     * @param boolean $html Whether to render the HTML itself
+     * @param boolean $css  Whether to include the CSS links
+     * @param boolean $js   Whether to include the JavaScript
      * @return string $html The rendered HTML
      */
     public function render($format = 'html', $html = true, $css = true, $js = true)
@@ -159,7 +138,7 @@ abstract class Template
      */
     public static function getRegionsProperties()
     {
-        return static::$regionsProperties;
+        return array();
     }
 
     /**
@@ -167,8 +146,7 @@ abstract class Template
      *
      * @return string Bundle name
      */
-    public function getBundleName()
-    {
+    public function getBundleName() {
         $reflection = new \ReflectionClass(get_class($this));
         return preg_replace('/\\\\|Template$/', '', $reflection->getNamespaceName());
     }
@@ -181,22 +159,6 @@ abstract class Template
     public static function getResourcePath()
     {
         return static::$resourcePath;
-    }
-
-    /**
-     * @param Application $twigTemplate
-     */
-    public function setTwigTemplate($twigTemplate)
-    {
-        $this->twigTemplate = $twigTemplate;
-    }
-
-    /**
-     * @param $title string Title
-     */
-    public static function setTitle($title)
-    {
-        static::$title = $title;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
 
+use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -8,15 +9,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Christian Wygoda
  */
-abstract class Template
+abstract class Template implements IApplicationTemplateInterface
 {
     protected $container;
 
     /** @var Application */
     protected $application;
-
-    /** @var string Bundle public resource path */
-    protected static $resourcePath;
 
 
     /**
@@ -27,22 +25,8 @@ abstract class Template
      */
     public function __construct(ContainerInterface $container, Application $application)
     {
-        static::$resourcePath = '@' . $this->getBundleName() . '/Resources/public';
         $this->container    = $container;
         $this->application  = $application;
-    }
-
-    /**
-     * Get the template title.
-     *
-     * This title is mainly used in the backend manager when creating a new
-     * application.
-     *
-     * @return string
-     */
-    static public function getTitle()
-    {
-        throw new \RuntimeException('getTitle must be implemented in subclasses');
     }
 
     /**
@@ -86,23 +70,19 @@ abstract class Template
 
     /**
      * Get assets for late including. These will be appended to the asset output last.
-     * Remember to list them in listAssets!
      * @param string $type Asset type to list, can be 'css' or 'js'
      * @return array
      */
     public function getLateAssets($type)
     {
-        return array();
-    }
-
-    /**
-     * Get the template regions available in the Twig template.
-     *
-     * @return array
-     */
-    static public function getRegions()
-    {
-        throw new \RuntimeException('getTitle must be implemented in subclasses');
+        switch ($type) {
+            case 'js':
+            case 'css':
+            case 'trans':
+                return array();
+            default:
+                throw new \InvalidArgumentException("Unsupported late asset type " . print_r($type, true));
+        }
     }
 
     /**
@@ -141,26 +121,6 @@ abstract class Template
     public static function getRegionsProperties()
     {
         return array();
-    }
-
-    /**
-     * Get template bundle name
-     *
-     * @return string Bundle name
-     */
-    public function getBundleName() {
-        $reflection = new \ReflectionClass(get_class($this));
-        return preg_replace('/\\\\|Template$/', '', $reflection->getNamespaceName());
-    }
-
-    /**
-     * Get resource path
-     *
-     * @return string
-     */
-    public static function getResourcePath()
-    {
-        return static::$resourcePath;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -6,7 +6,9 @@ use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateInte
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Base class for all application templates.
+ * Defines twig template and asset dependencies and regions for an Application template.
+ * Also defines the displayable title of the template that is displayed in the backend when choosing or
+ * displaying the template assigned to an Application.
  *
  * @author Christian Wygoda
  */
@@ -30,29 +32,17 @@ abstract class Template implements IApplicationTemplateInterface, IApplicationTe
     }
 
     /**
-     * @return array
-     */
-    static public function listAssets()
-    {
-        return array();
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getAssets($type)
     {
-        $allAssets = $this::listAssets();
-        $ownAssets = array_key_exists($type, $allAssets) ? $allAssets[$type] : array();
-        $parent = get_parent_class($this);
-        // Merge up all JavaScript assets, so we get all the required libraries into all
-        // extending templates.
-        if ($type === 'js' && $parent) {
-            $allBaseAssets = call_user_func(array($parent, 'listAssets'), $type);
-            $baseAssets = $ownAssets = array_key_exists($type, $allBaseAssets) ? $allBaseAssets[$type] : array();
-            return array_unique(array_merge($baseAssets, $ownAssets));
-        } else {
-            return $ownAssets;
+        switch ($type) {
+            case 'js':
+            case 'css':
+            case 'trans':
+                return array();
+            default:
+                throw new \InvalidArgumentException("Unsupported asset type " . print_r($type, true));
         }
     }
 

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender\CoreBundle\Component;
 
+use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateAssetDependencyInterface;
 use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -9,13 +10,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Christian Wygoda
  */
-abstract class Template implements IApplicationTemplateInterface
+abstract class Template implements IApplicationTemplateInterface, IApplicationTemplateAssetDependencyInterface
 {
     protected $container;
 
     /** @var Application */
     protected $application;
-
 
     /**
      * Template constructor.
@@ -38,19 +38,7 @@ abstract class Template implements IApplicationTemplateInterface
     }
 
     /**
-     * Get the element assets.
-     *
-     * Returns an array of references to asset files of the given type.
-     * References can either be filenames/path which are searched for in the
-     * Resources/public directory of the element's bundle or assetic references
-     * indicating the bundle to search in:
-     *
-     * array(
-     *   'foo.css'),
-     *   '@MapbenderCoreBundle/Resources/public/foo.css'));
-     *
-     * @param string $type Asset type to list, can be 'css' or 'js'
-     * @return array
+     * {@inheritdoc}
      */
     public function getAssets($type)
     {
@@ -69,9 +57,7 @@ abstract class Template implements IApplicationTemplateInterface
     }
 
     /**
-     * Get assets for late including. These will be appended to the asset output last.
-     * @param string $type Asset type to list, can be 'css' or 'js'
-     * @return array
+     * {@inheritdoc}
      */
     public function getLateAssets($type)
     {

--- a/src/Mapbender/CoreBundle/Component/Template.php
+++ b/src/Mapbender/CoreBundle/Component/Template.php
@@ -119,14 +119,16 @@ abstract class Template
         $application       = $this->application;
         $applicationEntity = $application->getEntity();
         $templateRender    = $this->container->get('templating');
+        $uploadsDir = Application::getAppWebDir($this->container, $this->application->getSlug());
 
-        return $templateRender->render($this->twigTemplate, array(
+        return $templateRender->render($this->getTwigTemplate(), array(
                 'html'                 => $html,
                 'css'                  => $css,
                 'js'                   => $js,
                 'application'          => $application,
                 'region_props'         => $applicationEntity->getNamedRegionProperties(),
-                'default_region_props' => static::getRegionsProperties()
+                'default_region_props' => static::getRegionsProperties(),
+                'uploads_dir' => $uploadsDir,
             )
         );
     }
@@ -164,9 +166,6 @@ abstract class Template
     /**
      * @return string TWIG template path
      */
-    public function getTwigTemplate()
-    {
-        return $this->twigTemplate;
-    }
+    abstract public function getTwigTemplate();
 }
 

--- a/src/Mapbender/CoreBundle/Template/Classic.php
+++ b/src/Mapbender/CoreBundle/Template/Classic.php
@@ -11,13 +11,21 @@ class Classic extends Fullscreen
 {
     protected static $title   = "Classic template";
     protected static $regions = array('toolbar', 'sidepane', 'content', 'footer');
-    protected static $css     = array(
-        '@MapbenderCoreBundle/Resources/public/sass/template/classic.scss',
-    );
-    protected static $js      = array(
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'
-    );
 
     public $twigTemplate = 'MapbenderCoreBundle:Template:classic.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    static public function listAssets()
+    {
+        return array(
+            'css'   => array(
+                '@MapbenderCoreBundle/Resources/public/sass/template/classic.scss'),
+            'js'    => array(
+                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
+            'trans' => array()
+        );
+    }
 }

--- a/src/Mapbender/CoreBundle/Template/Classic.php
+++ b/src/Mapbender/CoreBundle/Template/Classic.php
@@ -52,19 +52,6 @@ class Classic extends Template
     /**
      * @inheritdoc
      */
-    public function getLateAssets($type)
-    {
-        $assets = array(
-            'css' => array(),
-            'js' => array(),
-            'trans' => array()
-        );
-        return $assets[$type];
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getAssets($type)
     {
         $assets = $this::listAssets();

--- a/src/Mapbender/CoreBundle/Template/Classic.php
+++ b/src/Mapbender/CoreBundle/Template/Classic.php
@@ -2,31 +2,11 @@
 
 namespace Mapbender\CoreBundle\Template;
 
-use Mapbender\CoreBundle\Component\Template;
-
 /**
  * Template Classic
  */
-class Classic extends Template
+class Classic extends Fullscreen
 {
-
-    /**
-     * @inheritdoc
-     */
-    public static function getRegionsProperties()
-    {
-        return array(
-            'sidepane' => array(
-                'tabs' => array(
-                    'name' => 'tabs',
-                    'label' => 'mb.manager.template.region.tabs.label'),
-                'accordion' => array(
-                    'name' => 'accordion',
-                    'label' => 'mb.manager.template.region.accordion.label')
-            )
-        );
-    }
-
     /**
      * @inheritdoc
      */
@@ -36,34 +16,20 @@ class Classic extends Template
     }
 
     /**
-     * @inheritdoc
-     */
-    static public function listAssets()
-    {
-        $assets = array(
-            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/classic.scss'),
-            'js' => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
-            'trans' => array()
-        );
-        return $assets;
-    }
-
-    /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getAssets($type)
     {
-        $assets = $this::listAssets();
-        return $assets[$type];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function getRegions()
-    {
-        return array('toolbar', 'sidepane', 'content', 'footer');
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/template/classic.scss',
+                );
+            case 'js':
+            case 'trans':
+            default:
+                return parent::getAssets($type);
+        }
     }
 
     public function getTwigTemplate()

--- a/src/Mapbender/CoreBundle/Template/Classic.php
+++ b/src/Mapbender/CoreBundle/Template/Classic.php
@@ -79,23 +79,8 @@ class Classic extends Template
         return array('toolbar', 'sidepane', 'content', 'footer');
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $region_props = $this->application->getEntity()->getNamedRegionProperties();
-        $default_region_props = $this->getRegionsProperties();
-
-        $templating = $this->container->get('templating');
-        return $templating
-                ->render('MapbenderCoreBundle:Template:classic.html.twig', array(
-                    'html' => $html,
-                    'css' => $css,
-                    'js' => $js,
-                    'application' => $this->application,
-                    'region_props' => $region_props,
-                    'default_region_props' => $default_region_props));
+        return 'MapbenderCoreBundle:Template:classic.html.twig';
     }
-
 }

--- a/src/Mapbender/CoreBundle/Template/Classic.php
+++ b/src/Mapbender/CoreBundle/Template/Classic.php
@@ -2,30 +2,100 @@
 
 namespace Mapbender\CoreBundle\Template;
 
+use Mapbender\CoreBundle\Component\Template;
+
 /**
  * Template Classic
- *
- * @deprecated
  */
-class Classic extends Fullscreen
+class Classic extends Template
 {
-    protected static $title   = "Classic template";
-    protected static $regions = array('toolbar', 'sidepane', 'content', 'footer');
 
-    public $twigTemplate = 'MapbenderCoreBundle:Template:classic.html.twig';
+    /**
+     * @inheritdoc
+     */
+    public static function getRegionsProperties()
+    {
+        return array(
+            'sidepane' => array(
+                'tabs' => array(
+                    'name' => 'tabs',
+                    'label' => 'mb.manager.template.region.tabs.label'),
+                'accordion' => array(
+                    'name' => 'accordion',
+                    'label' => 'mb.manager.template.region.accordion.label')
+            )
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTitle()
+    {
+        return 'Classic template';
+    }
 
     /**
      * @inheritdoc
      */
     static public function listAssets()
     {
-        return array(
-            'css'   => array(
-                '@MapbenderCoreBundle/Resources/public/sass/template/classic.scss'),
-            'js'    => array(
-                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+        $assets = array(
+            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/classic.scss'),
+            'js' => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
                 '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
             'trans' => array()
         );
+        return $assets;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLateAssets($type)
+    {
+        $assets = array(
+            'css' => array(),
+            'js' => array(),
+            'trans' => array()
+        );
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets($type)
+    {
+        $assets = $this::listAssets();
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegions()
+    {
+        return array('toolbar', 'sidepane', 'content', 'footer');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render($format = 'html', $html = true, $css = true, $js = true)
+    {
+        $region_props = $this->application->getEntity()->getNamedRegionProperties();
+        $default_region_props = $this->getRegionsProperties();
+
+        $templating = $this->container->get('templating');
+        return $templating
+                ->render('MapbenderCoreBundle:Template:classic.html.twig', array(
+                    'html' => $html,
+                    'css' => $css,
+                    'js' => $js,
+                    'application' => $this->application,
+                    'region_props' => $region_props,
+                    'default_region_props' => $default_region_props));
+    }
+
 }

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -11,7 +11,6 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class Fullscreen extends Template
 {
-
     /**
      * @inheritdoc
      */
@@ -21,11 +20,13 @@ class Fullscreen extends Template
             'sidepane' => array(
                 'tabs' => array(
                     'name' => 'tabs',
-                    'label' => 'mb.manager.template.region.tabs.label'),
+                    'label' => 'mb.manager.template.region.tabs.label',
+                ),
                 'accordion' => array(
                     'name' => 'accordion',
-                    'label' => 'mb.manager.template.region.accordion.label')
-            )
+                    'label' => 'mb.manager.template.region.accordion.label',
+                ),
+            ),
         );
     }
 
@@ -37,37 +38,33 @@ class Fullscreen extends Template
         return 'Fullscreen';
     }
 
-    /**
-     * @inheritdoc
-     */
-    static public function listAssets()
-    {
-        $assets = array(
-            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss'),
-            'js'    => array(
-                '/components/underscore/underscore-min.js',
-                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-                '@MapbenderCoreBundle/Resources/public/mapbender.container.info.js',
-                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-                "/components/datatables/media/js/jquery.dataTables.min.js",
-                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-                "/components/vis-ui.js/vis-ui.js-built.js"
-
-            ),
-            'trans' => array()
-        );
-        return $assets;
-    }
 
     /**
      * @inheritdoc
      */
     public function getAssets($type)
     {
-        $assets = $this::listAssets();
-        return $assets[$type];
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss',
+                );
+            case 'js':
+                return array(
+                    '/components/underscore/underscore-min.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                    '@MapbenderCoreBundle/Resources/public/mapbender.container.info.js',
+                    '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                    "/components/datatables/media/js/jquery.dataTables.min.js",
+                    '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                    '/components/vis-ui.js/vis-ui.js-built.js',
+                );
+            case 'trans':
+            default:
+                return parent::getAssets($type);
+        }
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -11,7 +11,6 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class Fullscreen extends Template
 {
-    public $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen.html.twig';
 
     /**
      * @inheritdoc
@@ -97,18 +96,19 @@ class Fullscreen extends Template
      */
     public function render($format = 'html', $html = true, $css = true, $js = true)
     {
-        $application       = $this->application;
-        $applicationEntity = $application->getEntity();
-        $templating        = $this->container->get('templating');
+        $application          = $this->application;
+        $applicationEntity    = $application->getEntity();
+        $templating           = $this->container->get('templating');
 
-        return $templating->render($this->twigTemplate, array(
-                'html'                 => $html,
-                'css'                  => $css,
-                'js'                   => $js,
-                'application'          => $application,
-                'region_props'         => $applicationEntity->getNamedRegionProperties(),
-                'default_region_props' => $this->getRegionsProperties()
-            )
-        );
+        $parameters = array(
+            'html'                 => $html,
+            'css'                  => $css,
+            'js'                   => $js,
+            'application'          => $application,
+            'region_props'         => $applicationEntity->getNamedRegionProperties(),
+            'default_region_props' => $this->getRegionsProperties());
+
+        return $templating
+            ->render('MapbenderCoreBundle:Template:fullscreen.html.twig', $parameters);
     }
 }

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -64,19 +64,6 @@ class Fullscreen extends Template
     /**
      * @inheritdoc
      */
-    public function getLateAssets($type)
-    {
-        $assets = array(
-            'css' => array(),
-            'js' => array(),
-            'trans' => array()
-        );
-        return $assets[$type];
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getAssets($type)
     {
         $assets = $this::listAssets();

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -91,24 +91,8 @@ class Fullscreen extends Template
         return array('toolbar', 'sidepane', 'content', 'footer');
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $application          = $this->application;
-        $applicationEntity    = $application->getEntity();
-        $templating           = $this->container->get('templating');
-
-        $parameters = array(
-            'html'                 => $html,
-            'css'                  => $css,
-            'js'                   => $js,
-            'application'          => $application,
-            'region_props'         => $applicationEntity->getNamedRegionProperties(),
-            'default_region_props' => $this->getRegionsProperties());
-
-        return $templating
-            ->render('MapbenderCoreBundle:Template:fullscreen.html.twig', $parameters);
+        return 'MapbenderCoreBundle:Template:fullscreen.html.twig';
     }
 }

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -23,20 +23,29 @@ class Fullscreen extends Template
                 'label' => 'mb.manager.template.region.accordion.label')
         )
     );
-    protected static $css               = array(
-        '@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss'
-    );
-    protected static $js                = array(
-        '/components/underscore/underscore-min.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-        '@MapbenderCoreBundle/Resources/public/mapbender.container.info.js',
-        '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-        "/components/datatables/media/js/jquery.dataTables.min.js",
-        '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-        "/components/vis-ui.js/vis-ui.js-built.js"
-    );
 
     public $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    static public function listAssets()
+    {
+        return array(
+            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss'),
+            'js'    => array(
+                '/components/underscore/underscore-min.js',
+                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                '@MapbenderCoreBundle/Resources/public/mapbender.container.info.js',
+                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                "/components/datatables/media/js/jquery.dataTables.min.js",
+                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                "/components/vis-ui.js/vis-ui.js-built.js"
+
+            ),
+            'trans' => array()
+        );
+    }
 }

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -11,27 +11,39 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class Fullscreen extends Template
 {
-    protected static $title             = "Fullscreen";
-    protected static $regions           = array('toolbar', 'sidepane', 'content', 'footer');
-    protected static $regionsProperties = array(
-        'sidepane' => array(
-            'tabs'      => array(
-                'name'  => 'tabs',
-                'label' => 'mb.manager.template.region.tabs.label'),
-            'accordion' => array(
-                'name'  => 'accordion',
-                'label' => 'mb.manager.template.region.accordion.label')
-        )
-    );
-
     public $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegionsProperties()
+    {
+        return array(
+            'sidepane' => array(
+                'tabs' => array(
+                    'name' => 'tabs',
+                    'label' => 'mb.manager.template.region.tabs.label'),
+                'accordion' => array(
+                    'name' => 'accordion',
+                    'label' => 'mb.manager.template.region.accordion.label')
+            )
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTitle()
+    {
+        return 'Fullscreen';
+    }
 
     /**
      * @inheritdoc
      */
     static public function listAssets()
     {
-        return array(
+        $assets = array(
             'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss'),
             'js'    => array(
                 '/components/underscore/underscore-min.js',
@@ -46,6 +58,57 @@ class Fullscreen extends Template
 
             ),
             'trans' => array()
+        );
+        return $assets;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLateAssets($type)
+    {
+        $assets = array(
+            'css' => array(),
+            'js' => array(),
+            'trans' => array()
+        );
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets($type)
+    {
+        $assets = $this::listAssets();
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegions()
+    {
+        return array('toolbar', 'sidepane', 'content', 'footer');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render($format = 'html', $html = true, $css = true, $js = true)
+    {
+        $application       = $this->application;
+        $applicationEntity = $application->getEntity();
+        $templating        = $this->container->get('templating');
+
+        return $templating->render($this->twigTemplate, array(
+                'html'                 => $html,
+                'css'                  => $css,
+                'js'                   => $js,
+                'application'          => $application,
+                'region_props'         => $applicationEntity->getNamedRegionProperties(),
+                'default_region_props' => $this->getRegionsProperties()
+            )
         );
     }
 }

--- a/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
+++ b/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
@@ -2,19 +2,40 @@
 
 namespace Mapbender\CoreBundle\Template;
 
+use Mapbender\CoreBundle\Component\Template;
+
 /**
  * Template FullscreenAlternative
  *
  * @author Christian Wygoda
- * @author Andriy Oblivantsev
- *
- * @deprecated
  */
-class FullscreenAlternative extends Fullscreen
+class FullscreenAlternative extends Template
 {
-    protected static $title        = "Fullscreen alternative";
 
-    public           $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen_alternative.html.twig';
+    /**
+     * @inheritdoc
+     */
+    public static function getRegionsProperties()
+    {
+        return array(
+            'sidepane' => array(
+                'tabs' => array(
+                    'name' => 'tabs',
+                    'label' => 'mb.manager.template.region.tabs.label'),
+                'accordion' => array(
+                    'name' => 'accordion',
+                    'label' => 'mb.manager.template.region.accordion.label')
+            )
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTitle()
+    {
+        return 'Fullscreen alternative';
+    }
 
     /**
      * @inheritdoc
@@ -22,12 +43,49 @@ class FullscreenAlternative extends Fullscreen
     static public function listAssets()
     {
         $assets = array(
-            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss'),
-            'js'    => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                             '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                             '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
+            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss'),
+            'js' => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
             'trans' => array()
         );
         return $assets;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets($type)
+    {
+        $assets = $this::listAssets();
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegions()
+    {
+        return array('toolbar', 'sidepane', 'content', 'footer');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render($format = 'html', $html = true, $css = true, $js = true)
+    {
+        $region_props = $this->application->getEntity()->getNamedRegionProperties();
+        $default_region_props = $this->getRegionsProperties();
+
+        $templating = $this->container->get('templating');
+        return $templating
+                ->render('MapbenderCoreBundle:Template:fullscreen_alternative.html.twig', array(
+                    'html' => $html,
+                    'css' => $css,
+                    'js' => $js,
+                    'application' => $this->application,
+                    'region_props' => $region_props,
+                    'default_region_props' => $default_region_props));
+    }
+
 }

--- a/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
+++ b/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
@@ -12,15 +12,22 @@ namespace Mapbender\CoreBundle\Template;
  */
 class FullscreenAlternative extends Fullscreen
 {
-    protected static $title = "Fullscreen alternative";
-    protected static $css   = array(
-        '@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss'
-    );
-    protected static $js    = array(
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'
-    );
+    protected static $title        = "Fullscreen alternative";
 
-    public $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen_alternative.html.twig';
+    public           $twigTemplate = 'MapbenderCoreBundle:Template:fullscreen_alternative.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    static public function listAssets()
+    {
+        $assets = array(
+            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss'),
+            'js'    => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                             '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                             '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
+            'trans' => array()
+        );
+        return $assets;
+    }
 }

--- a/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
+++ b/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
@@ -69,23 +69,9 @@ class FullscreenAlternative extends Template
         return array('toolbar', 'sidepane', 'content', 'footer');
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $region_props = $this->application->getEntity()->getNamedRegionProperties();
-        $default_region_props = $this->getRegionsProperties();
-
-        $templating = $this->container->get('templating');
-        return $templating
-                ->render('MapbenderCoreBundle:Template:fullscreen_alternative.html.twig', array(
-                    'html' => $html,
-                    'css' => $css,
-                    'js' => $js,
-                    'application' => $this->application,
-                    'region_props' => $region_props,
-                    'default_region_props' => $default_region_props));
+        return 'MapbenderCoreBundle:Template:fullscreen_alternative.html.twig';
     }
 
 }

--- a/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
+++ b/src/Mapbender/CoreBundle/Template/FullscreenAlternative.php
@@ -2,32 +2,14 @@
 
 namespace Mapbender\CoreBundle\Template;
 
-use Mapbender\CoreBundle\Component\Template;
 
 /**
  * Template FullscreenAlternative
  *
  * @author Christian Wygoda
  */
-class FullscreenAlternative extends Template
+class FullscreenAlternative extends Fullscreen
 {
-
-    /**
-     * @inheritdoc
-     */
-    public static function getRegionsProperties()
-    {
-        return array(
-            'sidepane' => array(
-                'tabs' => array(
-                    'name' => 'tabs',
-                    'label' => 'mb.manager.template.region.tabs.label'),
-                'accordion' => array(
-                    'name' => 'accordion',
-                    'label' => 'mb.manager.template.region.accordion.label')
-            )
-        );
-    }
 
     /**
      * @inheritdoc
@@ -38,35 +20,20 @@ class FullscreenAlternative extends Template
     }
 
     /**
-     * @inheritdoc
-     */
-    static public function listAssets()
-    {
-        $assets = array(
-            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss'),
-            'js' => array('@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js'),
-            'trans' => array()
-        );
-        return $assets;
-    }
-
-    /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getAssets($type)
     {
-        $assets = $this::listAssets();
-        return $assets[$type];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function getRegions()
-    {
-        return array('toolbar', 'sidepane', 'content', 'footer');
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_alternative.scss',
+                );
+            case 'js':
+            case 'trans':
+            default:
+                return parent::getAssets($type);
+        }
     }
 
     public function getTwigTemplate()

--- a/src/Mapbender/CoreBundle/Template/Regional.php
+++ b/src/Mapbender/CoreBundle/Template/Regional.php
@@ -9,21 +9,68 @@ namespace Mapbender\CoreBundle\Template;
  * @author    Andriy Oblivantsev <eslider@gmail.com>
  * @copyright 2014 by WhereGroup GmbH & Co. KG
  */
-class Regional extends Responsive
+class Regional extends Fullscreen
 {
     protected static $title   = "Regional";
     protected static $regions = array('top', 'left', 'center', 'right', 'bottom');
-    protected static $js      = array(
-        '/components/underscore/underscore-min.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-        '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-        "/components/datatables/media/js/jquery.dataTables.min.js",
-        '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-        "/components/vis-ui.js/vis-ui.js-built.js",
-        '@MapbenderCoreBundle/Resources/public/js/responsive.js'
-    );
 
     public $twigTemplate = 'MapbenderCoreBundle:Template:regional.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    static public function listAssets()
+    {
+        return array(
+            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
+            'js'    => array(
+                '/components/underscore/underscore-min.js',
+                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                "/components/datatables/media/js/jquery.dataTables.min.js",
+                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                "/components/vis-ui.js/vis-ui.js-built.js",
+                '@MapbenderCoreBundle/Resources/public/js/responsive.js'
+            ),
+            'trans' => array());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getElementWhitelist()
+    {
+        return array(
+            'toolbar'       => array(
+                'Mapbender\CoreBundle\Element\Button',
+                'Mapbender\CoreBundle\Element\AboutDialog'),
+            'content'       => array(
+                'Mapbender\CoreBundle\Element\ActivityIndicator',
+                'Mapbender\CoreBundle\Element\CoordinatesDisplay',
+                'Mapbender\CoreBundle\Element\Copyright',
+                'Mapbender\CoreBundle\Element\Map',
+                'Mapbender\CoreBundle\Element\Overview',
+                'Mapbender\CoreBundle\Element\POI',
+                'Mapbender\CoreBundle\Element\PrintClient',
+                'Mapbender\CoreBundle\Element\Ruler',
+                'Mapbender\CoreBundle\Element\ScaleBar',
+                'Mapbender\CoreBundle\Element\ScaleDisplay',
+                'Mapbender\CoreBundle\Element\ScaleSelector',
+                'Mapbender\CoreBundle\Element\SearchRouter',
+                'Mapbender\CoreBundle\Element\SimpleSearch',
+                'Mapbender\CoreBundle\Element\Sketch',
+                'Mapbender\CoreBundle\Element\SrsSelector',
+                'Mapbender\CoreBundle\Element\ZoomBar'),
+            'infocontainer' => array(
+                'Mapbender\CoreBundle\Element\AboutDialog',
+                'Mapbender\CoreBundle\Element\BaseSourceSwitcher',
+                'Mapbender\CoreBundle\Element\CoordinatesDisplay',
+                'Mapbender\CoreBundle\Element\Copyright',
+                'Mapbender\CoreBundle\Element\ScaleBar',
+                'Mapbender\CoreBundle\Element\ScaleSelector',
+                'Mapbender\CoreBundle\Element\SrsSelector')
+        );
+    }
 }

--- a/src/Mapbender/CoreBundle/Template/Regional.php
+++ b/src/Mapbender/CoreBundle/Template/Regional.php
@@ -2,6 +2,8 @@
 
 namespace Mapbender\CoreBundle\Template;
 
+use Mapbender\CoreBundle\Component\Template;
+
 /**
  * Class Regional
  *
@@ -9,32 +11,64 @@ namespace Mapbender\CoreBundle\Template;
  * @author    Andriy Oblivantsev <eslider@gmail.com>
  * @copyright 2014 by WhereGroup GmbH & Co. KG
  */
-class Regional extends Fullscreen
+class Regional extends Template
 {
-    protected static $title   = "Regional";
-    protected static $regions = array('top', 'left', 'center', 'right', 'bottom');
 
-    public $twigTemplate = 'MapbenderCoreBundle:Template:regional.html.twig';
+    /**
+     * @inheritdoc
+     */
+    public static function getRegionsProperties()
+    {
+        return array('sidepane' => array('tabs'      => array('name'  => 'tabs',
+                                                              'label' => 'mb.manager.template.region.tabs.label'),
+                                         'accordion' => array('name'  => 'accordion',
+                                                              'label' => 'mb.manager.template.region.accordion.label')));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTitle()
+    {
+        return preg_replace('|.*\\\|', '', __CLASS__);
+    }
 
     /**
      * @inheritdoc
      */
     static public function listAssets()
     {
-        return array(
-            'css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
-            'js'    => array(
-                '/components/underscore/underscore-min.js',
-                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-                "/components/datatables/media/js/jquery.dataTables.min.js",
-                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-                "/components/vis-ui.js/vis-ui.js-built.js",
-                '@MapbenderCoreBundle/Resources/public/js/responsive.js'
-            ),
-            'trans' => array());
+        $assets = array('css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
+                        'js'    => array(
+                            '/components/underscore/underscore-min.js',
+                            '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                            '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                            '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                            '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                            "/components/datatables/media/js/jquery.dataTables.min.js",
+                            '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                            "/components/vis-ui.js/vis-ui.js-built.js",
+                            '@MapbenderCoreBundle/Resources/public/js/responsive.js'
+                        ),
+                        'trans' => array());
+        return $assets;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets($type)
+    {
+        $arr = self::listAssets();
+        return $arr[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegions()
+    {
+        return array('top', 'left', 'center', 'right', 'bottom');
     }
 
     /**
@@ -42,35 +76,49 @@ class Regional extends Fullscreen
      */
     public static function getElementWhitelist()
     {
-        return array(
-            'toolbar'       => array(
-                'Mapbender\CoreBundle\Element\Button',
-                'Mapbender\CoreBundle\Element\AboutDialog'),
-            'content'       => array(
-                'Mapbender\CoreBundle\Element\ActivityIndicator',
-                'Mapbender\CoreBundle\Element\CoordinatesDisplay',
-                'Mapbender\CoreBundle\Element\Copyright',
-                'Mapbender\CoreBundle\Element\Map',
-                'Mapbender\CoreBundle\Element\Overview',
-                'Mapbender\CoreBundle\Element\POI',
-                'Mapbender\CoreBundle\Element\PrintClient',
-                'Mapbender\CoreBundle\Element\Ruler',
-                'Mapbender\CoreBundle\Element\ScaleBar',
-                'Mapbender\CoreBundle\Element\ScaleDisplay',
-                'Mapbender\CoreBundle\Element\ScaleSelector',
-                'Mapbender\CoreBundle\Element\SearchRouter',
-                'Mapbender\CoreBundle\Element\SimpleSearch',
-                'Mapbender\CoreBundle\Element\Sketch',
-                'Mapbender\CoreBundle\Element\SrsSelector',
-                'Mapbender\CoreBundle\Element\ZoomBar'),
-            'infocontainer' => array(
-                'Mapbender\CoreBundle\Element\AboutDialog',
-                'Mapbender\CoreBundle\Element\BaseSourceSwitcher',
-                'Mapbender\CoreBundle\Element\CoordinatesDisplay',
-                'Mapbender\CoreBundle\Element\Copyright',
-                'Mapbender\CoreBundle\Element\ScaleBar',
-                'Mapbender\CoreBundle\Element\ScaleSelector',
-                'Mapbender\CoreBundle\Element\SrsSelector')
+        return array('toolbar'       => array('Mapbender\CoreBundle\Element\Button',
+                                              'Mapbender\CoreBundle\Element\AboutDialog'),
+                     'content'       => array('Mapbender\CoreBundle\Element\ActivityIndicator',
+                                              'Mapbender\CoreBundle\Element\CoordinatesDisplay',
+                                              'Mapbender\CoreBundle\Element\Copyright',
+                                              'Mapbender\CoreBundle\Element\Map',
+                                              'Mapbender\CoreBundle\Element\Overview',
+                                              'Mapbender\CoreBundle\Element\POI',
+                                              'Mapbender\CoreBundle\Element\PrintClient',
+                                              'Mapbender\CoreBundle\Element\Ruler',
+                                              'Mapbender\CoreBundle\Element\ScaleBar',
+                                              'Mapbender\CoreBundle\Element\ScaleDisplay',
+                                              'Mapbender\CoreBundle\Element\ScaleSelector',
+                                              'Mapbender\CoreBundle\Element\SearchRouter',
+                                              'Mapbender\CoreBundle\Element\SimpleSearch',
+                                              'Mapbender\CoreBundle\Element\Sketch',
+                                              'Mapbender\CoreBundle\Element\SrsSelector',
+                                              'Mapbender\CoreBundle\Element\ZoomBar'),
+                     'infocontainer' => array('Mapbender\CoreBundle\Element\AboutDialog',
+                                              'Mapbender\CoreBundle\Element\BaseSourceSwitcher',
+                                              'Mapbender\CoreBundle\Element\CoordinatesDisplay',
+                                              'Mapbender\CoreBundle\Element\Copyright',
+                                              'Mapbender\CoreBundle\Element\ScaleBar',
+                                              'Mapbender\CoreBundle\Element\ScaleSelector',
+                                              'Mapbender\CoreBundle\Element\SrsSelector'));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render($format = 'html', $html = true, $css = true, $js = true)
+    {
+        $region_props         = $this->application->getEntity()->getNamedRegionProperties();
+        $default_region_props = $this->getRegionsProperties();
+        $templating           = $this->container->get('templating');
+        return $templating->render('MapbenderCoreBundle:Template:regional.html.twig',
+            array('html'                 => $html,
+                  'css'                  => $css,
+                  'js'                   => $js,
+                  'application'          => $this->application,
+                  'region_props'         => $region_props,
+                  'default_region_props' => $default_region_props)
         );
     }
+
 }

--- a/src/Mapbender/CoreBundle/Template/Regional.php
+++ b/src/Mapbender/CoreBundle/Template/Regional.php
@@ -103,22 +103,8 @@ class Regional extends Template
                                               'Mapbender\CoreBundle\Element\SrsSelector'));
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $region_props         = $this->application->getEntity()->getNamedRegionProperties();
-        $default_region_props = $this->getRegionsProperties();
-        $templating           = $this->container->get('templating');
-        return $templating->render('MapbenderCoreBundle:Template:regional.html.twig',
-            array('html'                 => $html,
-                  'css'                  => $css,
-                  'js'                   => $js,
-                  'application'          => $this->application,
-                  'region_props'         => $region_props,
-                  'default_region_props' => $default_region_props)
-        );
+        return 'MapbenderCoreBundle:Template:regional.html.twig';
     }
-
 }

--- a/src/Mapbender/CoreBundle/Template/Regional.php
+++ b/src/Mapbender/CoreBundle/Template/Regional.php
@@ -36,31 +36,29 @@ class Regional extends Template
     /**
      * @inheritdoc
      */
-    static public function listAssets()
-    {
-        $assets = array('css'   => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
-                        'js'    => array(
-                            '/components/underscore/underscore-min.js',
-                            '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                            '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                            '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-                            '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-                            "/components/datatables/media/js/jquery.dataTables.min.js",
-                            '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-                            "/components/vis-ui.js/vis-ui.js-built.js",
-                            '@MapbenderCoreBundle/Resources/public/js/responsive.js'
-                        ),
-                        'trans' => array());
-        return $assets;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getAssets($type)
     {
-        $arr = self::listAssets();
-        return $arr[$type];
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss',
+                );
+            case 'js':
+                return array(
+                    '/components/underscore/underscore-min.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                    '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                    "/components/datatables/media/js/jquery.dataTables.min.js",
+                    '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                    "/components/vis-ui.js/vis-ui.js-built.js",
+                    '@MapbenderCoreBundle/Resources/public/js/responsive.js',
+                );
+            case 'trans':
+            default:
+                return parent::getAssets($type);
+        }
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Template/Responsive.php
+++ b/src/Mapbender/CoreBundle/Template/Responsive.php
@@ -2,27 +2,49 @@
 
 namespace Mapbender\CoreBundle\Template;
 
+use Mapbender\CoreBundle\Component\Template;
+
 /**
  * Template Responsive
  *
  * @author Vadim Hermann
- * @deprecated
  */
-class Responsive extends Fullscreen
+class Responsive extends Template
 {
-    protected static $title   = "Responsive";
-    protected static $regions = array('toolbar', 'content', 'infocontainer');
 
-    public $twigTemplate = 'MapbenderCoreBundle:Template:responsive.html.twig';
+    /**
+     * @inheritdoc
+     */
+    public static function getRegionsProperties()
+    {
+        return array(
+            'sidepane' => array(
+                'tabs' => array(
+                    'name' => 'tabs',
+                    'label' => 'mb.manager.template.region.tabs.label'),
+                'accordion' => array(
+                    'name' => 'accordion',
+                    'label' => 'mb.manager.template.region.accordion.label')
+            )
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTitle()
+    {
+        return 'Responsive';
+    }
 
     /**
      * @inheritdoc
      */
     static public function listAssets()
     {
-        return array(
+        $assets = array(
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
-            'js'  => array(
+            'js'    => array(
                 '/components/underscore/underscore-min.js',
                 '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
                 '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
@@ -33,9 +55,27 @@ class Responsive extends Fullscreen
                 "/components/vis-ui.js/vis-ui.js-built.js",
                 '@MapbenderCoreBundle/Resources/public/js/responsive.js'
             ),
-
+                
             'trans' => array()
         );
+        return $assets;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets($type)
+    {
+        $assets = $this::listAssets();
+        return $assets[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getRegions()
+    {
+        return array('toolbar', 'content', 'infocontainer');
     }
 
     /**
@@ -43,12 +83,9 @@ class Responsive extends Fullscreen
      */
     public static function getElementWhitelist()
     {
-        return array(
-            'toolbar'       => array(
-                'Mapbender\CoreBundle\Element\Button',
+        return array('toolbar' => array('Mapbender\CoreBundle\Element\Button',
                 'Mapbender\CoreBundle\Element\AboutDialog'),
-            'content'       => array(
-                'Mapbender\CoreBundle\Element\ActivityIndicator',
+            'content' => array('Mapbender\CoreBundle\Element\ActivityIndicator',
                 'Mapbender\CoreBundle\Element\CoordinatesDisplay',
                 'Mapbender\CoreBundle\Element\Copyright',
                 'Mapbender\CoreBundle\Element\Map',
@@ -64,14 +101,32 @@ class Responsive extends Fullscreen
                 'Mapbender\CoreBundle\Element\Sketch',
                 'Mapbender\CoreBundle\Element\SrsSelector',
                 'Mapbender\CoreBundle\Element\ZoomBar'),
-            'infocontainer' => array(
-                'Mapbender\CoreBundle\Element\AboutDialog',
+            'infocontainer' => array('Mapbender\CoreBundle\Element\AboutDialog',
                 'Mapbender\CoreBundle\Element\BaseSourceSwitcher',
                 'Mapbender\CoreBundle\Element\CoordinatesDisplay',
                 'Mapbender\CoreBundle\Element\Copyright',
                 'Mapbender\CoreBundle\Element\ScaleBar',
                 'Mapbender\CoreBundle\Element\ScaleSelector',
-                'Mapbender\CoreBundle\Element\SrsSelector')
-        );
+                'Mapbender\CoreBundle\Element\SrsSelector'));
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function render($format = 'html', $html = true, $css = true, $js = true)
+    {
+        $region_props = $this->application->getEntity()->getNamedRegionProperties();
+        $default_region_props = $this->getRegionsProperties();
+
+        $templating = $this->container->get('templating');
+        return $templating
+                ->render('MapbenderCoreBundle:Template:responsive.html.twig', array(
+                    'html' => $html,
+                    'css' => $css,
+                    'js' => $js,
+                    'application' => $this->application,
+                    'region_props' => $region_props,
+                    'default_region_props' => $default_region_props));
+    }
+
 }

--- a/src/Mapbender/CoreBundle/Template/Responsive.php
+++ b/src/Mapbender/CoreBundle/Template/Responsive.php
@@ -12,22 +12,31 @@ class Responsive extends Fullscreen
 {
     protected static $title   = "Responsive";
     protected static $regions = array('toolbar', 'content', 'infocontainer');
-    protected static $css     = array(
-        '@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'
-    );
-    protected static $js      = array(
-        '/components/underscore/underscore-min.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-        '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-        "/components/datatables/media/js/jquery.dataTables.min.js",
-        '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-        "/components/vis-ui.js/vis-ui.js-built.js",
-        '@MapbenderCoreBundle/Resources/public/js/responsive.js'
-    );
 
     public $twigTemplate = 'MapbenderCoreBundle:Template:responsive.html.twig';
+
+    /**
+     * @inheritdoc
+     */
+    static public function listAssets()
+    {
+        return array(
+            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
+            'js'  => array(
+                '/components/underscore/underscore-min.js',
+                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                "/components/datatables/media/js/jquery.dataTables.min.js",
+                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                "/components/vis-ui.js/vis-ui.js-built.js",
+                '@MapbenderCoreBundle/Resources/public/js/responsive.js'
+            ),
+
+            'trans' => array()
+        );
+    }
 
     /**
      * @inheritdoc

--- a/src/Mapbender/CoreBundle/Template/Responsive.php
+++ b/src/Mapbender/CoreBundle/Template/Responsive.php
@@ -21,11 +21,13 @@ class Responsive extends Template
             'sidepane' => array(
                 'tabs' => array(
                     'name' => 'tabs',
-                    'label' => 'mb.manager.template.region.tabs.label'),
+                    'label' => 'mb.manager.template.region.tabs.label',
+                ),
                 'accordion' => array(
                     'name' => 'accordion',
-                    'label' => 'mb.manager.template.region.accordion.label')
-            )
+                    'label' => 'mb.manager.template.region.accordion.label',
+                ),
+            ),
         );
     }
 
@@ -40,34 +42,29 @@ class Responsive extends Template
     /**
      * @inheritdoc
      */
-    static public function listAssets()
-    {
-        $assets = array(
-            'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss'),
-            'js'    => array(
-                '/components/underscore/underscore-min.js',
-                '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
-                '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
-                '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
-                "/components/datatables/media/js/jquery.dataTables.min.js",
-                '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-                "/components/vis-ui.js/vis-ui.js-built.js",
-                '@MapbenderCoreBundle/Resources/public/js/responsive.js'
-            ),
-                
-            'trans' => array()
-        );
-        return $assets;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getAssets($type)
     {
-        $assets = $this::listAssets();
-        return $assets[$type];
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/template/responsive.scss',
+                );
+            case 'js':
+                return array(
+                    '/components/underscore/underscore-min.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                    '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js',
+                    '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                    "/components/datatables/media/js/jquery.dataTables.min.js",
+                    '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                    "/components/vis-ui.js/vis-ui.js-built.js",
+                    '@MapbenderCoreBundle/Resources/public/js/responsive.js'
+                );
+            case 'trans':
+            default:
+                return parent::getAssets($type);
+        }
     }
 
     /**
@@ -83,9 +80,13 @@ class Responsive extends Template
      */
     public static function getElementWhitelist()
     {
-        return array('toolbar' => array('Mapbender\CoreBundle\Element\Button',
-                'Mapbender\CoreBundle\Element\AboutDialog'),
-            'content' => array('Mapbender\CoreBundle\Element\ActivityIndicator',
+        return array(
+            'toolbar' => array(
+                'Mapbender\CoreBundle\Element\Button',
+                'Mapbender\CoreBundle\Element\AboutDialog',
+            ),
+            'content' => array(
+                'Mapbender\CoreBundle\Element\ActivityIndicator',
                 'Mapbender\CoreBundle\Element\CoordinatesDisplay',
                 'Mapbender\CoreBundle\Element\Copyright',
                 'Mapbender\CoreBundle\Element\Map',
@@ -100,14 +101,18 @@ class Responsive extends Template
                 'Mapbender\CoreBundle\Element\SimpleSearch',
                 'Mapbender\CoreBundle\Element\Sketch',
                 'Mapbender\CoreBundle\Element\SrsSelector',
-                'Mapbender\CoreBundle\Element\ZoomBar'),
-            'infocontainer' => array('Mapbender\CoreBundle\Element\AboutDialog',
+                'Mapbender\CoreBundle\Element\ZoomBar',
+            ),
+            'infocontainer' => array(
+                'Mapbender\CoreBundle\Element\AboutDialog',
                 'Mapbender\CoreBundle\Element\BaseSourceSwitcher',
                 'Mapbender\CoreBundle\Element\CoordinatesDisplay',
                 'Mapbender\CoreBundle\Element\Copyright',
                 'Mapbender\CoreBundle\Element\ScaleBar',
                 'Mapbender\CoreBundle\Element\ScaleSelector',
-                'Mapbender\CoreBundle\Element\SrsSelector'));
+                'Mapbender\CoreBundle\Element\SrsSelector',
+            ),
+        );
     }
 
     public function getTwigTemplate()

--- a/src/Mapbender/CoreBundle/Template/Responsive.php
+++ b/src/Mapbender/CoreBundle/Template/Responsive.php
@@ -110,23 +110,8 @@ class Responsive extends Template
                 'Mapbender\CoreBundle\Element\SrsSelector'));
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $region_props = $this->application->getEntity()->getNamedRegionProperties();
-        $default_region_props = $this->getRegionsProperties();
-
-        $templating = $this->container->get('templating');
-        return $templating
-                ->render('MapbenderCoreBundle:Template:responsive.html.twig', array(
-                    'html' => $html,
-                    'css' => $css,
-                    'js' => $js,
-                    'application' => $this->application,
-                    'region_props' => $region_props,
-                    'default_region_props' => $default_region_props));
+        return 'MapbenderCoreBundle:Template:responsive.html.twig';
     }
-
 }

--- a/src/Mapbender/ManagerBundle/Template/LoginTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/LoginTemplate.php
@@ -9,8 +9,15 @@ namespace Mapbender\ManagerBundle\Template;
  */
 class LoginTemplate extends ManagerTemplate
 {
-    protected static $translations = array();
-    protected static $css          = array(
-        '@MapbenderManagerBundle/Resources/public/sass/manager/login.scss'
-    );
+    public function getAssets($type)
+    {
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderManagerBundle/Resources/public/sass/manager/login.scss'
+                );
+            default:
+                return parent::getAssets($type);
+        }
+    }
 }

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -11,6 +11,16 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class ManagerTemplate extends Template
 {
+    public static function getTitle()
+    {
+        throw new \RuntimeException("This is never called");
+    }
+
+    public static function getRegions()
+    {
+        throw new \RuntimeException("This is never called");
+    }
+
     public function getAssets($type)
     {
         switch ($type) {

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -24,8 +24,6 @@ class ManagerTemplate extends Template
                     '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',
                     '/components/datatables/media/js/jquery.dataTables.min.js',
                     '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-                    '/components/vis-ui.js/vis-ui.js-built.js',
-                    '/bundles/fosjsrouting/js/router.js',
                     '@MapbenderManagerBundle/Resources/public/js/SymfonyAjaxManager.js',
 
                     '@MapbenderCoreBundle/Resources/public/widgets/mapbender.popup.js',

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -11,38 +11,48 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class ManagerTemplate extends Template
 {
-    protected static $css = array(
-        '@MapbenderManagerBundle/Resources/public/sass/manager/applications.scss',
-    );
-
-    protected static $js = array(
-        '/components/underscore/underscore-min.js',
-        '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',
-        '/components/datatables/media/js/jquery.dataTables.min.js',
-        '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
-        '/components/vis-ui.js/vis-ui.js-built.js',
-        '/bundles/fosjsrouting/js/router.js',
-        '@MapbenderManagerBundle/Resources/public/js/SymfonyAjaxManager.js',
-
-        '@MapbenderCoreBundle/Resources/public/widgets/mapbender.popup.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/checkbox.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/radiobuttonExtended.js',
-        '@FOMCoreBundle/Resources/public/js/components.js',
-        '@FOMCoreBundle/Resources/public/js/widgets/collection.js',
-        '@MapbenderCoreBundle/Resources/public/mapbender.trans.js',
-    );
-
-    protected static $translations = array(
-        '@MapbenderManagerBundle/Resources/views/translations.json.twig'
-    );
-
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getAssets($type)
     {
-        return "";
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderManagerBundle/Resources/public/sass/manager/applications.scss',
+                );
+            case 'js':
+                return array(
+                    '/components/underscore/underscore-min.js',
+                    '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',
+                    '/components/datatables/media/js/jquery.dataTables.min.js',
+                    '/components/jquerydialogextendjs/jquerydialogextendjs-built.js',
+                    '/components/vis-ui.js/vis-ui.js-built.js',
+                    '/bundles/fosjsrouting/js/router.js',
+                    '@MapbenderManagerBundle/Resources/public/js/SymfonyAjaxManager.js',
+
+                    '@MapbenderCoreBundle/Resources/public/widgets/mapbender.popup.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/popup.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/checkbox.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/radiobuttonExtended.js',
+                    '@FOMCoreBundle/Resources/public/js/components.js',
+                    '@FOMCoreBundle/Resources/public/js/widgets/collection.js',
+                    '@MapbenderCoreBundle/Resources/public/mapbender.trans.js',
+                );
+            case 'trans':
+                return array(
+                    '@MapbenderManagerBundle/Resources/views/translations.json.twig',
+                );
+            default:
+                return parent::getAssets($type);
+        }
+    }
+
+    public function getTwigTemplate()
+    {
+        // NOTE: Old versions had an overriden render method that returns an empty string.
+        //       Url path /application/manager itself never functioned
+        //       Actual rendering of the backend is in WelcomeController::listAction, which uses the template
+        //       MapbenderCoreBundle:Welcome:list.html.twig
+        //       Url paths /application/manager/assets/js et al
+        throw new \RuntimeException("ManagerTemplate does not support standard rendering, only provides asset dependencies");
     }
 }

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -2,25 +2,22 @@
 
 namespace Mapbender\ManagerBundle\Template;
 
-use Mapbender\CoreBundle\Component\Template;
+use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateAssetDependencyInterface;
 
 /**
- * Application manager template
+ * Not an application template.
  *
- * @copyright 03.02.2015 by WhereGroup GmbH & Co. KG
+ * The actual twigs used to render the backend pages vary signficantly by controller action.
+ *
+ * The only commonality of the manager application is that it uses the same mechanism as proper
+ * application templates to declare and generate its required assets. See (currently in FOM):
+ * https://github.com/mapbender/fom/blob/v3.0.6.2/src/FOM/ManagerBundle/Resources/views/manager.html.twig#L8
  */
-class ManagerTemplate extends Template
+class ManagerTemplate implements IApplicationTemplateAssetDependencyInterface
 {
-    public static function getTitle()
-    {
-        throw new \RuntimeException("This is never called");
-    }
-
-    public static function getRegions()
-    {
-        throw new \RuntimeException("This is never called");
-    }
-
+    /**
+     * {@inheritdoc}
+     */
     public function getAssets($type)
     {
         switch ($type) {
@@ -50,17 +47,25 @@ class ManagerTemplate extends Template
                     '@MapbenderManagerBundle/Resources/views/translations.json.twig',
                 );
             default:
-                return parent::getAssets($type);
+                throw new \InvalidArgumentException("Unsupported late asset type " . print_r($type, true));
         }
     }
 
-    public function getTwigTemplate()
+    /**
+     * ManagerTemplate does not use late assets. Required only for compatibility with application assets action.
+     *
+     * @param string $type one of 'css', 'js' or 'trans'
+     * @return string[]
+     */
+    public function getLateAssets($type)
     {
-        // NOTE: Old versions had an overriden render method that returns an empty string.
-        //       Url path /application/manager itself never functioned
-        //       Actual rendering of the backend is in WelcomeController::listAction, which uses the template
-        //       MapbenderCoreBundle:Welcome:list.html.twig
-        //       Url paths /application/manager/assets/js et al
-        throw new \RuntimeException("ManagerTemplate does not support standard rendering, only provides asset dependencies");
+        switch ($type) {
+            case 'js':
+            case 'css':
+            case 'trans':
+                return array();
+            default:
+                throw new \InvalidArgumentException("Unsupported late asset type " . print_r($type, true));
+        }
     }
 }

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -5,11 +5,16 @@ namespace Mapbender\ManagerBundle\Template;
 use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateAssetDependencyInterface;
 
 /**
- * Not an application template.
+ * Not an application template. Models (only) the common asset dependencies of backend sections.
  *
  * The actual twigs used to render the backend pages vary signficantly by controller action.
+ * Manager template has no regions, no region properties and no title, and thus cannot be popuplated with
+ * Elements and cannot be assigned to an Application manually.
  *
- * The only commonality of the manager application is that it uses the same mechanism as proper
+ * ManagerTemplate is assigned fixed to the magic 'manager' application via predefined YAML magic. See
+ * https://github.com/mapbender/mapbender/blob/HEAD/src/Mapbender/CoreBundle/Resources/config/mapbender.yml#L4
+ *
+ * The only similarity with regular Application templates is that ManagerTemplate uses the same mechanism as proper
  * application templates to declare and generate its required assets. See (currently in FOM):
  * https://github.com/mapbender/fom/blob/v3.0.6.2/src/FOM/ManagerBundle/Resources/views/manager.html.twig#L8
  */

--- a/src/Mapbender/MobileBundle/Template/Mobile.php
+++ b/src/Mapbender/MobileBundle/Template/Mobile.php
@@ -1,7 +1,6 @@
 <?php
 namespace Mapbender\MobileBundle\Template;
 
-use Mapbender\CoreBundle\Component\Application;
 use Mapbender\CoreBundle\Component\Template;
 
 /**
@@ -12,9 +11,6 @@ class Mobile extends Template
 {
     /** @var string Application title */
     protected static $title = 'Mapbender Mobile template';
-
-    /** @var string Application TWIG template path */
-    protected $twigTemplate = 'MapbenderMobileBundle:Template:mobile.html.twig';
 
     /** @var array Late assets */
     protected $lateAssets = array(
@@ -36,19 +32,8 @@ class Mobile extends Template
     /**  @var array Region names */
     protected static $regions = array('footer', 'content', 'mobilePane');
 
-    /**
-     * @inheritdoc
-     */
-    public function render($format = 'html', $html = true, $css = true, $js = true)
+    public function getTwigTemplate()
     {
-        $templateEngine = $this->container->get('templating');
-        return $templateEngine->render($this->twigTemplate, array(
-                'html'        => $html,
-                'css'         => $css,
-                'js'          => $js,
-                'application' => $this->application,
-                'uploads_dir' => Application::getAppWebDir($this->container, $this->application->getSlug())
-            )
-        );
+        return 'MapbenderMobileBundle:Template:mobile.html.twig';
     }
 }

--- a/src/Mapbender/MobileBundle/Template/Mobile.php
+++ b/src/Mapbender/MobileBundle/Template/Mobile.php
@@ -9,28 +9,47 @@ use Mapbender\CoreBundle\Component\Template;
  */
 class Mobile extends Template
 {
-    /** @var string Application title */
-    protected static $title = 'Mapbender Mobile template';
+    public static function getTitle()
+    {
+        return 'Mapbender Mobile template';
+    }
 
-    /** @var array Late assets */
-    protected $lateAssets = array(
-        'js'    => array(),
-        'css'   => array(
-            '@MapbenderMobileBundle/Resources/public/sass/theme/mobile.scss'
-        ),
-        'trans' => array(),
-    );
+    public static function getRegions()
+    {
+        return array(
+            'footer',
+            'content',
+            'mobilePane',
+        );
+    }
 
-    protected static $js  = array(
-        '/components/underscore/underscore-min.js',
-        '@MapbenderMobileBundle/Resources/public/js/mapbender.mobile.js',
-        '@MapbenderMobileBundle/Resources/public/js/vendors/jquery.mobile.custom.min.js',
-        '@MapbenderMobileBundle/Resources/public/js/mobile.js',
-        '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js'
-    );
+    public function getLateAssets($type)
+    {
+        switch ($type) {
+            case 'css':
+                return array(
+                    '@MapbenderMobileBundle/Resources/public/sass/theme/mobile.scss',
+                );
+            default:
+                return parent::getLateAssets($type);
+        }
+    }
 
-    /**  @var array Region names */
-    protected static $regions = array('footer', 'content', 'mobilePane');
+    public function getAssets($type)
+    {
+        switch ($type) {
+            case 'js':
+                return array(
+                    '/components/underscore/underscore-min.js',
+                    '@MapbenderMobileBundle/Resources/public/js/mapbender.mobile.js',
+                    '@MapbenderMobileBundle/Resources/public/js/vendors/jquery.mobile.custom.min.js',
+                    '@MapbenderMobileBundle/Resources/public/js/mobile.js',
+                    '@MapbenderCoreBundle/Resources/public/regional/vendor/notify.0.3.2.min.js',
+                );
+            default:
+                return parent::getAssets($type);
+        }
+    }
 
     public function getTwigTemplate()
     {


### PR DESCRIPTION
Reverts a bunch of "Refactor and improve" that ended up turning the Template classes into [a mess of self-modifying static attributes](https://github.com/mapbender/mapbender/blob/v3.0.7.7/src/Mapbender/CoreBundle/Component/Template.php#L224).

The methods getAssets, getTitle are the only ones that are ever called on a Template from the outside. This has been true since years before the "refactor and improve" period, and still remains true.

Doing this with methods allows standard inheritance. An inheriting template's getAssets('js') could simply do
```php
return array_merge(parent::getAssets('js'), array(
   'something-extra.js',
));
```
This would just work, enabling independent maintenance on the base class asset dependencies without side effects in a customized project Template.

Static properties can't do this.  
Placing placeholder fallback logic at the abstract Template level prevents language-level enforcement of the API, because every bit involved in this must have a non-abstract implementation, as we see with the current code.   
Self-modification through the hierarchy to circumvent limitations of static properties is a dirty hack working around the initial dirty hack.

We are already heavily impeded in our ability to remove obsolete libraries or replace them with newer versions, and the way Template currently works multiplies this issue across projects on the most fundamental level of project is customization.

This pull looks like a straightforward change only affecting the Template hierarchy itself, because that's exactly what it is.

Unfortunately, this has very real compatibility impact on customized project-level Template children implemented in the "refactor and improve" fashion. The `listAssets` method, and nearly all the static properties, lose their meaning. The template will silently not do anything.

No solution has been found to remain backwards-compatible with "refactor and improve"-style custom Template classes that would not, again, require new built-in magic, hacks and workarounds.
