### PR TITLE
Fix geodesic measurements in line / area ruler

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
@@ -65,7 +65,7 @@
                 },
                 persist: this.options.persist,
                 immediate: immediate,
-                geodesic: this._isGeodesic()
+                geodesic: true
             });
 
             this.control.events.on({
@@ -98,7 +98,6 @@
             var self = this,
                     olMap = this.map.data('mapQuery').olMap;
             olMap.addControl(this.control);
-            this.control.geodesic = this._isGeodesic();
             this.control.activate();
 
             this._reset();
@@ -148,15 +147,8 @@
             this.popup = null;
             this.callback ? this.callback.call() : this.callback = null;
         },
-        _isGeodesic: function(){
-            var mapProj = this.map.data('mapQuery').olMap.getProjectionObject();
-            return mapProj.proj.units === 'degrees' || mapProj.proj.units === 'dd';
-        },
         _mapSrsChanged: function(event, srs){
-            if (this.control.active) { // change geodesic if a control is active
-                this.control.geodesic = this._isGeodesic();
-                this.control.deactivate();
-                this.control.activate();
+            if (this.control) {
                 this._reset();
             }
         },


### PR DESCRIPTION
Removes all detection, redetection (on SrsSwitcher interaction) and handling of geodesic vs non-geodesic CRS from Ruler, which makes measurements equal across both CRS families.

The trick here is that [OpenLayers.Control.Measure's geodesic property](https://github.com/openlayers/ol2/blob/master/lib/OpenLayers/Control/Measure.js#L58) works just fine in a non-geodesic CRS.

This change fixes #1026.
