### PR TITLE
Change Twig url function to path for compability with reverse proxy installations

### DIFF
--- a/src/Mapbender/KmlBundle/Resources/views/Element/kmlexport.html.twig
+++ b/src/Mapbender/KmlBundle/Resources/views/Element/kmlexport.html.twig
@@ -1,2 +1,2 @@
-<form id="{{ id }}" class="mb-element mb-element-kmlexport" action="{{ url('mapbender_core_application_element', { 'slug': app.request.get('slug'), 'id': id, 'action': 'mapexport' } ) }}" method="post" target="_blank">
+<form id="{{ id }}" class="mb-element mb-element-kmlexport" action="{{ path('mapbender_core_application_element', { 'slug': app.request.get('slug'), 'id': id, 'action': 'mapexport' } ) }}" method="post" target="_blank">
 </form>

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/actions.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/actions.html.twig
@@ -2,7 +2,7 @@
     {% set actions = {
         'create': {
             'display': create_permission,
-            'url': url('mapbender_manager_application_new'),
+            'url': path('mapbender_manager_application_new'),
             'title': 'mb.manager.admin.application.new.title',
             'attr': {
                 'class': 'iconAdd iconBig right'

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/delete.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/delete.html.twig
@@ -19,7 +19,7 @@
     <footer>
         <div class="btn-group">
             <input type="submit" value="{{ 'mb.manager.admin.element.btn.delete' | trans }}" class="btn btn-danger"/>
-            <a href="{{ url('mapbender_manager_application_edit', {'slug': app.request.get('slug')}) }}#elements" class="btn">{{ 'mb.manager.admin.element.btn.cancel' | trans}}</a>
+            <a href="{{ path('mapbender_manager_application_edit', {'slug': app.request.get('slug')}) }}#elements" class="btn">{{ 'mb.manager.admin.element.btn.cancel' | trans}}</a>
         </div>
     </footer>
 </form>

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/confirmdelete.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/confirmdelete.html.twig
@@ -1,3 +1,3 @@
-<form method="POST" action="{{ url( "mapbender_manager_repository_delete",{"sourceId": source.id}) }}" >
+<form method="POST" action="{{ path( "mapbender_manager_repository_delete",{"sourceId": source.id}) }}" >
     <input type="hidden" name="sourceId" value="{{source.id}}"  />
 </form>

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/index.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/index.html.twig
@@ -13,7 +13,7 @@
 
 {% block manager_content %}
 {% if create_permission %}
-<a class="iconAdd iconBig right" href="{{ url("mapbender_manager_repository_new") }}" title="{{ 'mb.manager.admin.source.add' | trans }}"></a>
+<a class="iconAdd iconBig right" href="{{ path("mapbender_manager_repository_new") }}" title="{{ 'mb.manager.admin.source.add' | trans }}"></a>
 {% endif %}
 {% if sources|length > 0 %}
   <label for="inputFilterServices" class="labelInput left">{{"mb.manager.admin.filter.source"|trans}}</label><input id="inputFilterServices" type="text" class="input listFilterInput">
@@ -31,17 +31,17 @@
             {% endif %}
         </div>
         <div class="col2 box">
-          <a href="{{ url("mapbender_manager_repository_view",{"sourceId":source.id}) }}" class="title">{{ source.title }}<span class="smallerText"> {{ source.alias }}</span></a>
+          <a href="{{ path("mapbender_manager_repository_view",{"sourceId":source.id}) }}" class="title">{{ source.title }}<span class="smallerText"> {{ source.alias }}</span></a>
           <div class="description">{{ source.description }}</div>
           <div class="buttonGroup">
-            <a class="iconView iconBig" href="{{ url("mapbender_manager_repository_view",{"sourceId":source.id}) }}" title="{{ 'mb.manager.admin.source.show_metadata' | trans }}"></a>
+            <a class="iconView iconBig" href="{{ path("mapbender_manager_repository_view",{"sourceId":source.id}) }}" title="{{ 'mb.manager.admin.source.show_metadata' | trans }}"></a>
             {% if is_granted('EDIT', oid) or is_granted('EDIT', source) %}
-            <a class="iconReset iconBig" href="{{ url("mapbender_manager_repository_updateform",{"sourceId":source.id}) }}" title="{{ 'mb.manager.admin.source.update' | trans }} {{ source.title }}"></a>
+            <a class="iconReset iconBig" href="{{ path("mapbender_manager_repository_updateform",{"sourceId":source.id}) }}" title="{{ 'mb.manager.admin.source.update' | trans }} {{ source.title }}"></a>
             {% endif %}
             {% if is_granted('DELETE', oid) or is_granted('DELETE', source) %}
                <span class="iconRemove iconBig"
                 title="{{"mb.manager.admin.source.delete"|trans}} {{ source.title }}"
-                data-url="{{ url("mapbender_manager_repository_confirmdelete",{"sourceId":source.id}) }}"
+                data-url="{{ path("mapbender_manager_repository_confirmdelete",{"sourceId":source.id}) }}"
                 data-id="{{ source.id }}"></span>
             {% endif %}
           </div>

--- a/src/Mapbender/WmcBundle/Resources/views/Element/wmc-list.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Element/wmc-list.html.twig
@@ -1,5 +1,5 @@
 {% if 'listloader' in configuration.components %}
-<a href="{{ url('mapbender_manager_element_select', { 'slug': application.slug, 'region': region }) }}" class="iconAdd iconSmall addElement" title="{{'mb.wmc.list.add_wmc'|trans}} {{region}}"></a>
+<a href="{{ path('mapbender_manager_element_select', { 'slug': application.slug, 'region': region }) }}" class="iconAdd iconSmall addElement" title="{{'mb.wmc.list.add_wmc'|trans}} {{region}}"></a>
 {% endif %}
 {% if 'listloader' in configuration.components %}
 <table class="tableCore">

--- a/src/Mapbender/WmcBundle/Resources/views/Wmc/wmceditor-form.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Wmc/wmceditor-form.html.twig
@@ -1,4 +1,4 @@
-<form id="wmc-save" action="{{ url('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'save'}) }}" method="post" title="{% if form.id.vars.value == '' %}{{ 'mb.wmc.wmceditor.create'|trans}}{% else %}{{ 'mb.wmc.wmceditor.edit'|trans}}{% endif %}">
+<form id="wmc-save" action="{{ path('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'save'}) }}" method="post" title="{% if form.id.vars.value == '' %}{{ 'mb.wmc.wmceditor.create'|trans}}{% else %}{{ 'mb.wmc.wmceditor.edit'|trans}}{% endif %}">
     <div class="elementFormWMC elementForm">
         <div class="left">
             {{ form_widget(form.public) }}<label for="{{form.public.vars.id}}" class="labelCheck">{{"mb.wmc.wmceditor.publish"|trans}}</label>

--- a/src/Mapbender/WmcBundle/Resources/views/Wmc/wmceditor-list.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Wmc/wmceditor-list.html.twig
@@ -5,7 +5,7 @@
             <th>{{ 'mb.wmc.wmceditor.list.title' | trans }}</th>
             <th>{{ 'mb.wmc.wmceditor.list.description' | trans }}</th>
             <th class="iconColumn right" colspan="3">
-                <a href="{{ url('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'get', 'wmcid': '' }) }}" class="icon iconAdd iconSmall addWmc" title="{{'mb.wmc.wmceditor.list.add_wmc'|trans}}"></a>
+                <a href="{{ path('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'get', 'wmcid': '' }) }}" class="icon iconAdd iconSmall addWmc" title="{{'mb.wmc.wmceditor.list.add_wmc'|trans}}"></a>
             </th>
         </tr>
     </thead>
@@ -17,10 +17,10 @@
             <td class="description">{{ wmc.state.title }}</td>
             <td class="description">{{ wmc.abstract }}</td>
             <td class="iconColumn right">
-                <span class="iconRemove iconSmall removeWmc" title="{{"mb.wmc.wmceditor.list.delete_wmc"|trans}} {{wmc.state.title}}" data-id="{{ wmc.id }}" data-slug="{{ application.slug }}" data-url="{{ url('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'confirmdelete', '_id': wmc.id }) }}"></span>
+                <span class="iconRemove iconSmall removeWmc" title="{{"mb.wmc.wmceditor.list.delete_wmc"|trans}} {{wmc.state.title}}" data-id="{{ wmc.id }}" data-slug="{{ application.slug }}" data-url="{{ path('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'confirmdelete', '_id': wmc.id }) }}"></span>
             </td>
             <td class="iconColumn right">
-                <span class="iconEdit iconSmall editWmc" title="{{"mb.wmc.wmceditor.list.edit_wmc"|trans}}  {{wmc.state.title}}" data-url="{{ url('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'get', 'wmcid': wmc.id }) }}"></span>
+                <span class="iconEdit iconSmall editWmc" title="{{"mb.wmc.wmceditor.list.edit_wmc"|trans}}  {{wmc.state.title}}" data-url="{{ path('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'get', 'wmcid': wmc.id }) }}"></span>
             </td>
             <td class="iconColumn right">
                 <div class="checkWrapper iconCheckbox iconSmall {% if wmc.public %}iconCheckboxActive{% endif %}" title="{{"mb.wmc.wmceditor.list.toggle"|trans}} {{wmc.state.title}}">

--- a/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloader-form.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloader-form.html.twig
@@ -1,4 +1,4 @@
-<form id="wmc-load" action="{{ url('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'loadxml'}) }}" method="post" target="_blank" title="Load WMC">
+<form id="wmc-load" action="{{ path('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'loadxml'}) }}" method="post" target="_blank" title="Load WMC">
     <div class="elementFormToolbar elementForm">
         {{ form_widget(form.xml) }}
         <div class="clearContainer"></div>

--- a/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloader-list.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloader-list.html.twig
@@ -1,5 +1,5 @@
 {% if 'wmcxmlloader' in configuration.components %}
-<a href="{{ url('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'loadform' }) }}" class="iconAdd iconSmall loadWmcXml" title="{{'mb.wmc.wmcloader.load_xml_wmc'|trans}}"></a>
+<a href="{{ path('mapbender_core_application_element', { 'slug': application.slug, 'id': id, 'action': 'loadform' }) }}" class="iconAdd iconSmall loadWmcXml" title="{{'mb.wmc.wmcloader.load_xml_wmc'|trans}}"></a>
 {% endif %}
 {% if 'wmclistloader' in configuration.components %}
 <table class="elementsTable tableCore">

--- a/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloaderstate-form.html.twig
+++ b/src/Mapbender/WmcBundle/Resources/views/Wmc/wmcloaderstate-form.html.twig
@@ -1,4 +1,4 @@
-<form id="wmc-state-load" action="{{ url('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'loadxml'}) }}" method="post" target="_blank" title="Load WMC">
+<form id="wmc-state-load" action="{{ path('mapbender_core_application_element', {'slug': app.request.get('slug'), 'id': id, 'action': 'loadxml'}) }}" method="post" target="_blank" title="Load WMC">
     <div class="elementFormToolbar elementForm">
         {{ form_widget(form.state) }}
         <div class="clearContainer"></div>

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance-layer-form.html.twig
@@ -9,7 +9,7 @@
 {% for form_layer in form_layers %}
     {% if form_layer.vars.value.id == layer.id %}
         <tr id="{{ type }}{{ layer.id }}" class="{{ type }} level{{ level }}" data-id="{{ form_layer.vars.value.id }}"{% if layer.parent != null %} data-parent="{{layer.parent.id}}"{% endif %} data-type="{{ type }}"
-            data-href="{{url("mapbender_manager_repository_instancelayerweight", {"slug": slug, "instanceId": instance.id, "instLayerId": form_layer.vars.value.id})}}">
+            data-href="{{path("mapbender_manager_repository_instancelayerweight", {"slug": slug, "instanceId": instance.id, "instLayerId": form_layer.vars.value.id})}}">
             <td class="level{{ level }} itemType {% if type == 'node' or  type == 'root' %}iconFolderActive{% else %}iconLinkButton{% endif %} iconSmall"></td>
             <td class="titleColumn" title="{{ "mb.wms.wmsloader.repo.instancelayerform.label.layerstitle"|trans }}">{{ form_widget(form_layer.title) }}</td>
 


### PR DESCRIPTION
If you use Mapbender behind a reverse proxy url-funciton will generate links to the internal server no to the reverse proxy.