### PR TITLE
Fix broken applications with undefined click configuration

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/button.html.twig
@@ -1,4 +1,4 @@
-{% if configuration.click %}
+{% if configuration.click is defined and configuration.click  %}
   <a id="{{ id }}" target="_blank" class="mb-button" href="{{ configuration.click }}" title="{{ configuration.tooltip|default(title)|trans }}"><span class="{% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</span></a>
 {% else  %}
   <span id="{{ id }}" data-group="{{ configuration.group }}" title="{{ configuration.tooltip|default(title)|trans }}" class="mb-button {% if configuration.icon is defined %} iconBig {{ configuration.icon }}{% endif %}">{% if configuration.label %}{{ title|trans }}{% endif %}</span>


### PR DESCRIPTION
In twig "if(variable)" only checks if the value has a non null value but throws an error if the variable is not present, so we need to check this first.