### PR TITLE
Enh/print layer visibility forward resolution

### DIFF
--- a/src/Mapbender/PrintBundle/Component/Export/ExportCanvas.php
+++ b/src/Mapbender/PrintBundle/Component/Export/ExportCanvas.php
@@ -10,15 +10,19 @@ class ExportCanvas extends GdCanvas
 {
     /** @var FeatureTransform */
     public $featureTransform;
+    /** @var int */
+    public $physicalDpi;
 
     /**
      * @param number $width
      * @param number $height
      * @param FeatureTransform $featureTransform
+     * @param int|null $physicalDpi
      */
-    public function __construct($width, $height, $featureTransform)
+    public function __construct($width, $height, $featureTransform, $physicalDpi = null)
     {
         parent::__construct($width, $height);
         $this->featureTransform = $featureTransform;
+        $this->physicalDpi = intval($physicalDpi ?: 72);
     }
 }

--- a/src/Mapbender/PrintBundle/Component/ImageExportService.php
+++ b/src/Mapbender/PrintBundle/Component/ImageExportService.php
@@ -154,8 +154,9 @@ class ImageExportService
      */
     protected function canvasFactory($jobData)
     {
+        $dpi = ArrayUtil::getDefault($jobData, 'quality', null);
         $featureTransform = $this->initializeFeatureTransform($jobData);
-        return new ExportCanvas($jobData['width'], $jobData['height'], $featureTransform);
+        return new ExportCanvas($jobData['width'], $jobData['height'], $featureTransform, $dpi);
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/LayerRendererWms.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererWms.php
@@ -162,7 +162,7 @@ class LayerRendererWms extends LayerRenderer
 
     /**
      * @param $layerDef
-     * @param GdCanvas $canvas
+     * @param ExportCanvas $canvas
      * @param Box $extent
      * @return string
      */
@@ -197,7 +197,7 @@ class LayerRendererWms extends LayerRenderer
     /**
      * @param mixed[] $params
      * @param mixed[] $layerDef
-     * @param BaseCanvas $canvas
+     * @param ExportCanvas $canvas
      * @param Box $extent
      * @return mixed[] params array with potentially updated WIDTH and HEIGHT
      */
@@ -214,6 +214,9 @@ class LayerRendererWms extends LayerRenderer
         if ($targetResV != $resolution->getVertical()) {
             $params['HEIGHT'] = intval(max(16, abs($extent->getHeight()) / $targetResV));
         }
+
+        $symbolResolution = max(36, min(576, intval($params['WIDTH'] / $canvas->getWidth() * $canvas->physicalDpi)));
+        $params['map_resolution'] = $symbolResolution;
         return $params;
     }
 

--- a/src/Mapbender/PrintBundle/Element/PrintClient.php
+++ b/src/Mapbender/PrintBundle/Element/PrintClient.php
@@ -312,13 +312,7 @@ class PrintClient extends Element
         foreach ($data['layers'] as $ix => $layerDef) {
             if (!empty($layerDef['url'])) {
                 $updatedUrl = $urlProcessor->getInternalUrl($layerDef['url']);
-                if (!isset($configuration['replace_pattern'])) {
-                    if ($data['quality'] != 72) {
-                        $updatedUrl = UrlUtil::validateUrl($updatedUrl, array(
-                            'map_resolution' => $data['quality'],
-                        ));
-                    }
-                } else {
+                if (!empty($configuration['replace_pattern'])) {
                     $updatedUrl = $this->addReplacePattern($updatedUrl, $configuration['replace_pattern'], $data['quality']);
                 }
                 $data['layers'][$ix]['url'] = $updatedUrl;

--- a/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
@@ -253,41 +253,25 @@
         _collectLegends: function() {
             var legends = [];
             var scale = this._getPrintScale();
-            function _getLegends(layer) {
-                var legend = {};
-                if (!layer.options.treeOptions.selected) {
-                    return false;
-                }
-                if (layer.children) {
-                    var childrenActive = false;
-                    for (var i = 0; i < layer.children.length; i++) {
-                        var childLegends = _getLegends(layer.children[i]);
-                        if (childLegends !== false) {
-                            _.assign(legend, childLegends);
-                            childrenActive = true;
-                        }
-                    }
-                    if (!childrenActive) {
-                        return false;
-                    }
-                }
-                // Only include the legend for a "group" / non-leaf layer if we haven't collected any
-                // legend images from leaf layers yet, but at least one leaf layer is actually active
-                if (!Object.keys(legend).length) {
-                    if (layer.options.legend && layer.options.legend.url && layer.options.treeOptions.selected) {
-                        legend[layer.options.title] = layer.options.legend.url;
-                    }
-                }
-                return legend;
-            }
             var sources = this._getRasterSourceDefs();
             for (var i = 0; i < sources.length; ++i) {
                 var source = sources[i];
-                if (source.type === 'wms' && this._getRasterVisibilityInfo(source, scale).layers.length) {
-                    var ll = _getLegends(sources[i].configuration.children[0]);
-                    if (ll && Object.keys(ll).length) {
-                        legends = legends.concat(ll);
+                var gsHandler = this.map.model.getGeoSourceHandler(source);
+                var leafInfo = gsHandler.getExtendedLeafInfo(source, scale, this._getExportExtent());
+                var sourceLegendMap = {};
+                _.forEach(leafInfo, function(activeLeaf) {
+                    if (activeLeaf.state.visibility) {
+                        for (var p = -1; p < activeLeaf.parents.length; ++p) {
+                            var legendLayer = (p < 0) ? activeLeaf.layer : activeLeaf.parents[p];
+                            if (legendLayer.options.legend && legendLayer.options.legend.url) {
+                                sourceLegendMap[legendLayer.options.title] = legendLayer.options.legend.url;
+                                break;
+                            }
+                        }
                     }
+                });
+                if (Object.keys(sourceLegendMap).length) {
+                    legends.push(sourceLegendMap);
                 }
             }
             return legends;

--- a/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
@@ -140,28 +140,14 @@
 
             for (var i = 0; i < sources.length; i++) {
                 var sourceDef = sources[i];
-                var visLayers = this._getRasterVisibilityInfo(sourceDef, scale);
-
-                if (visLayers.layers.length) {
-                    var layer = this.map.model.getNativeLayer(sourceDef);
-                    var prevLayers = layer.params.LAYERS;
-                    var prevStyles = layer.params.STYLES;
-                    if (scale) {
-                        layer.params.LAYERS = visLayers.layers;
-                        layer.params.STYLES = visLayers.styles;
-                    }
-
-                    var layerData = Mapbender.source[sourceDef.type].getPrintConfig(layer, extent);
-                    layerData.opacity = sourceDef.configuration.options.opacity;
-                    // flag to change axis order
-                    layerData.changeAxis = this._changeAxis(layer);
-                    dataOut.push(layerData);
-
-                    if (scale) {
-                        layer.params.LAYERS = prevLayers;
-                        layer.params.STYLES = prevStyles;
-                    }
-                }
+                var olLayer = this.map.model.getNativeLayer(sourceDef);
+                var extra = {
+                    opacity: sourceDef.configuration.options.opacity,
+                    changeAxis: this._changeAxis(olLayer)
+                };
+                _.forEach(this.map.model.getPrintConfigEx(sourceDef, scale, extent), function(printConfig) {
+                    dataOut.push($.extend({}, printConfig, extra));
+                });
             }
             return dataOut;
         },


### PR DESCRIPTION
Uses [new "pretend" layer state calculation machinery](https://github.com/mapbender/mapbender/blob/44a789b2f688fb439602e89a88216b90cb7b0b2e/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js#L382) to extract the appropriate layers for any print scale _without_ side effects on the layer states.

This resolves erratic LayerTree "ghosting" behaviour on certain map interactions immediately following the submission of a print job.

Also switches client-side print job data collection over to an extended format that includes min / max resolution for individual layers.

This additional information allows the image export + print backend to exactly reproduce the layer visibility observed client-side, at any scale without "replacePattern" tricks.  
The determination of which legend images go into the printout is rebased onto the same logic that determines the visible layers at the selected print scale, so these should now be fully in sync under all circumstances.

This change makes "print optimized" WMS services and their assorted collateral issues fully redundant. Any layer that _would_ go out of scale in the print backend at a certain dpi setting is now simply _kept_ in scale, by allowing individual WMS layers to be requested at varying pixel densities before compositing them onto the complete map image.
