### PR TITLE
Enh/improved line pattern quality in export + print

### DIFF
--- a/src/Mapbender/PrintBundle/Component/Geometry/LineLoopIterator.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/LineLoopIterator.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Geometry;
+
+
+class LineLoopIterator extends LineStringIterator
+{
+    public function __construct(array $points)
+    {
+        if (count($points) < 2) {
+            throw new \InvalidArgumentException("Cannot form a loop from " . count($points) . " points");
+        }
+        parent::__construct($points);
+    }
+
+    public function valid()
+    {
+        // unline parent, allow iteration to continue even if lineEndIterator is one past the last point
+        return $this->lineStartIterator->valid();
+    }
+
+    public function current()
+    {
+        if ($this->lineEndIterator->valid()) {
+            return parent::current();
+        } else {
+            // Connect final point back to first point
+            return new LineSegment($this->lineStartIterator->current(), $this->points[0]);
+        }
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Geometry/LineSegment.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/LineSegment.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Mapbender\PrintBundle\Component\Geometry;
+
+
+use Mapbender\PrintBundle\Util\CoordUtil;
+
+class LineSegment
+{
+    /** @var Point2D */
+    protected $from;
+    /** @var Point2D */
+    protected $to;
+
+    /**
+     * @param Point2D $from
+     * @param Point2D $to
+     */
+    public function __construct(Point2D $from, Point2D $to)
+    {
+        $this->from = $from;
+        $this->to = $to;
+    }
+
+    /**
+     * @param float[] $a
+     * @return LineSegment
+     */
+    public static function fromArray(array $a)
+    {
+        if (count($a) < 2) {
+            throw new \InvalidArgumentException("Input array must have at least 2 elements, got " . count($a));
+        }
+        $a = array_values($a);
+        $from = $a[0];
+        $to = $a[1];
+        if (!$from instanceof Point2D) {
+            $from = Point2D::fromArray($from);
+        }
+        if (!$to instanceof Point2D) {
+            $to = Point2D::fromArray($to);
+        }
+        return new static($from, $to);
+    }
+
+    public function toArray()
+    {
+        return array(
+            $this->from->toArray(),
+            $this->to->toArray(),
+        );
+    }
+
+    /**
+     * @return Point2D
+     */
+    public function getStart()
+    {
+        return $this->from;
+    }
+
+    /**
+     * @return Point2D
+     */
+    public function getEnd()
+    {
+        return $this->to;
+    }
+
+    /**
+     * @return float
+     */
+    public function getLength()
+    {
+        return CoordUtil::distance($this->from->toArray(), $this->to->toArray());
+    }
+
+    /**
+     * @param float $ratio in [0;1] for a point on the LineSegment (other values produce points OUTSIDE the LineSegment)
+     * @return Point2D
+     */
+    public function getBisectingPoint($ratio)
+    {
+        $xYArray = CoordUtil::interpolateLinear($this->from->toArray(), $this->to->toArray(), $ratio);
+        return Point2D::fromArray($xYArray);
+    }
+
+    /**
+     * @param float $offset in [0;length] for a point on the LineSegment
+     * @return Point2D
+     */
+    public function getPointAtLenghtOffset($offset)
+    {
+        $ratio = $offset / $this->getLength();
+        return $this->getBisectingPoint($ratio);
+    }
+
+    /**
+     * Generate a new LineSegment using offset points on this LineSegment as start and end.
+     *
+     * @param float $offsetFrom in [0;length] for start points on this LineSegment
+     * @param float $length in [-$offsetFrom;+$offsetFrom] for end points on this LineSegment
+     * @return LineSegment
+     */
+    public function getSlice($offsetFrom, $length)
+    {
+        $length0 = $this->getLength();
+        $ratioFrom = $offsetFrom / $length0;
+        $ratioTo = ($offsetFrom + $length) / $length0;
+        return new static($this->getBisectingPoint($ratioFrom), $this->getBisectingPoint($ratioTo));
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Geometry/LineStringIterator.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/LineStringIterator.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Geometry;
+
+/**
+ * Loops over a number of points and yields LineSegment instances constructed
+ * from adjacent pairs of these points.
+ * "LineString" in this case refers to the non-closed the nature of the yielded LineSegments.
+ * The last point is not connected back to the first by a LineSegment.
+ */
+class LineStringIterator implements \Iterator
+{
+    /** @var Point2D[] */
+    protected $points;
+
+    /** @var \ArrayIterator */
+    protected $lineStartIterator;
+    /** @var \ArrayIterator */
+    protected $lineEndIterator;
+
+    /**
+     * @param array $points elements should be Point2D instances or arrays that can be promoted to Point2D
+     */
+    public function __construct(array $points)
+    {
+        if (count($points) === 1) {
+            throw new \InvalidArgumentException("Cannot form lines from exactly 1 point");
+        }
+        $this->points = array();
+        foreach ($points as $point) {
+            if ($point instanceof Point2D) {
+                $this->points[] = $point;
+            } else {
+                $this->points[] = Point2D::fromArray($point);
+            }
+        }
+        $this->lineStartIterator = new \ArrayIterator($this->points);
+        $this->lineEndIterator = new \ArrayIterator($this->points);
+    }
+
+    public function rewind()
+    {
+        $this->lineStartIterator->rewind();
+        $this->lineEndIterator->rewind();
+        $this->lineEndIterator->next();
+    }
+
+    public function next()
+    {
+        $this->lineStartIterator->next();
+        $this->lineEndIterator->next();
+    }
+
+    public function valid()
+    {
+        return $this->lineStartIterator->valid() && $this->lineEndIterator->valid();
+    }
+
+    /**
+     * @return LineSegment
+     */
+    public function current()
+    {
+        return new LineSegment($this->lineStartIterator->current(), $this->lineEndIterator->current());
+    }
+
+    public function key()
+    {
+        return $this->lineStartIterator->current();
+    }
+}
+

--- a/src/Mapbender/PrintBundle/Component/Geometry/Point2D.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/Point2D.php
@@ -3,7 +3,7 @@
 namespace Mapbender\PrintBundle\Component\Geometry;
 
 
-class Point2D implements \ArrayAccess
+class Point2D extends Tuple
 {
     /** @var float */
     protected $x;
@@ -16,37 +16,10 @@ class Point2D implements \ArrayAccess
      */
     public function __construct($x, $y)
     {
-        $this->x = floatval($x);
-        $this->y = floatval($y);
-    }
-
-    public function offsetExists($offset)
-    {
-        return $offset == 0 || $offset == 'x';
-    }
-
-    public function offsetGet($offset)
-    {
-        switch ($offset) {
-            case '0':
-            case 'x':
-                return $this->x;
-            case 1:
-            case 'y':
-                return $this->y;
-            default:
-                throw new \RuntimeException("No such offset " . print_r($offset, true));
-        }
-    }
-
-    public function offsetSet($offset, $value)
-    {
-        throw new \RuntimeException("Immutable after construction");
-    }
-
-    public function offsetUnset($offset)
-    {
-        throw new \RuntimeException("Immutable after construction");
+        parent::__construct(array(
+            $x,
+            $y,
+        ));
     }
 
     /**
@@ -60,16 +33,5 @@ class Point2D implements \ArrayAccess
         } else {
             return new static($a[0], $a[1]);
         }
-    }
-
-    /**
-     * @return float[]
-     */
-    public function toArray()
-    {
-        return array(
-            $this->x,
-            $this->y,
-        );
     }
 }

--- a/src/Mapbender/PrintBundle/Component/Geometry/Point2D.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/Point2D.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Mapbender\PrintBundle\Component\Geometry;
+
+
+class Point2D implements \ArrayAccess
+{
+    /** @var float */
+    protected $x;
+    /** @var float */
+    protected $y;
+
+    /**
+     * @param float $x
+     * @param float $y
+     */
+    public function __construct($x, $y)
+    {
+        $this->x = floatval($x);
+        $this->y = floatval($y);
+    }
+
+    public function offsetExists($offset)
+    {
+        return $offset == 0 || $offset == 'x';
+    }
+
+    public function offsetGet($offset)
+    {
+        switch ($offset) {
+            case '0':
+            case 'x':
+                return $this->x;
+            case 1:
+            case 'y':
+                return $this->y;
+            default:
+                throw new \RuntimeException("No such offset " . print_r($offset, true));
+        }
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \RuntimeException("Immutable after construction");
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \RuntimeException("Immutable after construction");
+    }
+
+    /**
+     * @param float[] $a
+     * @return Point2D
+     */
+    public static function fromArray(array $a)
+    {
+        if (array_key_exists('x', $a) && array_key_exists('y', $a)) {
+            return new static($a['x'], $a['y']);
+        } else {
+            return new static($a[0], $a[1]);
+        }
+    }
+
+    /**
+     * @return float[]
+     */
+    public function toArray()
+    {
+        return array(
+            $this->x,
+            $this->y,
+        );
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Geometry/Tuple.php
+++ b/src/Mapbender/PrintBundle/Component/Geometry/Tuple.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Geometry;
+
+
+class Tuple
+{
+    /** @var float[] */
+    protected $components;
+
+    /**
+     * @param float[] $components
+     */
+    public function __construct($components)
+    {
+        if (!count($components)) {
+            throw new \InvalidArgumentException("Tuple cannot be 0-dimensional");
+        }
+        $this->components = array_map('\floatval', $components);
+    }
+
+    /**
+     * @param int $index
+     * @return float
+     */
+    public function getComponent($index)
+    {
+        return $this->components[$index];
+    }
+
+    /**
+     * @return int
+     */
+    public function getDimensionality()
+    {
+        return count($this->components);
+    }
+
+    /**
+     * @return float[]
+     */
+    public function toArray()
+    {
+        return $this->components;
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -7,9 +7,7 @@ use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\PrintBundle\Component\Export\Box;
 use Mapbender\PrintBundle\Component\Export\ExportCanvas;
 use Mapbender\PrintBundle\Component\Geometry\LineLoopIterator;
-use Mapbender\PrintBundle\Component\Geometry\LineSegment;
 use Mapbender\PrintBundle\Component\Geometry\LineStringIterator;
-use Mapbender\PrintBundle\Util\CoordUtil;
 use Mapbender\Utils\InfiniteCyclicArrayIterator;
 
 /**
@@ -640,6 +638,7 @@ class LayerRendererGeoJson extends LayerRenderer
                         //       We end-cap the lines with circles to give them a more pleasant appearance.
                         //       This also has the very nice side benefit of putting a circle on every vertex joint,
                         //       rounding out those edges, too.
+                        // @todo: suppress the intermittent point at very obtuse vertex angles to reduce noise
                         $dots[] = $drawSegment->getStart()->toArray();
                         $dots[] = $drawSegment->getEnd()->toArray();
                         break;

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -391,7 +391,6 @@ class LayerRendererGeoJson extends LayerRenderer
 
         $pixelThickness = $style['strokeWidth'] * $lineScale;
         $intThickness = max(1, intval(round($pixelThickness)));
-        imagesetthickness($subRegion->resource, $intThickness);
         $opacity = $style['strokeOpacity'];
         if ($pixelThickness < 1) {
             $opacity = max(0.0, $opacity * $pixelThickness);
@@ -408,6 +407,7 @@ class LayerRendererGeoJson extends LayerRenderer
                 $this->renderPatternFragments($subRegion, $patternFragments, $lineColor, $intThickness);
             }
         } else {
+            imagesetthickness($subRegion->resource, $intThickness);
             foreach ($coordSets as $lineCoords) {
                 if ($close) {
                     $subRegion->drawPolygonOutline($lineCoords, $lineColor);
@@ -603,7 +603,7 @@ class LayerRendererGeoJson extends LayerRenderer
         if ($closeLoop) {
             $lineCoords[] = $lineCoords[count($lineCoords) - 1];
         }
-        $descriptors = $this->getPatternDescriptors('longdashdot');
+        $descriptors = $this->getPatternDescriptors($patternName);
         $descriptorIndex = 0;
         $descriptorLengthLeft = $descriptors[0]['length'];
 
@@ -684,8 +684,18 @@ class LayerRendererGeoJson extends LayerRenderer
         );
     }
 
+    /**
+     * Render individual dot and line primitives.
+     * @see generatePatternFragments
+     *
+     * @param GdCanvas $canvas
+     * @param array $fragments
+     * @param int $color GDish
+     * @param int $thickness used for both line thickness and dot diameter
+     */
     protected function renderPatternFragments(GdCanvas $canvas, $fragments, $color, $thickness)
     {
+        imagesetthickness($canvas->resource, $thickness);
         foreach ($fragments['dots'] as $dot) {
             $canvas->drawFilledCircle($dot[0], $dot[1], $color, $thickness);
         }

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -263,7 +263,6 @@ class LayerRendererGeoJson extends LayerRenderer
         }
 
         $diameter = max(1, round(2 * $style['pointRadius'] * $resizeFactor));
-        // Filled circle
         if ($style['fillOpacity'] > 0) {
             $color = $this->getColor(
                 $style['fillColor'],
@@ -302,10 +301,10 @@ class LayerRendererGeoJson extends LayerRenderer
 
         $innerDiameter = intval(round(2 * ($radius - 0.5 * $width)));
         $outerDiameter = intval(round(2 * ($radius + 0.5 * $width)));
-        $tempCanvas->drawFilledCircle($offsetXy, $offsetXy, $color, $outerDiameter);
+        $tempCanvas->drawFilledCircle($centerX, $centerY, $color, $outerDiameter);
         if ($innerDiameter > 0) {
             // stamp out a fully transparent circle
-            $tempCanvas->drawFilledCircle($offsetXy, $offsetXy, $transparent, $innerDiameter);
+            $tempCanvas->drawFilledCircle($centerX, $centerY, $transparent, $innerDiameter);
         }
         $tempCanvas->mergeBack();
     }

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -6,7 +6,9 @@ namespace Mapbender\PrintBundle\Component;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\PrintBundle\Component\Export\Box;
 use Mapbender\PrintBundle\Component\Export\ExportCanvas;
+use Mapbender\PrintBundle\Component\Geometry\LineLoopIterator;
 use Mapbender\PrintBundle\Component\Geometry\LineSegment;
+use Mapbender\PrintBundle\Component\Geometry\LineStringIterator;
 use Mapbender\PrintBundle\Util\CoordUtil;
 use Mapbender\Utils\InfiniteCyclicArrayIterator;
 
@@ -603,7 +605,9 @@ class LayerRendererGeoJson extends LayerRenderer
         $lines = array();
         $lineCoords = array_values($lineCoords);
         if ($closeLoop) {
-            $lineCoords[] = $lineCoords[count($lineCoords) - 1];
+            $segmentIterator = new LineLoopIterator($lineCoords);
+        } else {
+            $segmentIterator = new LineStringIterator($lineCoords);
         }
 
         $descriptors = $this->getPatternDescriptors($patternName);
@@ -611,9 +615,7 @@ class LayerRendererGeoJson extends LayerRenderer
         $currentDescriptor = $descriptorIterator->current();
         $descriptorLengthLeft = $currentDescriptor['length'];
 
-        foreach (array_slice(array_keys($lineCoords), 1) as $lcIndex) {
-            $lineSegment = LineSegment::fromArray(array_slice($lineCoords, $lcIndex - 1, 2));
-
+        foreach ($segmentIterator as $lineSegment) {
             $segmentLength = $lineSegment->getLength();
             $segmentLengthLeft = $segmentLength;
             $nextFragmentStart = 0;

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -396,22 +396,27 @@ class LayerRendererGeoJson extends LayerRenderer
         if ($pixelThickness < 1) {
             $opacity = max(0.0, $opacity * $pixelThickness);
         }
+        $patternName = $style['strokeDashstyle'];
         $lineColor = $this->getColor($style['strokeColor'], $opacity, $subRegion->resource);
-        if ($style['strokeDashstyle'] !== 'solid') {
-            $strokeStyleArray = $this->getStrokeStyle($lineColor, $pixelThickness, $style['strokeDashstyle'], $lineScale);
-            imagesetstyle($subRegion->resource, $strokeStyleArray);
-            $gdColor = IMG_COLOR_STYLED;
+        if ($intThickness > 5 || $patternName !== 'solid') {
+            // Native gd rendering doesn't do patterns well, and starts looking bad for solid lines above
+            // certain thickness.
+            // Generate, under great pain, a bunch of rendering primitives that form the line pattern when
+            // combined.
+            foreach ($coordSets as $lineCoords) {
+                $patternFragments = $this->generatePatternFragments($patternName, $lineCoords, $lineScale, $close);
+                $this->renderPatternFragments($subRegion, $patternFragments, $lineColor, $intThickness);
+            }
         } else {
-            $gdColor = $lineColor;
-        }
-
-        foreach ($coordSets as $lineCoords) {
-            if ($close) {
-                $subRegion->drawPolygonOutline($lineCoords, $gdColor);
-            } else {
-                $subRegion->drawLineString($lineCoords, $gdColor);
+            foreach ($coordSets as $lineCoords) {
+                if ($close) {
+                    $subRegion->drawPolygonOutline($lineCoords, $lineColor);
+                } else {
+                    $subRegion->drawLineString($lineCoords, $lineColor);
+                }
             }
         }
+
         $subRegion->mergeBack();
     }
 
@@ -527,5 +532,165 @@ class LayerRendererGeoJson extends LayerRenderer
         $height = intval(max(1, min($height, $canvas->getHeight() - $offsetY)));
 
         return $canvas->getSubRegion($offsetX, $offsetY, $width, $height);
+    }
+
+    protected function getPatternDescriptors($patternName)
+    {
+        $dot = array(
+            'type' => 'dot',
+            'length' => 0,
+        );
+        $gap = array(
+            'type' => 'gap',
+            'length' => 45,
+        );
+        $dash = array(
+            'type' => 'draw',
+            'length' => 45,
+        );
+        $longDash = array(
+            'type' => 'draw',
+            'length' => 85,
+        );
+        $infiniteDraw = array(
+            'type' => 'draw',
+            'length' => null,
+        );
+        switch ($patternName) {
+            case 'solid' :
+                return array(
+                    $infiniteDraw,
+                );
+            case 'dot' :
+                return array(
+                    $dot,
+                    $gap,
+                );
+            case 'dash' :
+                return array(
+                    $dash,
+                    $gap,
+                );
+            case 'dashdot' :
+                return array(
+                    $dash,
+                    $gap,
+                    $dot,
+                    $gap,
+                );
+            case 'longdash' :
+                return array(
+                    $longDash,
+                    $gap,
+                );
+            case 'longdashdot':
+                return array(
+                    $longDash,
+                    $gap,
+                    $dot,
+                    $gap,
+                );
+            default:
+                throw new \InvalidArgumentException("Unsupported pattern name " . print_r($patternName, true));
+        }
+    }
+
+    protected function generatePatternFragments($patternName, $lineCoords, $patternScale, $closeLoop)
+    {
+        $dots = array();
+        $lines = array();
+        $lineCoords = array_values($lineCoords);
+        if ($closeLoop) {
+            $lineCoords[] = $lineCoords[count($lineCoords) - 1];
+        }
+        $descriptors = $this->getPatternDescriptors('longdashdot');
+        $descriptorIndex = 0;
+        $descriptorLengthLeft = $descriptors[0]['length'];
+
+        $interpolateCoord = function($from, $to, $length, $delta) {
+            // @todo: respect angle instead of interpolation both directions linearly
+            return array(
+                $from[0] + ($to[0] - $from[0]) * $delta / $length,
+                $from[1] + ($to[1] - $from[1]) * $delta / $length,
+            );
+        };
+
+        foreach (array_slice(array_keys($lineCoords), 1) as $lcIndex) {
+            $from = $lineCoords[$lcIndex - 1];
+            $to = $lineCoords[$lcIndex];
+
+            $deltaX = $to[0] - $from[0];
+            $deltaY = $to[1] - $from[1];
+            $segmentLength = sqrt($deltaX * $deltaX + $deltaY * $deltaY);
+            $segmentLengthLeft = sqrt($deltaX * $deltaX + $deltaY * $deltaY);
+            $nextFragmentStart = 0;
+            while ($segmentLengthLeft > 0) {
+                if ($descriptorLengthLeft !== null) {
+                    $takenSegmentLength = min($segmentLengthLeft, $descriptorLengthLeft * $patternScale);
+                    $takenDescriptorLength = $takenSegmentLength / $patternScale;
+                } else {
+                    $takenSegmentLength = $segmentLengthLeft;
+                    $takenDescriptorLength = null;
+                }
+                switch ($descriptors[$descriptorIndex]['type']) {
+                    case 'dot':
+                        $dots[] = $interpolateCoord($from, $to, $segmentLength, $nextFragmentStart);
+                        break;
+                    case 'draw':
+                        // Produce an end-cappend line segment
+                        $startPoint = $interpolateCoord($from, $to, $segmentLength, $nextFragmentStart);
+                        $endPoint = $interpolateCoord($from, $to, $segmentLength, $nextFragmentStart + $takenSegmentLength);
+                        $lines[] = array(
+                            $startPoint,
+                            $endPoint,
+                        );
+                        // NOTE: gd lines with any thickness > 1 will have their edges rendered 'perfectly' vertically
+                        //       or horizontally, with no angles.
+                        //       We end-cap the lines with circles to give them a more pleasant appearance.
+                        //       This also has the very nice side benefit of putting a circle on every vertex joint,
+                        //       rounding out those edges, too.
+                        $dots[] = $startPoint;
+                        $dots[] = $endPoint;
+                        break;
+                    default:
+                    case 'gap':
+                        // nothing to do
+                        break;
+                }
+                if ($takenDescriptorLength !== null && $descriptorLengthLeft !== null) {
+                    $descriptorLengthLeft -= $takenDescriptorLength;
+                    if ($descriptorLengthLeft <= 0) {
+                        // cycle to next pattern descriptor or loop around
+                        ++$descriptorIndex;
+                        if ($descriptorIndex >= count($descriptors)) {
+                            $descriptorIndex = 0;
+                        }
+                        $nextDescriptorLength = $descriptors[$descriptorIndex]['length'];
+                        if ($nextDescriptorLength === null) {
+                            $descriptorLengthLeft = null;
+                            break;
+                        } else {
+                            $descriptorLengthLeft += $nextDescriptorLength;
+                        }
+                    }
+                }
+                $segmentLengthLeft -= $takenSegmentLength;
+                $nextFragmentStart += $takenSegmentLength;
+            }
+        }
+        return array(
+            'dots' => $dots,
+            'lines' => $lines,
+        );
+    }
+
+    protected function renderPatternFragments(GdCanvas $canvas, $fragments, $color, $thickness)
+    {
+        foreach ($fragments['dots'] as $dot) {
+            $canvas->drawFilledCircle($dot[0], $dot[1], $color, $thickness);
+        }
+        foreach ($fragments['lines'] as $line) {
+            $canvas->drawLineString($line, $color);
+        }
     }
 }

--- a/src/Mapbender/PrintBundle/Util/CoordUtil.php
+++ b/src/Mapbender/PrintBundle/Util/CoordUtil.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Mapbender\PrintBundle\Util;
+
+class CoordUtil
+{
+    /**
+     * Interpolate between given vectors. Inputs can have any dimensionality,
+     * but must use common keys. Return value will also have the same keys.
+     *
+     * @param float[] $start
+     * @param float[] $end
+     * @param float $ratio [0;1] for results between start and end
+     * @return float[]
+     */
+    public static function interpolateLinear($start, $end, $ratio)
+    {
+        $vOut = array();
+        foreach ($start as $key => $startElement) {
+            $vOut[$key] = $startElement + ($end[$key] - $startElement) * $ratio;
+        }
+        return $vOut;
+    }
+
+    /**
+     * Calculate distance between two vectors, simple Pythagoras method.
+     * Expect to be surprised if inputs have zero or differing number of elements.
+     *
+     * @param float[] $a
+     * @param float[] $b
+     * @return float
+     */
+    public static function distance($a, $b)
+    {
+        $sumOfSquares = 0;
+        foreach ($a as $key => $aElement) {
+            $elementDifference = $b[$key] - $aElement;
+            $sumOfSquares += $elementDifference * $elementDifference;
+        }
+        return sqrt($sumOfSquares);
+    }
+}

--- a/src/Mapbender/Utils/InfiniteCyclicArrayIterator.php
+++ b/src/Mapbender/Utils/InfiniteCyclicArrayIterator.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace Mapbender\Utils;
+
+/**
+ * Iterator that loops around the initially passed array infinitely.
+ */
+class InfiniteCyclicArrayIterator implements \Iterator
+{
+    /** @var array */
+    protected $elements;
+    /** @var array */
+    protected $keys;
+    /** @var int */
+    protected $index = 0;
+    /** @var int */
+    protected $nTotal;
+
+    public function __construct(array $elements)
+    {
+        $this->elements = array_values($elements);
+        $this->keys = array_keys($elements);
+        $this->nTotal = count($elements);
+    }
+
+    public function next()
+    {
+        ++$this->index;
+        if ($this->index >= $this->nTotal) {
+            $this->index = 0;
+        }
+    }
+
+    public function valid()
+    {
+        // NOTE: This can never retrun true if the original $elements array was empty,
+        //       thus ensuring no looping takes place.
+        return $this->index < $this->nTotal;
+    }
+
+    public function rewind()
+    {
+        $this->index = 0;
+    }
+
+    public function current()
+    {
+        return $this->elements[$this->index];
+    }
+
+    public function key()
+    {
+        return $this->keys[$this->index];
+    }
+}


### PR DESCRIPTION
Polygonal features generated by Digitizer or similar developments can have quite complex line styling, which has historically not transferred very well into ImageExport / Print.

This pull improves support for high line widths, non-trivial line opacities and line pattern styling. This is achieved by
1) Compositing. The polygon and its outline are both prepared on a temporary sub-canvas, where holes can be cut without undesired removal of base image portions, and where blending artifacts can be avoided by simply turning blending off.
2) Deconstructing the line pattern into individual line and point primitives.

Consider geometries styled like this (browser view, Digitizer):
![poly-browser-view](https://user-images.githubusercontent.com/24895932/52323517-9a9cf680-29dd-11e9-9368-5fce896bcc7e.png)

The best you could previously achieve in a Mapbender printout ended up something like this:
![poly-badness](https://user-images.githubusercontent.com/24895932/52323543-b6a09800-29dd-11e9-97c3-4b1e00f23812.png)

Things of note:
* The outline opacity escalates around steep edges, where the thick outline self-intersects and incrementally blends its color onto the background several times
* The "donut" hole is not cut out, but filled with the polygon color "normally"
* The line pattern comes out completely jumbled
* Sharp angles produce very abrupt changes between completely horizontal and completely vertical line segment caps produced by GD. This is especially obvious for the the lone purple dot, which was created as a tiny circle geometry. It comes out barely recognizable as a cross.

Result after changes in this pull:
![poly-improvements](https://user-images.githubusercontent.com/24895932/52323634-11d28a80-29de-11e9-9465-464587abf873.png)

The donut cutout works.  
The outline pattern, while admittedly still not 100% perfect, is much smoother.  
Intermittent vertices are rounded out.  
The tiny circle geometry looks much closer to what it should be.

Sidenote: I'd also like to document the recent evolution of point rendering here
![point-evo](https://user-images.githubusercontent.com/24895932/52323890-34b16e80-29df-11e9-840d-680a1392a71a.png)
v3.0.7.7 could not render a point outline with any other width than 1 pixel, at all, following an unfortunate GD limitation.  
The middle image is an attempt to resolve this by creating polygonal geometry for the point outline.  
The right version shows the current development version, which renders the outline as a fully transparent circle stamped out of a non-transparent circle, which then goes through compositing. The result is indistinguishable from the browser view.