### PR TITLE
Fix/declarative mb wms layers repeatability + empty group layer names

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -637,7 +637,7 @@
                         options.layers[$layerLi.attr('data-id')] = value;
                     }
                 });
-                self.model.changeLayerState(source, options, false, true);
+                self.model.changeLayerState(source, options, null);
             });
             return false;
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -482,7 +482,10 @@ Mapbender.Geo.SourceHandler = Class({
                 parentLayer.state.visibility = parentLayer.state.visibility || layer.state.visibility;
                 if (stateChanged) {
                     changeMap[parentId] = $.extend(changeMap[parentId] || {}, {
-                        state: parentLayer.state
+                        state: parentLayer.state,
+                        options: {
+                            treeOptions: parentLayer.options.treeOptions
+                        }
                     });
                 }
             }

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -144,7 +144,10 @@
                 layerNamesToActivate = false;
             }
             if (mergeSource) {
-                var mergeLayers = !elm.attr('mb-wms-layer-merge') || elm.attr('mb-wms-layer-merge') === '1';
+                // NOTE: The evaluated attribute name has always been 'mb-wms-layer-merge', but documenented name
+                //       was 'mb-layer-merge'. Just support both equivalently.
+                var mergeLayersAttribValue = elm.attr('mb-wms-layer-merge') || elm.attr('mb-layer-merge');
+                var mergeLayers = !mergeLayersAttribValue || (mergeLayersAttribValue === '1');
                 var mbMap = $('#' + self.options.target).data('mapbenderMbMap');
                 var sources = mbMap.model.getSources();
                 for(var i = 0; i < sources.length; i++){

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -4,7 +4,6 @@
         options: {
             autoOpen: false,
             title: Mapbender.trans('mb.wms.wmsloader.title'),
-            splitLayers: false,
             wms_url: null
         },
         loadedSourcesCount: 0,
@@ -32,7 +31,6 @@
                     'layers': {},
                     'global': {
                         'mergeSource': false,
-                        'splitLayers': this.options.splitLayers,
                         'options': {'treeOptions': {'selected': true}}
                     }
                 };
@@ -46,7 +44,6 @@
                     'layers': {},
                     'global': {
                         'mergeSource': false,
-                        'splitLayers': this.options.splitLayers,
                         'options': {'treeOptions': {'selected': true}}
                     }
                 };
@@ -97,7 +94,6 @@
                                     'layers': {},
                                     'global': {
                                         'mergeSource': false,
-                                        'splitLayers': self.options.splitLayers,
                                         'options': {'treeOptions': {'selected': true}}
                                     }
                                 };
@@ -132,8 +128,6 @@
                 'type': 'declarative',
                 'layers': {},
                 'global': {
-                    'mergeSource': mergeSource,
-                    'splitLayers': false,
                     'options': {'treeOptions': {'selected': false}}
                 }
             };
@@ -149,7 +143,7 @@
             } else {
                 layerNamesToActivate = false;
             }
-            if (options.global.mergeSource) {
+            if (mergeSource) {
                 var mergeLayers = !elm.attr('mb-wms-layer-merge') || elm.attr('mb-wms-layer-merge') === '1';
                 var mbMap = $('#' + self.options.target).data('mapbenderMbMap');
                 var sources = mbMap.model.getSources();
@@ -179,6 +173,7 @@
                     }
                 }
             }
+            options.mergeSource = mergeSource;
             this.loadWms(options);
             return false;
         },

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -173,7 +173,7 @@
                     }
                 }
             }
-            options.mergeSource = mergeSource;
+            options.global.mergeSource = mergeSource;
             this.loadWms(options);
             return false;
         },


### PR DESCRIPTION
Fixes non-repeatable behaviour in handling of 'declarative' links that dynamically add or update Wms sources with explicit layers via `mb-wms-layers` attribute _and_ (default) `mb-wms-merge` "1". Previously, the performed operations on the source were different for newly added sources and already loaded sources.  Now a repeated click on the same declarative link performs the same incremental (`mb-layer-merge` omitted or "1") or total (`mb-layer-merge` "0") set of changes to the source.  

Supports `mb-layer-merge` attribute on 'declarative' links as documented. Previously the code respected only the `mb-wms-layer-merge` attribute, which wasn't documented. Now it supports both equivalently.  

Enhanced support for activating layers explicitly even on sources with intermediate group or root layers with empty names. Previously such layers could not be acted upon distinctly, because `mb-wms-layers` can only identify layers with distinct names. Now the 'declarative' `mb-wms-layers` interaction implicitly activates also the parents of the named layers (including the root layers). This supports all relevant workflows nicely. It also increases robustness against structural changes of the WMS layer setup (regrouping, increase of nesting).  
