### PR TITLE
Fix/3078 mobile template config error

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -2,6 +2,7 @@
 namespace Mapbender\CoreBundle\Component;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Mapbender\CoreBundle\Component\Presenter\Application\ConfigService;
 use Mapbender\CoreBundle\Component\Presenter\ApplicationService;
 use Mapbender\CoreBundle\Entity\Application as Entity;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
@@ -119,6 +120,32 @@ class Application
     {
         $template = $this->getTemplate();
         return $template->render();
+    }
+
+    /**
+     * @return ConfigService
+     */
+    private function getConfigService()
+    {
+        /** @var ConfigService $presenter */
+        $presenter = $this->container->get('mapbender.presenter.application.config.service');
+        return $presenter;
+    }
+
+    /**
+     * Get the configuration (application, elements, layers) as an StringAsset.
+     * Filters can be applied later on with the ensureFilter method.
+     *
+     * @return string Configuration as JSON string
+     */
+    public function getConfiguration()
+    {
+        $configService = $this->getConfigService();
+        $configuration = $configService->getConfiguration($this->entity);
+
+        // Convert to asset
+        $asset = new StringAsset(json_encode((object)$configuration));
+        return $asset->dump();
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Application.php
+++ b/src/Mapbender/CoreBundle/Component/Application.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle\Component;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Mapbender\CoreBundle\Component\Presenter\Application\ConfigService;
 use Mapbender\CoreBundle\Component\Presenter\ApplicationService;
+use Mapbender\CoreBundle\Controller\ApplicationController;
 use Mapbender\CoreBundle\Entity\Application as Entity;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -133,19 +134,24 @@ class Application
     }
 
     /**
-     * Get the configuration (application, elements, layers) as an StringAsset.
-     * Filters can be applied later on with the ensureFilter method.
+     * Get the Application configuration (application, elements, layers) as a json-encoded string.
      *
      * @return string Configuration as JSON string
+     * @deprecated This method is only called from (copies of) the mobile.html.twig application template
+     *     In modern Mapbender templates, Application configuration is loaded by a separate Ajax route,
+     *     completely independent of the twig template. Simply removing the script fragment that ends up
+     *     calling this method from your twig template will automatically switch to Ajax config loading,
+     *     doesn't require writing any replacement logic, and removes the warning.
+     * @see ApplicationController::configurationAction()
      */
     public function getConfiguration()
     {
+        @trigger_error("Deprecated: Inlining Application configuration data into your template is unnecessary. "
+                     . "Please remove the 'Mapbender.configuration = {{ application.configuration | raw }};' script "
+                     . "fragment from your Application twig template.", E_USER_DEPRECATED);
         $configService = $this->getConfigService();
         $configuration = $configService->getConfiguration($this->entity);
-
-        // Convert to asset
-        $asset = new StringAsset(json_encode((object)$configuration));
-        return $asset->dump();
+        return json_encode((object)$configuration);
     }
 
     /**

--- a/src/Mapbender/MobileBundle/Resources/views/Template/mobile.html.twig
+++ b/src/Mapbender/MobileBundle/Resources/views/Template/mobile.html.twig
@@ -62,9 +62,4 @@
           </div>
       </div>
   </div>
-
-  <script type="text/javascript">
-      var Mapbender = Mapbender || {};
-      Mapbender.configuration = {{ application.configuration | raw }};
-  </script>
 {% endblock %}


### PR DESCRIPTION
Fix for testing cycle v3.0.7.8: mobile template initialization.  
Reverts removal of Component\Application::getConfiguration.  
Adds a relevant deprecation warning (which goes to the log) and documents "replacement" strategy (which is simply removal of a script fragment from the twig.  
Cleans up the redundant (and ill-described) Assetic StringAsset usage as to not reintroduce a dependency with will cause conflicts later down the roadmap.

This is not a changelog topic, because the error this fixes has not been part of a tagged version, but was introduced during later development.