### PR TITLE
Sidepane interaction hooks for mbBaseElement

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -176,6 +176,7 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender.trans.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.application.wdt.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.element.base.js',
+                    '@MapbenderCoreBundle/Resources/public/init/element-sidepane.js',
                     '@MapbenderCoreBundle/Resources/public/polyfills.js',
                     '/components/underscore/underscore-min.js',
                     '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',

--- a/src/Mapbender/CoreBundle/Resources/public/init/element-sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/init/element-sidepane.js
@@ -1,0 +1,95 @@
+((function($) {
+    function notifyElements(scope, state) {
+        $('.mb-element[id]', scope).each(function() {
+            var promise, methodName;
+            if (state) {
+                // Before we call 'reveal' an element, we want it to be done initializing
+                promise = Mapbender.elementRegistry.waitReady(this.id);
+                // See mapbender.element.base.js
+                methodName = 'reveal';
+            } else {
+                // We do not wait for an element to become ready before we call 'hide'
+                promise = Mapbender.elementRegistry.waitCreated(this.id);
+                // See mapbender.element.base.js
+                methodName = 'hide';
+            }
+            promise.then(function(elementWidget) {
+                if (typeof elementWidget[methodName] === 'function') {
+                    elementWidget[methodName].call(elementWidget);
+                }
+            });
+        });
+    }
+    function addTabContainerElementEvents() {
+        var $panels = $('>.container[id]', this);
+        var currentPanel = null;
+        function setCurrentTab() {
+            var panelId = this.id.replace('tab', 'container');
+            var panel = $panels.filter('#' + panelId + ':first').get(0);
+            if (panel) {
+                if (currentPanel) {
+                    notifyElements(currentPanel, false);
+                }
+                notifyElements(panel, true);
+                currentPanel = panel;
+            }
+        }
+        // set initial active tab from .active class
+        $('>.tabs >.tab.active:first', this).each(setCurrentTab);
+        // follow further click events
+        $('>.tabs', this).on('click', '>.tab[id]', setCurrentTab);
+    }
+
+    function addAccordionElementEvents() {
+        var $panels = $('>.container-accordion', this);
+        $('>.accordion', this).on('selected', function(e, tabData) {
+            var activatedHeader = tabData.current && tabData.current.get(0);
+            var deactivatedHeader = tabData.previous && tabData.previous.get(0);
+            var activatedId = activatedHeader && activatedHeader.id
+                && activatedHeader.id.replace("accordion", "container");
+            var deactivatedId = deactivatedHeader && deactivatedHeader.id
+                && deactivatedHeader.id.replace("accordion", "container");
+            var activatedPanel = activatedId
+                && $panels.filter('#' + activatedId + ':first').get(0);
+            var deactivatedPanel = deactivatedId
+                && $panels.filter('#' + deactivatedId + ':first').get(0);
+            if (deactivatedPanel) {
+                notifyElements(deactivatedPanel, false);
+            }
+            if (activatedPanel) {
+                notifyElements(activatedPanel, true);
+            }
+        });
+    }
+
+    function processSidePane(node) {
+        // Generate unified Element signals independent of sidepane organization
+        // Accordions already generate events, but they are fired on the panel headers
+        // where the contained Elements can't see them
+        // .tabContainer and .tabContainerAlt do not produce any events at all
+        // @todo: bring the base code for these two different pieces from FOM into
+        //        Mapbender so they can be done properly
+        var $accordions = $('>.accordionContainer', node);
+        var $tabContainers = $('>.tabContainer, >.tabContainerAlt', node);
+        if (!$accordions.length && !$tabContainers.length) {
+            // try finding an accordion again with a deeper scan, but avoid picking nested accordions
+            $accordions = $('.accordionContainer:not(.accordionContainer .accordionContainer)', node);
+        }
+        if ($tabContainers.length && $accordions.length) {
+            console.warn("Found both tab containers and accordions in same sidepane, preferring tab containers",
+                $tabContainers, $accordions, node);
+        }
+
+        if ($tabContainers.length) {
+            $tabContainers.each(addTabContainerElementEvents);
+        } else if ($accordions.length) {
+            $accordions.each(addAccordionElementEvents);
+        }
+    }
+    function processSidepanes() {
+        $('.sideContent:not(.sideContent .sideContent)').each(function() {
+            processSidePane(this);
+        });
+    }
+    $(document).on("mapbender.setupfinished", processSidepanes);
+})(jQuery));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.base.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.base.js
@@ -2,7 +2,32 @@
     'use strict';
 
     $.widget("mapbender.mbBaseElement", {
-
+        /**
+         * Called when a widget is becoming visible through user action.
+         * This is (currently only) used by sidepane machinery.
+         * This is never called before the widget has sent its 'ready' event.
+         * This SHOULD NOT open a popup dialog (though opening a popup dialog MAY implicitly also
+         * call this method, if it performs important state changes).
+         * @see element-sidepane.js
+         *
+         * This method doesn't receive any arguments and doesn't need to return anything.
+         */
+        reveal: function() {
+            // nothing to do in base implementation
+        },
+        /**
+         * Called when a widget is getting hidden through user action.
+         * This is (currently only) used by sidepane machinery.
+         * NOTE: This method MAY be called even if the widget never sent a 'ready' event.
+         * Overridden versions MAY close any popup dialogs owned by the widget, though elements in the
+         * side pane should usually never reside inside a popup themselves.
+         * @see element-sidepane.js
+         *
+         * This method doesn't receive any arguments and doesn't need to return anything.
+         */
+        hide: function() {
+            // nothing to do in base implementation
+        },
         /**
          * Destroy callback
          *


### PR DESCRIPTION
Technical basis for fixing systemic sidepane element visibility issues such as #992.  
Coalesces FOM [`.tabContainerAlt` and `.accordion`](https://github.com/mapbender/fom/blob/release/3.0.6/src/FOM/CoreBundle/Resources/public/js/frontend/tabcontainer.js) event behaviour into a single flow, which long story short ends up calling either a 'reveal' or 'hide' method on an mbBaseElement widget living in a sidepane.

The effect felt by the mbBaseElement is the same for both `Button` and `Accordeon` sidepane types. When a sidepane tab or accordeon slice opens that contains Mapbender Element widgets, `reveal` will be called on them. When it closes, `hide` will be called. Order is `hide` first, `reveal` second.

Sidepanes are required to carry the `sideContent` CSS class for this to work, because that's how they are recognized. Highly customized project templates may want to check for this precondition.

Nothing at all will happen to Element widget instances not living inside a sidepane.  
Nothing at all will happen to Element widgets not implementing `hide` or `reveal` methods.  
Nothing at all will happen to Element widget instances living inside an unstructured `None`-type sidepane.  
Nothing at all will happen to Application templates that do not emit a DOM node matching `.sideContent`.  
Nothing at all will happen to `.sideContent` nodes nested into other `.sideContent` nodes.


The naming `hide` and `reveal` was chosen in part to get away from the highly inconsistent usage of `activate` and `deactivate` in existing element widgets. Also because it is envisioned that at some point there can be some utility even for non-sidepane (popup-style) widgets.   
Widgets should be able to clearly separate in their lifecycle:
* Showing themselves in a ready-and-waiting for usage state (e.g. showing a form or a list of items)
* Enabling map and general event manipulation (running a drawing tool, waiting for map clicks etc)
* Opening a popup
Plus the reverse stages
