### PR TITLE
Fix/redlining sidepane deactivate tools

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -176,6 +176,7 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender.trans.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.application.wdt.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.element.base.js',
+                    '@MapbenderCoreBundle/Resources/public/init/element-sidepane.js',
                     '@MapbenderCoreBundle/Resources/public/polyfills.js',
                     '/components/underscore/underscore-min.js',
                     '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',

--- a/src/Mapbender/CoreBundle/Resources/public/init/element-sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/init/element-sidepane.js
@@ -1,0 +1,95 @@
+((function($) {
+    function notifyElements(scope, state) {
+        $('.mb-element[id]', scope).each(function() {
+            var promise, methodName;
+            if (state) {
+                // Before we call 'reveal' an element, we want it to be done initializing
+                promise = Mapbender.elementRegistry.waitReady(this.id);
+                // See mapbender.element.base.js
+                methodName = 'reveal';
+            } else {
+                // We do not wait for an element to become ready before we call 'hide'
+                promise = Mapbender.elementRegistry.waitCreated(this.id);
+                // See mapbender.element.base.js
+                methodName = 'hide';
+            }
+            promise.then(function(elementWidget) {
+                if (typeof elementWidget[methodName] === 'function') {
+                    elementWidget[methodName].call(elementWidget);
+                }
+            });
+        });
+    }
+    function addTabContainerElementEvents() {
+        var $panels = $('>.container[id]', this);
+        var currentPanel = null;
+        function setCurrentTab() {
+            var panelId = this.id.replace('tab', 'container');
+            var panel = $panels.filter('#' + panelId + ':first').get(0);
+            if (panel) {
+                if (currentPanel) {
+                    notifyElements(currentPanel, false);
+                }
+                notifyElements(panel, true);
+                currentPanel = panel;
+            }
+        }
+        // set initial active tab from .active class
+        $('>.tabs >.tab.active:first', this).each(setCurrentTab);
+        // follow further click events
+        $('>.tabs', this).on('click', '>.tab[id]', setCurrentTab);
+    }
+
+    function addAccordionElementEvents() {
+        var $panels = $('>.container-accordion', this);
+        $('>.accordion', this).on('selected', function(e, tabData) {
+            var activatedHeader = tabData.current && tabData.current.get(0);
+            var deactivatedHeader = tabData.previous && tabData.previous.get(0);
+            var activatedId = activatedHeader && activatedHeader.id
+                && activatedHeader.id.replace("accordion", "container");
+            var deactivatedId = deactivatedHeader && deactivatedHeader.id
+                && deactivatedHeader.id.replace("accordion", "container");
+            var activatedPanel = activatedId
+                && $panels.filter('#' + activatedId + ':first').get(0);
+            var deactivatedPanel = deactivatedId
+                && $panels.filter('#' + deactivatedId + ':first').get(0);
+            if (deactivatedPanel) {
+                notifyElements(deactivatedPanel, false);
+            }
+            if (activatedPanel) {
+                notifyElements(activatedPanel, true);
+            }
+        });
+    }
+
+    function processSidePane(node) {
+        // Generate unified Element signals independent of sidepane organization
+        // Accordions already generate events, but they are fired on the panel headers
+        // where the contained Elements can't see them
+        // .tabContainer and .tabContainerAlt do not produce any events at all
+        // @todo: bring the base code for these two different pieces from FOM into
+        //        Mapbender so they can be done properly
+        var $accordions = $('>.accordionContainer', node);
+        var $tabContainers = $('>.tabContainer, >.tabContainerAlt', node);
+        if (!$accordions.length && !$tabContainers.length) {
+            // try finding an accordion again with a deeper scan, but avoid picking nested accordions
+            $accordions = $('.accordionContainer:not(.accordionContainer .accordionContainer)', node);
+        }
+        if ($tabContainers.length && $accordions.length) {
+            console.warn("Found both tab containers and accordions in same sidepane, preferring tab containers",
+                $tabContainers, $accordions, node);
+        }
+
+        if ($tabContainers.length) {
+            $tabContainers.each(addTabContainerElementEvents);
+        } else if ($accordions.length) {
+            $accordions.each(addAccordionElementEvents);
+        }
+    }
+    function processSidepanes() {
+        $('.sideContent:not(.sideContent .sideContent)').each(function() {
+            processSidePane(this);
+        });
+    }
+    $(document).on("mapbender.setupfinished", processSidepanes);
+})(jQuery));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.base.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.base.js
@@ -2,7 +2,32 @@
     'use strict';
 
     $.widget("mapbender.mbBaseElement", {
-
+        /**
+         * Called when a widget is becoming visible through user action.
+         * This is (currently only) used by sidepane machinery.
+         * This is never called before the widget has sent its 'ready' event.
+         * This SHOULD NOT open a popup dialog (though opening a popup dialog MAY implicitly also
+         * call this method, if it performs important state changes).
+         * @see element-sidepane.js
+         *
+         * This method doesn't receive any arguments and doesn't need to return anything.
+         */
+        reveal: function() {
+            // nothing to do in base implementation
+        },
+        /**
+         * Called when a widget is getting hidden through user action.
+         * This is (currently only) used by sidepane machinery.
+         * NOTE: This method MAY be called even if the widget never sent a 'ready' event.
+         * Overridden versions MAY close any popup dialogs owned by the widget, though elements in the
+         * side pane should usually never reside inside a popup themselves.
+         * @see element-sidepane.js
+         *
+         * This method doesn't receive any arguments and doesn't need to return anything.
+         */
+        hide: function() {
+            // nothing to do in base implementation
+        },
         /**
          * Destroy callback
          *

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -1,6 +1,6 @@
 (function($){
 
-    $.widget("mapbender.mbRedlining", {
+    $.widget("mapbender.mbRedlining", $.mapbender.mbBaseElement, {
         options: {
             target: null,
             display_type: 'dialog',

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -62,6 +62,9 @@
             }
             $('.redlining-tool', this.element).on('click', $.proxy(this._newControl, this));
         },
+        hide: function() {
+            this._deactivateControl();
+        },
         deactivate: function(){
             if (this.options.display_type === 'dialog'){
                 this._close();


### PR DESCRIPTION
Piggy-backs on #1087, which introduce visibility information machinery for sidepane-dwelling element widgets.  
Fixes #992  

Redlining in sidepane is rebased to inherit from mbBaseWidget, and implements the new `hide` method to deactivate its drawing control.