### PR TITLE
[WIP] Enh/remove button activate deactivate methods poc

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -15,7 +15,7 @@
         $toolBarItem: null,
         /** initialized to true if button can determine target's active state and remember its own active state */
         stateful: null,
-        actionMethods: {},
+        actionMethods: null,
 
         _create: function () {
             if (this.options.click) {
@@ -145,10 +145,7 @@
                     var dataKey = [namespace, innerName.charAt(0).toUpperCase(), innerName.slice(1)].join('');
                     this.targetWidget = $target.data(dataKey);
                 }
-                if (this.targetWidget) {
-                    this.actionMethods = this._extractActionMethods(this.targetWidget);
-                    this.stateful = !!this.actionMethods.deactivate;
-                } else {
+                if (!this.targetWidget) {
                     console.warn("Could not identify target element", this.options.target, targetInit);
                     // Avoid attempting this again
                     // null: target widget not initialized; false: looked for target widget but got nothing
@@ -158,6 +155,16 @@
             }
             return this.targetWidget || null;
         },
+        _initializeActionMethods: function() {
+            if (this.actionMethods === null) {
+                if (this._initializeTarget()) {
+                    this.actionMethods = this._extractActionMethods(this.targetWidget);
+                    this.stateful = !!this.actionMethods.deactivate;
+                } else {
+                    this.actionMethods = {};
+                }
+            }
+        },
         /**
          * Calls 'activate' method on target if defined, and if in group, sets a visual highlight
          */
@@ -165,7 +172,7 @@
             if (this.stateful && this.active) {
                 return;
             }
-            this._initializeTarget();
+            this._initializeActionMethods();
             if (this.actionMethods.activate) {
                 (this.actionMethods.activate)();
                 this.active = this.stateful;
@@ -180,7 +187,7 @@
          */
         deactivate: function () {
             this.reset();
-            this._initializeTarget();
+            this._initializeActionMethods();
             if (this.actionMethods.deactivate) {
                 (this.actionMethods.deactivate)();
                 this.active = false;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -13,8 +13,6 @@
         active: false,
         targetWidget: null,
         $toolBarItem: null,
-        /** initialized to true if button can determine target's active state and remember its own active state */
-        stateful: null,
         actionMethods: null,
 
         _create: function () {
@@ -63,7 +61,7 @@
                 }
             }
 
-            if (!this.stateful || !this.active) {
+            if (!this.active) {
                 this.activate();
             } else {
                 this.deactivate();
@@ -155,7 +153,6 @@
                     // Avoid attempting this again
                     // null: target widget not initialized; false: looked for target widget but got nothing
                     this.targetWidget = false;
-                    this.stateful = false;
                 }
             }
             return this.targetWidget || null;
@@ -164,7 +161,6 @@
             if (this.actionMethods === null) {
                 if (this._initializeTarget()) {
                     this.actionMethods = this._extractActionMethods(this.targetWidget);
-                    this.stateful = !!this.actionMethods.deactivate;
                 } else {
                     this.actionMethods = {};
                 }
@@ -195,19 +191,20 @@
             } else {
                 this._highlightState = false;
             }
+
             this.updateHighlight();
         },
         /**
          * Calls 'activate' method on target if defined, and if in group, sets a visual highlight
          */
         activate: function () {
-            if (this.stateful && this.active) {
+            if (this.active) {
                 return;
             }
             this._initializeActionMethods();
             if (this.actionMethods.activate) {
                 (this.actionMethods.activate)();
-                this.active = this.stateful;
+                this.active = true;
             }
             this._highlightState = this.active || !!this.options.group;
             this.updateHighlight();
@@ -217,14 +214,11 @@
          * calls 'deactivate' method on target (if defined)
          */
         deactivate: function () {
-            this.reset();
             this._initializeActionMethods();
             if (this.actionMethods.deactivate) {
                 (this.actionMethods.deactivate)();
-                this.active = false;
             }
-            this._highlightState = false;
-            this.updateHighlight();
+            this.reset();
         },
         /**
          * Clears visual highlighting, marks inactive state

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -22,6 +22,9 @@
                 // so we still need to load the JS asset, and we still end up right here
                 return;
             }
+            // Proof of concept: this can work with no 'activate' or 'deactivate' settings from the backend
+            this.options.deactivate = null;
+            this.options.activate = null;
             var self = this,
                 option = {};
 
@@ -94,8 +97,8 @@
                 activate: null,
                 deactivate: null
             };
-            var activateCandidateNames = [this.options.action, 'defaultAction', 'activate', 'open'];
-            var deactivateCandidateNames = [this.options.deactivate, 'deactivate', 'close'];
+            var activateCandidateNames = ['defaultAction', 'activate', 'open'];
+            var deactivateCandidateNames = ['deactivate', 'close'];
             var activateCandidates = this._extractCallableMethods(
                 targetWidget, activateCandidateNames);
             var deactivateCandidates = this._extractCallableMethods(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -111,7 +111,6 @@
 
             mapElement.removeClass('mb-feature-info-active');
 
-            $(".toolBarItemActive").removeClass("toolBarItemActive");
             if (widget.popup) {
                 if (widget.popup.$element) {
                     $('body').append(element.addClass('hidden'));


### PR DESCRIPTION
Proof of concept version of [enh/grand-unified-button-api](https://github.com/mapbender/mapbender/tree/enh/grand-unified-button-api): empties any 'activate' and 'deactivate' options the Button receives from the Backend (or a YAML application), and thus forces it to figure it out all on its own.

Observed behaviour:  
Button auto-detects a probable initial activation state of its target widget by evaluating [various](https://github.com/mapbender/mapbender/commit/04b50b5b392106d817ca49847a365bb821769565#diff-47bf66afd39ec612d69958ee81aafcb8R176) configuration options.

Button can activate and deactivate all but one of the tested widgets properly. Button self-assigns an adequate highlight (without needing the single-member 'group' setting workaround). Note: button will still deactivate other members of the same group. Other non-grouped targets, or targets in a different group, will remain active.

The only outlier that didn't work fully in testing is Coordinates Utility, which does not close on the second click, and can have inverted button highlighting states.