### PR TITLE
Enh/print template as an object

### DIFF
--- a/src/Mapbender/PrintBundle/Component/OdgParser.php
+++ b/src/Mapbender/PrintBundle/Component/OdgParser.php
@@ -115,9 +115,10 @@ class OdgParser
         foreach ($customShapes as $customShape) {
             $shapeName = $customShape->getAttribute('draw:name');
             $templateRegion = $this->parseShapeIntoRegion($customShape);
+            $templateRegion->setName($shapeName);
             // @todo: extract (non-default) font styles for all shapes?
             $templateRegion->setFontStyle(FontStyle::defaultFactory());
-            $templateObject->addRegion($shapeName, $templateRegion);
+            $templateObject->addRegion($templateRegion);
         }
 
         foreach ($xPath->query("draw:page/draw:frame", $doc->getElementsByTagName('drawing')->item(0)) as $node) {
@@ -130,7 +131,8 @@ class OdgParser
             $styleNode = $this->detectStyleNode($xPath, $node);
             $styleData = $this->parseStyleNode($styleNode);
             $textField->setFontStyle(new FontStyle($styleData['font'], $styleData['fontsize'], $styleData['fontcolor']));
-            $templateObject->addTextField($name, $textField);
+            $textField->setName($name);
+            $templateObject->addTextField($textField);
         }
         return $templateObject;
     }

--- a/src/Mapbender/PrintBundle/Component/OdgParser.php
+++ b/src/Mapbender/PrintBundle/Component/OdgParser.php
@@ -115,8 +115,9 @@ class OdgParser
         foreach ($customShapes as $customShape) {
             $shapeName = $customShape->getAttribute('draw:name');
             $templateRegion = $this->parseShapeIntoRegion($customShape);
+            // @todo: extract (non-default) font styles for all shapes?
+            $templateRegion->setFontStyle(FontStyle::defaultFactory());
             $templateObject->addRegion($shapeName, $templateRegion);
-            // @todo: extract font styles for all shapes?
         }
 
         foreach ($xPath->query("draw:page/draw:frame", $doc->getElementsByTagName('drawing')->item(0)) as $node) {

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -20,6 +20,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
 {
     /** @var PDF_Extensions|\FPDF */
     protected $pdf;
+    /** @var Template|array */
     protected $conf;
 
     /** @var array */
@@ -58,6 +59,13 @@ class PrintService extends ImageExportService implements PrintServiceInterface
         parent::__construct($layerRenderers, $logger);
     }
 
+    /**
+     * Executes the job (plain array), returns a binary string representation of the resulting PDF.
+     *
+     * @param mixed[] $jobData
+     * @return string
+     * @throws \Exception on invalid template
+     */
     public function doPrint($jobData)
     {
         $templateData = $this->getTemplateData($jobData);
@@ -70,13 +78,29 @@ class PrintService extends ImageExportService implements PrintServiceInterface
         return $this->dumpPdf($pdf);
     }
 
+    /**
+     * Executes the job (plain array), returns a binary string representation of the resulting PDF.
+     *
+     * @param array $jobData
+     * @return string
+     * @throws \Exception on invalid template
+     */
     public function dumpPrint(array $jobData)
     {
         return $this->doPrint($jobData);
     }
 
+    /**
+     * Executes the job (plain array), writes the PDF result as directly as possible to $fileName.
+     *
+     * @param array $jobData
+     * @param string $fileName
+     * @throws \Exception on invalid template
+     */
     public function storePrint(array $jobData, $fileName)
     {
+        // NOTE: FPDI's 'direct' file output mode isn't any more efficient than its string output mode
+        //       (uses the same amount of memory). This may be more worthwhile with a different PDF lib...
         if (!file_put_contents($fileName, $this->doPrint($jobData))) {
             throw new \RuntimeException("Failed to store printout at {$fileName}");
         }
@@ -84,7 +108,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
 
     /**
      * @param array $jobData
-     * @return array
+     * @return Template|array
      */
     protected function getTemplateData($jobData)
     {
@@ -92,7 +116,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
     }
 
     /**
-     * @param array $templateData
+     * @param Template|array $templateData
      * @param array $jobData
      */
     protected function setup($templateData, $jobData)
@@ -130,8 +154,8 @@ class PrintService extends ImageExportService implements PrintServiceInterface
     }
 
     /**
-     * @param $templateData
-     * @param $templateName
+     * @param Template|array $templateData
+     * @param string $templateName
      * @return \FPDF|\FPDF_TPL|PDF_Extensions
      * @throws \Exception
      */
@@ -157,7 +181,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
 
     /**
      * @param string $mapImageName
-     * @param array $templateData
+     * @param Template|array $templateData
      * @param array $jobData
      * @return \FPDF|\FPDF_TPL|PDF_Extensions
      * @throws \Exception
@@ -201,7 +225,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
     /**
      * @param \FPDF|\FPDF_TPL|PDF_Extensions $pdf
      * @param string $mapImageName
-     * @param array $templateData
+     * @param Template|array $templateData
      */
     protected function addMapImage($pdf, $mapImageName, $templateData)
     {
@@ -217,7 +241,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
      * page, may spill over and start adding more pages.
      *
      * @param \FPDF|\FPDF_TPL|PDF_Extensions $pdf
-     * @param array $templateData
+     * @param Template|array $templateData
      * @param array $jobData
      */
     protected function afterMainMap($pdf, $templateData, $jobData)
@@ -263,7 +287,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
      * Fills textual regions on the first page.
      *
      * @param \FPDF|\FPDF_TPL|PDF_Extensions $pdf
-     * @param array $templateData
+     * @param Template|array $templateData
      * @param array $jobData
      */
     protected function addTextFields($pdf, $templateData, $jobData)

--- a/src/Mapbender/PrintBundle/Component/Region/FontStyle.php
+++ b/src/Mapbender/PrintBundle/Component/Region/FontStyle.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Region;
+
+
+use Mapbender\PrintBundle\Component\OdgParser;
+
+/**
+ * Font style for template regions. Initialized by OdgParser and assigned to 'fields'-style regions only,
+ * at least currently.
+ */
+class FontStyle
+{
+    /** @var string */
+    protected $fontName;
+    /** @var string */
+    protected $color;
+    /** @var float */
+    protected $size;
+
+    /**
+     * @param string $fontName
+     * @param float $size (silently dropping trailing 'pt'...)
+     * @param string $color CSS hex style ('#ff00ff')
+     */
+    public function __construct($fontName, $size, $color)
+    {
+        if (!$fontName) {
+            throw new \InvalidArgumentException("Font name empty " . print_r($fontName, true));
+        }
+        $this->fontName = $fontName;
+
+        if (!preg_match('/^#?[0-9a-f]{3}([0-9a-f]{3}?)$/i', $color)) {
+            throw new \InvalidArgumentException("Invalid font color, expected CSS hex style, got " . print_r($color, true));
+        }
+        $this->color = $color;
+        if ($size <= 0) {
+            throw new \InvalidArgumentException("Invalid font size " . print_r($size, true));
+        }
+        $this->size = floatval($size);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFontName()
+    {
+        return $this->fontName;
+    }
+
+    /**
+     * @return float
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * @return string hex coded (w/ leading hash)
+     */
+    public function getColor()
+    {
+        return $this->color;
+    }
+
+    /**
+     * Returns new instance set up with OdgParser defaults.
+     *
+     * @return FontStyle
+     */
+    public static function defaultFactory()
+    {
+        return new static(OdgParser::DEFAULT_FONT_NAME, OdgParser::DEFAULT_FONT_SIZE, OdgParser::DEFAULT_FONT_COLOR);
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Region/RegionCollection.php
+++ b/src/Mapbender/PrintBundle/Component/Region/RegionCollection.php
@@ -1,0 +1,91 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component\Region;
+
+
+use Mapbender\PrintBundle\Component\TemplateRegion;
+
+/**
+ * ArrayAccess / Traversable shim around TemplateRegion objects, so users can do e.g.
+ * if (!empty($template['fields']['title']))
+ * foreach ($template['fields'] as $name => $field)
+ * $something = $template['map']['pageSize']['width']
+ *
+ */
+class RegionCollection implements \ArrayAccess, \IteratorAggregate
+{
+    /** @var TemplateRegion[] */
+    protected $regions = array();
+
+    /**
+     * @param TemplateRegion[] $regions
+     */
+    public function __construct($regions = array())
+    {
+        foreach ($regions as $name => $region) {
+            $this->addMember($name, $region, false);
+        }
+    }
+
+    /**
+     * @param string
+     * @return TemplateRegion
+     */
+    public function getMember($name)
+    {
+        return $this->regions[$name];
+    }
+
+    /**
+     * @param $name
+     * @return bool
+     */
+    public function hasMember($name)
+    {
+        return !empty($this->regions[$name]);
+    }
+
+    /**
+     * @param string $name
+     * @param TemplateRegion $region
+     * @param bool $allowReplace
+     */
+    public function addMember($name, TemplateRegion $region, $allowReplace=false)
+    {
+        if (!$name || preg_match('#^\d+#', $name)) {
+            throw new \InvalidArgumentException("All region names should be non-empty strings, got " . print_r($name, true));
+        }
+        if (!$allowReplace && array_key_exists($name, $this->regions)) {
+            throw new \RuntimeException("Name collision on " . print_r($name, true));
+        }
+        $this->regions[$name] = $region;
+    }
+
+    // foreach support
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->regions);
+    }
+
+    // array-style access support
+    public function offsetExists($offset)
+    {
+        return isset($this->regions[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->regions[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Template.php
+++ b/src/Mapbender/PrintBundle/Component/Template.php
@@ -1,0 +1,175 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component;
+
+use Mapbender\PrintBundle\Component\Region\RegionCollection;
+
+/**
+ * Full structural description of the first page of the PDF we want to generate.
+ * Contains individual 'regions' (such as one named 'map', 'overview' etc) and
+ * 'text fields' (such as 'title').
+ *
+ * Text fields and regions are functionally the same, but kept in separate pools
+ * for historical reasons.
+ *
+ * Simulates an array structure via ArrayAccess for compatibility with legacy access
+ * patterns. The simulated array looks sth like:
+ * pageSize:
+ *    width: <number>
+ *    height: <number>
+ * orientation: <string>
+ * fields: @see RegionCollection
+ * <other dynamic string keys>: @see RegionCollection
+ */
+class Template implements \ArrayAccess
+{
+    const ORIENTATION_LANDSCAPE = 'landscape';
+    const ORIENTATION_PORTRAIT = 'portrait';
+
+    /** @var float in mm*/
+    protected $width;
+    /** @var float in mm*/
+    protected $height;
+    /** @var string */
+    protected $orientation;
+    /** @var RegionCollection */
+    protected $textFields;
+    /** @var RegionCollection */
+    protected $regions;
+
+    /**
+     * @param float $width in mm
+     * @param float $height in mm
+     * @param string $orientation
+     */
+    public function __construct($width, $height, $orientation)
+    {
+        if ($width <= 0 || $height <=0) {
+            throw new \InvalidArgumentException("Invalid width / height "
+                . print_r($width, true) . ' ' . print_r($height, true));
+        }
+        $this->width = floatval($width);
+        $this->height = floatval($height);
+        switch ($orientation) {
+            case self::ORIENTATION_LANDSCAPE:
+            case self::ORIENTATION_PORTRAIT:
+                $this->orientation = $orientation;
+                break;
+            default:
+                throw new \InvalidArgumentException("Invalid orientation " . print_r($orientation, true));
+        }
+
+        $this->textFields = new RegionCollection();
+        $this->regions = new RegionCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrientation()
+    {
+        return $this->orientation;
+    }
+
+    /**
+     * @return float
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * @return float
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return RegionCollection
+     */
+    public function getTextFields()
+    {
+        return $this->textFields;
+    }
+
+    /**
+     * @param string
+     * @return TemplateRegion
+     */
+    public function getRegion($name)
+    {
+        return $this->regions->getMember($name);
+    }
+
+    /**
+     * @param string
+     * @return bool
+     */
+    public function hasRegion($name)
+    {
+        return $this->regions->hasMember($name);
+    }
+
+    /**
+     * @param string
+     * @return bool
+     */
+    public function hasTextField($name)
+    {
+        return $this->textFields->hasMember($name);
+    }
+
+    public function addRegion($name, $region)
+    {
+        $this->regions->addMember($name, $region);
+    }
+
+    public function addTextField($name, $field)
+    {
+        $this->textFields->addMember($name, $field);
+    }
+
+
+    public function offsetGet($offset)
+    {
+        switch ($offset) {
+            case 'orientation':
+                return $this->getOrientation();
+            case 'pageSize':
+                return array(
+                    'width' => $this->getWidth(),
+                    'height' => $this->getHeight(),
+                );
+            case 'fields':
+                return $this->getTextFields();
+            default:
+                return $this->getRegion($offset);
+        }
+    }
+
+    public function offsetExists($offset)
+    {
+        switch ($offset) {
+            case 'orientation':
+            case 'pageSize':
+            case 'fields':
+                return true;
+            default:
+                return $this->hasRegion($offset);
+        }
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/Template.php
+++ b/src/Mapbender/PrintBundle/Component/Template.php
@@ -97,7 +97,7 @@ class Template implements \ArrayAccess
     }
 
     /**
-     * @return RegionCollection
+     * @return RegionCollection|TemplateRegion[]
      */
     public function getTextFields()
     {

--- a/src/Mapbender/PrintBundle/Component/Template.php
+++ b/src/Mapbender/PrintBundle/Component/Template.php
@@ -89,6 +89,14 @@ class Template implements \ArrayAccess
     }
 
     /**
+     * @return RegionCollection|TemplateRegion[]
+     */
+    public function getRegions()
+    {
+        return $this->regions;
+    }
+
+    /**
      * @return RegionCollection
      */
     public function getTextFields()
@@ -123,14 +131,22 @@ class Template implements \ArrayAccess
         return $this->textFields->hasMember($name);
     }
 
-    public function addRegion($name, $region)
+    /**
+     * @param TemplateRegion $region
+     */
+    public function addRegion($region)
     {
-        $this->regions->addMember($name, $region);
+        $region->setParentTemplate($this);
+        $this->regions->addMember($region->getName(), $region);
     }
 
-    public function addTextField($name, $field)
+    /**
+     * @param TemplateRegion $field
+     */
+    public function addTextField($field)
     {
-        $this->textFields->addMember($name, $field);
+        $field->setParentTemplate($this);
+        $this->textFields->addMember($field->getName(), $field);
     }
 
 

--- a/src/Mapbender/PrintBundle/Component/TemplateRegion.php
+++ b/src/Mapbender/PrintBundle/Component/TemplateRegion.php
@@ -8,8 +8,7 @@ use Mapbender\PrintBundle\Component\Region\FontStyle;
 /**
  * A rectangular portion of the PDF we want to generate.
  * Has dimensions, margins, and some font styling.
- * If the template parser didn't give us specific font styles,
- * we still carry some defaults.
+ * Can work backwards to the Template object it is a part of (but also works standalone).
  */
 class TemplateRegion implements \ArrayAccess
 {
@@ -21,6 +20,10 @@ class TemplateRegion implements \ArrayAccess
     protected $offsets;
     /** @var FontStyle|null */
     protected $style;
+    /** @var string|null */
+    protected $name;
+    /** @var Template|null */
+    protected $parentTemplate;
 
     /**
      * @param float $width in mm
@@ -36,6 +39,38 @@ class TemplateRegion implements \ArrayAccess
         } else {
             $this->offsets = array(0, 0);
         }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Template|null
+     */
+    public function getParentTemplate()
+    {
+        return $this->parentTemplate;
+    }
+
+    /**
+     * @param Template|null $parentTemplate
+     */
+    public function setParentTemplate($parentTemplate)
+    {
+        $this->parentTemplate = $parentTemplate;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/TemplateRegion.php
+++ b/src/Mapbender/PrintBundle/Component/TemplateRegion.php
@@ -1,0 +1,139 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component;
+
+use Mapbender\PrintBundle\Component\Region\FontStyle;
+
+/**
+ * A rectangular portion of the PDF we want to generate.
+ * Has dimensions, margins, and some font styling.
+ * If the template parser didn't give us specific font styles,
+ * we still carry some defaults.
+ */
+class TemplateRegion implements \ArrayAccess
+{
+    /** @var float */
+    protected $width;
+    /** @var float */
+    protected $height;
+    /** @var float[] */
+    protected $offsets;
+    /** @var FontStyle|null */
+    protected $style;
+
+    /**
+     * @param float $width in mm
+     * @param float $height in mm
+     * @param float[] $offsets x/y of upper left corner in mm (default: 0;0)
+     */
+    public function __construct($width, $height, $offsets = null)
+    {
+        $this->width = floatval($width);
+        $this->height = floatval($height);
+        if ($offsets) {
+            $this->offsets = array_map('floatval', array_values(array_slice($offsets, 0, 2)));
+        } else {
+            $this->offsets = array(0, 0);
+        }
+    }
+
+    /**
+     * @return float
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * @return float
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return FontStyle|null
+     */
+    public function getFontStyle()
+    {
+        return $this->style;
+    }
+
+    /**
+     * @param FontStyle $style
+     */
+    public function setFontStyle(FontStyle $style)
+    {
+        $this->style = $style;
+    }
+
+    /**
+     * @return float in mm
+     */
+    public function getOffsetX()
+    {
+        return $this->offsets[0];
+    }
+
+    /**
+     * @return float in mm
+     */
+    public function getOffsetY()
+    {
+        return $this->offsets[1];
+    }
+
+
+    // array-style access support
+    public function offsetGet($offset)
+    {
+        switch($offset) {
+            case 'x':
+                return $this->offsets[0];
+            case 'y':
+                return $this->offsets[1];
+            case 'width':
+                return $this->width;
+            case 'height':
+                return $this->height;
+            case 'font':
+                return $this->style->getFontName();
+            case 'fontsize':
+                return $this->style->getSize();
+            case 'color':
+                return $this->style->getColor();
+            default:
+                throw new \RuntimeException("Invalid offset " . print_r($offset, true));
+        }
+    }
+
+    public function offsetExists($offset)
+    {
+        switch ($offset) {
+            case 'x':
+            case 'y':
+            case 'width':
+            case 'height':
+                return true;
+            case 'font':
+            case 'fontsize':
+            case 'color':
+                return !!$this->style;
+            default:
+                return false;
+        }
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \RuntimeException(get_class($this) . " does not support array-style mutation");
+    }
+}


### PR DESCRIPTION
Result of parsing the print template in OdgParser becomes an object with semantically informative methods.  
ArrayAccess / Traversable behaviour is shimmed to emulate all previously available "array" keys on this return value transparently.  

Introducing this object hierarchy allowed for some cleanups and a more unified handling of both 'regions' and 'textFields' and a reusable 'applyFontStyle' method.

Collateral effects:
* 'dynamic_text' restored to full glory.  
* 'dynamic_text' and the coordinate textfields ('extent_ul_x' et al) can now be (individually) colored and sized from the odg template.
