### PR TITLE
Fix/button auto action method detection

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -94,8 +94,8 @@
                 activate: null,
                 deactivate: null
             };
-            var activateCandidateNames = [this.options.action, 'defaultAction', 'activate', 'open'];
-            var deactivateCandidateNames = [this.options.deactivate, 'deactivate', 'close'];
+            var activateCandidateNames = [this.options.action, 'defaultAction', 'open', 'activate'];
+            var deactivateCandidateNames = [this.options.deactivate, 'close', 'deactivate'];
             var activateCandidates = this._extractCallableMethods(
                 targetWidget, activateCandidateNames);
             var deactivateCandidates = this._extractCallableMethods(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -111,7 +111,6 @@
 
             mapElement.removeClass('mb-feature-info-active');
 
-            $(".toolBarItemActive").removeClass("toolBarItemActive");
             if (widget.popup) {
                 if (widget.popup.$element) {
                     $('body').append(element.addClass('hidden'));


### PR DESCRIPTION
This makes Buttons controlling other Elements work even if the backend `activate` / `deactivate` configuration is completely empy, or kind of bad. The "correct" settings for these options can be [non-intuitive](https://github.com/mapbender/mapbender/issues/1050#issuecomment-463119829) and figuring that out is better left to [a piece of code](https://github.com/mapbender/mapbender/commit/d8be3b5dc64decfe752f054c45a99ceecda52ab4#diff-47bf66afd39ec612d69958ee81aafcb8R90).  

NOTE: if there are any backend `activate` / `deactivate` settings they are respected insofar as they are the highest-priority picks of methods to use to control the target element _but_ _only_ _if_ the target widget has such a method. This retains administrative control and the option to call entirely non-standard, randomly named methods.  
OTOH it auto-heals any erroneous configurations by finding something that works. So the straightforward approach of leaving those backend values completely empty, will now just work.
