### PR TITLE
Fix/restore button inheritability

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Button.php
+++ b/src/Mapbender/CoreBundle/Element/Button.php
@@ -62,7 +62,21 @@ class Button extends Element
      */
     public function getWidgetName()
     {
-        return 'mapbender.mbButton';
+        if (get_class() === get_called_class()) {
+            // Most definitely a control button
+            return 'mapbender.mbControlButton';
+        } else {
+            // Called for a child class without an own getWidgetName implementation
+
+            // We expect any other Element inheriting from button to just want a simple
+            // self-highlighting toggle switch, with no actual desire to control other
+            // Elements. We give them a simpler, non-controlling button widget.
+            @trigger_error(
+                "Warning: assuming " . get_class($this) . " doesn't want to control other Element widgets,"
+              . " using different JS widget constructor. Override getWidgetName if you really want to control"
+              . " other Elements", E_USER_DEPRECATED);
+            return 'mapbender.mbButton';
+        }
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -142,6 +142,9 @@
                 });
             }
             this._super();
+            // Amenity for special snowflake mobile.js, which expects to see us under
+            // the 'mapbenderMbButton' data key
+            this.element.data('mapbenderMbButton', this);
         },
         /**
          *

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -1,18 +1,131 @@
 (function ($) {
     'use strict';
-
-    $.widget("mapbender.mbButton", {
+    /**
+     * Just a button that toggles its own visual highlighting state on / off on every click.
+     * If it has a group option, it will try to find other buttons with the same group and
+     * deactivate them before activating itself.
+     *
+     * Override activate and deactivate to add functionality.
+     */
+    $.widget("mapbender.mbBaseButton", {
         options: {
-            target: undefined,
-            click: undefined,
+            label: undefined,
             icon: undefined,
-            label: true,
+            /**
+             * @var {String|null|undefined}
+             */
+            // Buttons in the same group have mutual exclusion. Only one of them
+            // can be active at a time.
             group: undefined
         },
-
         active: false,
-        targetWidget: null,
         $toolBarItem: null,
+
+        _create: function() {
+            this.$toolBarItem = $(this.element).closest('.toolBarItem');
+            $(this.element)
+                .on('click', $.proxy(this._onClick, this))
+                .on('mbButtonDeactivate', $.proxy(this.deactivate, this));
+            // child widget may have initialized highlight state to a non-default
+            this._setActive(this.isActive());
+        },
+        /**
+         * Toggles the button state active / inactive.
+         * Deactivates same-group siblings, if any, when activated.
+         * Updates own visual highlighting state.
+         * @private
+         */
+        _onClick: function () {
+            if (this.isActive()) {
+                this.deactivate();
+            } else {
+                // If we're part of a group, deactivate all other buttons in the same group
+                // Do this BEFORE updating
+                if (this.options.group) {
+                    var $others = $('.mb-button[data-group="' + this.options.group + '"]')
+                        .not(this);
+                    try {
+                        $others.trigger('mbButtonDeactivate');
+                    } catch (e) {
+                        console.error("Suppressing error from sibling button deactivate handlers", e);
+                    }
+                }
+                this.activate();
+            }
+        },
+        /**
+         * Turns on highlight, remembers active state for next click.
+         * Override this if you need more stuff to happen
+         */
+        activate: function() {
+            this._setActive(true);
+        },
+        /**
+         * Turns off highlight, remembers inactive state for next click.
+         * Override this if you need more stuff to happen
+         */
+        deactivate: function() {
+            this._setActive(false);
+        },
+        /**
+         * Alias of deactivate in base implementation. Commonly used as an on-close callback for popups,
+         * invoked when they close, thus informing the button to clear its highlight, and that the next
+         * click should be another activation.
+         *
+         * For this reason, you should not override this to trigger external cleanup logic. Override
+         * deactivate instead.
+         */
+        reset: function () {
+            this._setActive(false);
+        },
+        /**
+         * Stores a new .active value and updates the highlighting with no further side effects
+         * (no events etc).
+         *
+         * @param isActive
+         * @private
+         */
+        _setActive: function(isActive) {
+            this.active = !!isActive;
+            this.$toolBarItem.toggleClass("toolBarItemActive", this.active);
+        },
+        /**
+         * Trivial base implementation. Override this if you're not really sure ahead of time
+         * what the button state is. Evaluated in click event handler.
+         *
+         * @return {boolean}
+         */
+        isActive: function() {
+            return this.active;
+        }
+    });
+    /**
+     * Just a button that toggles its own highlighting state on / off on every click.
+     * This is how the control button was called. We provide this alias name because
+     * many Element widgets inherit from the mapbender.mbButton, despite having nothing
+     * at all to do with controlling other Element widgets. Extended control logic
+     * in proper control button has made it somewhat incompatible with this
+     * non-controlling button usage.
+     */
+    $.widget("mapbender.mbButton", $.mapbender.mbBaseButton, {
+        options: {
+            // legacy options, not required for operation of base / control buttons
+            label: undefined,
+            icon: undefined
+        }
+    });
+
+    /**
+     * A button that controls other Element widgets. Never, ever inherit from this unless
+     * your intention is to control other Element widgets.
+     */
+    $.widget("mapbender.mbControlButton", $.mapbender.mbBaseButton, {
+        options: {
+            target: undefined,
+            click: undefined
+        },
+
+        targetWidget: null,
         actionMethods: null,
 
         _create: function () {
@@ -22,50 +135,13 @@
                 // so we still need to load the JS asset, and we still end up right here
                 return;
             }
-            var self = this,
-                option = {};
-
-            this.$toolBarItem = $(this.element).closest('.toolBarItem');
-
-            if (this.options.icon) {
-                $.extend(option, {
-                    icons: {
-                        primary: this.options.icon
-                    },
-                    text: this.options.label
-                });
-            }
-
+            var self = this;
             if (this.options.target) {
                 $(document).on('mapbender.setupfinished', function() {
                     self._initializeHighlightState();
                 });
             }
-            $(this.element)
-                .on('click', $.proxy(self._onClick, self))
-                .on('mbButtonDeactivate', $.proxy(self.deactivate, self));
-        },
-
-        _onClick: function () {
-            var $me = $(this.element);
-
-            // If we're part of a group, deactivate all other actions in this group
-            if (this.options.group) {
-                var others = $('.mb-button[data-group="' + this.options.group + '"]')
-                    .not($me);
-
-                try {
-                    others.trigger('mbButtonDeactivate');
-                } catch (e) {
-                    console.error("Suppressing error from sibling button deactivate handlers", e);
-                }
-            }
-
-            if (!this.active) {
-                this.activate();
-            } else {
-                this.deactivate();
-            }
+            this._super();
         },
         /**
          *
@@ -117,7 +193,6 @@
                               "Tried: ",  deactivateCandidateNames);
             }
             return methodPair;
-
         },
         /**
          * @returns {null|object} the target widget object (NOT the DOM node; NOT a jQuery selection)
@@ -167,6 +242,10 @@
             }
         },
         _initializeHighlightState: function() {
+            // skip logic if already active
+            if (this.active) {
+                return;
+            }
             if (this._initializeTarget() && this.targetWidget.options) {
                 var targetOptions = this.targetWidget.options;
                 var state = targetOptions.autoActivate;         // FeatureInfo style
@@ -186,51 +265,41 @@
                 if (targetOptions.auto_activate) {              // Redlining
                     state = targetOptions.display_type === 'dialog';
                 }
-                this._highlightState = state;
-                this.active = this.active || state;
-            } else {
-                this._highlightState = false;
+                this._setActive(!!state);
             }
-
-            this.updateHighlight();
         },
         /**
          * Calls 'activate' method on target if defined, and if in group, sets a visual highlight
          */
         activate: function () {
+            // defensive activation to prevent redundant state transitions
             if (this.active) {
                 return;
             }
             this._initializeActionMethods();
             if (this.actionMethods.activate) {
                 (this.actionMethods.activate)();
-                this.active = true;
+            } else {
+                console.error("Unknown control method for target widget", this.targetWidget);
             }
-            this._highlightState = this.active || !!this.options.group;
-            this.updateHighlight();
+            this._super();
         },
         /**
          * Clears visual highlighting, marks inactive state and
          * calls 'deactivate' method on target (if defined)
          */
         deactivate: function () {
+            if (!this.active) {
+                // defensive deactivation to prevent unneeded state transitions
+                return;
+            }
             this._initializeActionMethods();
             if (this.actionMethods.deactivate) {
                 (this.actionMethods.deactivate)();
+            } else {
+                console.error("Unknown control method for target widget", this.targetWidget);
             }
-            this.reset();
-        },
-        /**
-         * Clears visual highlighting, marks inactive state
-         */
-        reset: function () {
-            this.active = false;
-            this._highlightState = false;
-            this.updateHighlight();
-        },
-        updateHighlight: function() {
-            this.$toolBarItem.toggleClass("toolBarItemActive", !!this._highlightState);
+            this._super();
         }
     });
-
 })(jQuery);


### PR DESCRIPTION
The purpose of the Mapbender Button is to toggle Elements on and off. Doing this properly can be [a complex task](https://github.com/mapbender/mapbender/issues/1050#issuecomment-463119829).

Some Elements that have nothing at all to do with controlling other Elements are seen to inherit from Button in both the PHP and JavaScript worlds. Most commonly so they blend into the toolbar visually without trying to reinvent the markup for that, and to get the base functionality of a toggling highlight.

Recent changes to the Button as a control device for other Elements have posed compatibility issues for those "I just want to look like a Button" non-controlling Elements.

To resolve this conflict of goals, the Button JavaScript widget has been split, offering a plain, just-for-looks button under the old name `mapbender.mbButton`, while spinning off all functionality related to Element control into a new `mapbender.mbControlButton`.

The decision which to initialize is [based on inheritance](https://github.com/mapbender/mapbender/commit/667336720ab1f607b7c5e64987f7ba67aa357d27#diff-b105db1fc6b43c7f7d1dc8184f651ac5R63):
* If the Button is just _the_ Button, it will be initialized as an `mbControlButton`
* If the Button is a child class of _the_ Button, it will be initialized as an `mbButton`   
  NOTE: of course, any PHP child class of the Button can override get getWidgetName method and thus overrule this logic. We expect most existing Button children already do this anyway.

