### PR TITLE
Fix MapbenderContainerInfo-using widget behaviours in button-style sidepanes

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.container.info.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.container.info.js
@@ -5,16 +5,26 @@
  * @param widget
  * @param options {onactive: function(), oninactive(): function()
  * @author Andriy Oblivantsev <eslider@gmail.com>
+ * @deprecated for lack of separation of concerns
+ * @deprecated because its primary function, activating / deactivating elements,
+ *    only works in 'accordion'-style containers, but not in 'button'-style containers
+ *
+ * We can do element widget activation / deactivation in a safer, more uniform way now,
+ * for that see element-sidepane.js.
  */
 function MapbenderContainerInfo(widget, options) {
     'use strict';
+    this.options = options;
+    if (widget.element) {
+        widget.element.data('MapbenderContainerInfo', this);
+    }
 
     var element = $(widget.element),
         toolBar = element.closest(".toolBar"),
         contentPane = element.closest(".contentPane"),
         sidePane = element.closest(".sidePane"),
-        container = null,
-        lastState = null;
+        container = null
+    ;
 
     if (contentPane.size()) {
         container = contentPane;
@@ -59,42 +69,4 @@ function MapbenderContainerInfo(widget, options) {
     this.getContainer = function () {
         return container;
     };
-
-    function handleByTab(tab) {
-        var tabContent = tab.parent().find("> div")[tab.index() + 1],
-            hasWidget = $(tabContent).find(element).length > 0,
-            state = hasWidget ? 'active' : 'inactive';
-
-        if (lastState === state) {
-            return;
-        }
-
-        if (state === "active") {
-            if (options.onactive) {
-                options.onactive();
-            }
-        } else {
-            if (options.oninactive) {
-                options.oninactive();
-            }
-        }
-
-        lastState = state;
-    }
-
-    if (this.isSidePane()) {
-        var accordion = $(".accordionContainer", sidePane),
-            hasAccordion = accordion.length > 0;
-
-        if (hasAccordion) {
-            var tabs = accordion.find('> div.accordion'),
-                currentTab = accordion.find('> div.accordion.active');
-
-            tabs.on('click', function (e) {
-                var tab = $(e.currentTarget);
-                handleByTab(tab);
-            });
-            handleByTab(currentTab);
-        }
-    }
 }


### PR DESCRIPTION
[MapbenderContainerInfo](https://github.com/mapbender/mapbender/blob/v3.0.7.7/src/Mapbender/CoreBundle/Resources/public/mapbender.container.info.js) was devised as a way to help Elements living in sidepanes reacting to the user switching accordion tabs. Unfortunately, _only_ accordion tabs. Plus a bunch of getters for properties of the container.

This change ties a knot between MapbenderContainerInfo and [the recent attempt at more uniform sidepane element control](https://github.com/mapbender/mapbender/blob/0e0506118f4cd7721c7b258c66a9aba3adc5d0fd/src/Mapbender/CoreBundle/Resources/public/init/element-sidepane.js). MCI instances are punched into the element node data if present, and provisions are made to invoke those callbacks, even though MCI itself no longer does any of this itself.

The immediate benefit is that Element widgets relying on MapbenderContainerInfo now behave properly in a `buttons`-style sidepane. Most prominently, Digitizer now correctly switches itself on and off. This was previously only possible in an `accordion`-style sidepane.
