### PR TITLE
Fix layerset long title overflow, fix broken hover background color change

### DIFF
--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
@@ -39,7 +39,7 @@
       width: 100%;
       .checkWrapper, label {
         color: $secondColor;
-        margin-bottom: 0px;
+        margin-bottom: 0;
         line-height: $lineHeight;
         display: inline;
       }
@@ -48,7 +48,7 @@
         float: none;
       }
       .labelInput {
-        margin-left: 0px;
+        margin-left: 0;
         width: $label;
       }
       div {
@@ -57,26 +57,28 @@
     }
   }
   .choiceExpandedSortable {
-    position: relative;
+    color: $secondColor;
     display: inline-block;
     border: solid 1px lighten($thirdColor, 15%);
     background-color: $contentColor;
     .sortableItem {
-      position: relative;
-      display: block;
-      float: none;
-      clear: both;
-      width: 100%;
-      height: $inputHeight;
-      padding-left: 5px;
+      padding: 0 0.4em;
       cursor: move;
+      line-height: $lineHeight;
       .checkWrapper, label {
-        color: $secondColor;
-        margin-bottom: 0px;
-        line-height: $lineHeight;
-        cursor: move;
+        line-height: inherit;
+        color: inherit;
+        margin: 0;
       }
-      .sortableItem :hover {
+      label {
+        cursor: inherit;
+        width: 92%; // for browser without calc
+        // Width taken by checkbox is exactly $fontSize
+        // No immediate variable refs inside calc(): https://github.com/sass/sass/issues/818
+        width: calc(100% - #{$fontSize} - 2px);  // subtract fontsize (=checkbox width) plus 2 extra pixels for safety
+        padding-left: 0.2em;
+      }
+      &:hover {
         background-color: darken($contentColor, 10%);
       }
     }

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
@@ -1,7 +1,7 @@
 <div class="elementFormMap elementForm">
     {{ form_label(form.title) }}{{ form_widget(form.title) }}
     <div class="clearContainer"></div>
-    {{ form_label(form.configuration.layersets) }}{{ form_widget(form.configuration.layersets) }}
+    {{ form_row(form.configuration.layersets) }}
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.dpi) }}{{ form_widget(form.configuration.dpi) }}
     <div class="clearContainer"></div>


### PR DESCRIPTION
Allows long layerset titles to in the Map Element backend form to take the full width of the container and avoids spillage outside of the container on line breaks.

Before / After image:
![layerset-overflow-1085](https://user-images.githubusercontent.com/24895932/52916896-39cac380-32e5-11e9-9e3f-08d010943e60.png)

The broken CSS declaration for highlighting the hovered item by darkening its background is fixed as well.

Closes #1085.
