### PR TITLE
Fix/redlining srschange support

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -45,6 +45,7 @@
         },
         setupMapEventListeners: function() {
             $(document).on('mbmapsourceadded', this._moveLayerToLayerStackTop.bind(this));
+            $(document).on('mbmapsrschanged', this._onSrsChange.bind(this));
         },
         defaultAction: function(callback){
             this.activate(callback);
@@ -330,6 +331,18 @@
             if (this.layer) {
                 this.map.raiseLayer(this.layer, this.map.getNumLayers());
                 this.map.resetLayersZIndex();
+            }
+        },
+        _onSrsChange: function(event, data) {
+            this._endEdit(null);
+            this._deactivateControl();
+            if (this.layer) {
+                (this.layer.features || []).map(function(feature) {
+                    if (feature.geometry && feature.geometry.transform) {
+                        feature.geometry.transform(data.from, data.to);
+                    }
+                });
+                this.layer.redraw();
             }
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -1190,7 +1190,9 @@ Mapbender.Model = {
         this.mbMap.fireModelEvent({
             name: 'srschanged',
             value: {
-                projection: srs.projection
+                projection: srs.projection,
+                from: oldProj,
+                to: srs.projection
             }
         });
     },


### PR DESCRIPTION
Adds missing survivability of Redlining features on runtime SRS switch.  
Switching SRS deactivates any currently active control, because they were found to break on switching.  
All features are retransformed and redisplayed.