### PR TITLE
Add marker layer support for ImageExport and Print

### DIFF
--- a/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace Mapbender\PrintBundle\Component;
+
+
+use Mapbender\PrintBundle\Component\Export\Box;
+use Mapbender\PrintBundle\Component\Export\ExportCanvas;
+use Mapbender\PrintBundle\Util\GdUtil;
+
+class LayerRendererMarkers extends LayerRenderer
+{
+    /** @var string */
+    protected $imageRoot;
+
+    /**
+     * @param string $imageRoot should be the web root
+     */
+    public function __construct($imageRoot)
+    {
+        $this->imageRoot = $imageRoot;
+    }
+
+    public function squashLayerDefinitions($layerDef, $nextLayerDef, $resolution)
+    {
+        // squash everything
+        $layerDef['markers'] = array_merge($layerDef['markers'], $nextLayerDef['markers']);
+        return $layerDef;
+    }
+
+    public function addLayer(ExportCanvas $canvas, $layerDef, Box $extent)
+    {
+        foreach ($layerDef['markers'] as $markerDef) {
+            $this->addMarker($canvas, $markerDef, $layerDef['opacity']);
+        }
+    }
+
+    protected function addMarker(ExportCanvas $canvas, $markerDef, $opacity)
+    {
+        $image = $this->getMarkerImage($markerDef, $opacity);
+        if ($image) {
+            $transform = $canvas->featureTransform;
+            $transformedCoords = $transform->transformXy($markerDef['coordinates']);
+            $offsetX = $transformedCoords['x'] + $markerDef['offset']['x'] * $transform->lineScale;
+            $offsetY = $transformedCoords['y'] + $markerDef['offset']['y'] * $transform->lineScale;
+            imagecopyresampled($canvas->resource, $image, $offsetX, $offsetY, 0, 0,
+                $markerDef['width'] * $transform->lineScale, $markerDef['height'] * $transform->lineScale,
+                imagesx($image), imagesy($image));
+        }
+    }
+
+    /**
+     * @param array $markerDef
+     * @param float $opacity
+     * @return resource|null
+     */
+    protected function getMarkerImage($markerDef, $opacity)
+    {
+        $markerPath = rtrim($this->imageRoot, '/') . '/' . ltrim($markerDef['path'], '/');
+        $data = file_get_contents($markerPath);
+        if ($data) {
+            $image = imagecreatefromstring($data);
+            if ($image) {
+                if ($opacity <= (1.0 - 1 / 127)) {
+                    $multipliedImage = GdUtil::multiplyAlpha($image, $opacity);
+                    if ($multipliedImage !== $image) {
+                        imagedestroy($image);
+                    }
+                    $image = $multipliedImage;
+                }
+                return $image;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
@@ -46,6 +46,7 @@ class LayerRendererMarkers extends LayerRenderer
             imagecopyresampled($canvas->resource, $image, $offsetX, $offsetY, 0, 0,
                 $markerDef['width'] * $transform->lineScale, $markerDef['height'] * $transform->lineScale,
                 imagesx($image), imagesy($image));
+            imagedestroy($image);
         }
     }
 

--- a/src/Mapbender/PrintBundle/Resources/config/services.xml
+++ b/src/Mapbender/PrintBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
              (c.f. Mapserver's "partial" label rendering settings) -->
         <parameter key="mapbender.imaageexport.renderer.wms.tile_buffer">512</parameter>
         <parameter key="mapbender.imageexport.renderer.geojson.class">Mapbender\PrintBundle\Component\LayerRendererGeoJson</parameter>
+        <parameter key="mapbender.imageexport.renderer.markers.class">Mapbender\PrintBundle\Component\LayerRendererMarkers</parameter>
         <parameter key="mapbender.print.service.class">Mapbender\PrintBundle\Component\PrintService</parameter>
         <!-- print resource / temp dirs are by default == imageexport dirs, but can be changed independently -->
         <parameter key="mapbender.print.resource_dir">%mapbender.imageexport.resource_dir%</parameter>
@@ -47,6 +48,7 @@
             <argument type="collection" key="layerRenderers">
                 <argument key="wms" type="service" id="mapbender.imageexport.renderer.wms" />
                 <argument key="GeoJSON+Style" type="service" id="mapbender.imageexport.renderer.geojson" />
+                <argument key="markers" type="service" id="mapbender.imageexport.renderer.markers" />
             </argument>
             <argument type="service" id="logger" />
         </service>
@@ -59,6 +61,9 @@
             <argument>%mapbender.imaageexport.renderer.wms.max_getmap_size%</argument>
             <argument>%mapbender.imaageexport.renderer.wms.tile_buffer%</argument>
         </service>
+        <service id="mapbender.imageexport.renderer.markers" class="%mapbender.imageexport.renderer.markers.class%">
+            <argument>%kernel.root_dir%/../web</argument>
+        </service>
         <service id="mapbender.imageexport.renderer.geojson" class="%mapbender.imageexport.renderer.geojson.class%">
             <argument>%mapbender.imageexport.resource_dir%/fonts</argument>
         </service>
@@ -66,6 +71,7 @@
             <argument type="collection" key="layerRenderers">
                 <argument key="wms" type="service" id="mapbender.imageexport.renderer.wms" />
                 <argument key="GeoJSON+Style" type="service" id="mapbender.imageexport.renderer.geojson" />
+                <argument key="markers" type="service" id="mapbender.imageexport.renderer.markers" />
             </argument>
             <argument type="service" id="mapbender.imageexport.image_transport.service" />
             <argument type="service" id="mapbender.print.legend_handler.service" />


### PR DESCRIPTION
Mapbender has never rendered marker layers in ImageExport or print.  
Now it does. Here's the familiar pin from the POI Element:  
![poi-marker-in-print](https://user-images.githubusercontent.com/24895932/53385772-e5c47c80-397f-11e9-9624-819f13a2f30a.png)

Supports blended marker layers (opacity << 1), icon offsets, arbitrary dpi scaling.  
Does *not* support icon images located outside of <webroot>/bundles/  
