### PR TITLE
Enh/element inventory service

### DIFF
--- a/src/Mapbender/BaseKernel.php
+++ b/src/Mapbender/BaseKernel.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mapbender;
 
+use Mapbender\CoreBundle\DependencyInjection\Compiler\RebuildElementInventoryPass;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -138,5 +139,12 @@ abstract class BaseKernel extends Kernel
         // intersect instances with deduped keys => instances of same class gone, order preserved
         $keptBundleInstances = array_intersect_key($bundles, $keptBundleClasses);
         return $keptBundleInstances;
+    }
+
+    protected function buildContainer()
+    {
+        $container = parent::buildContainer();
+        $container->addCompilerPass(new RebuildElementInventoryPass($this));
+        return $container;
     }
 }

--- a/src/Mapbender/CoreBundle/Component/ElementCompatibilityChecker.php
+++ b/src/Mapbender/CoreBundle/Component/ElementCompatibilityChecker.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component;
+
+
+class ElementCompatibilityChecker
+{
+    /** @var string[] */
+    protected $movedElementClasses = array(
+        'Mapbender\CoreBundle\Element\PrintClient' => 'Mapbender\PrintBundle\Element\PrintClient',
+    );
+
+    /**
+     * @param string $classNameIn
+     * @return string
+     */
+    public function getAdjustedElementClassName($classNameIn)
+    {
+        if (!empty($this->movedElementClasses[$classNameIn])) {
+            $classNameOut = $this->movedElementClasses[$classNameIn];
+            return $classNameOut;
+        } else {
+            return $classNameIn;
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/ElementFactory.php
+++ b/src/Mapbender/CoreBundle/Component/ElementFactory.php
@@ -105,12 +105,21 @@ class ElementFactory
      */
     protected function instantiateComponent($className, Entity\Element $entity, Application $appComponent)
     {
-        if (!class_exists($className, true)) {
-            throw new Component\Exception\UndefinedElementClassException($className);
+        /** @var ElementCompatibilityChecker $compatService */
+        $compatService = $this->container->get('mapbender.element_compatibility_checker.service');
+        $finalClassName = $compatService->getAdjustedElementClassName($className);
+        // The class_exists call itself may throw, depending on Composer version and promotion of warnings to
+        // Exceptions via Symfony.
+        try {
+            if (!class_exists($finalClassName, true)) {
+                throw new Component\Exception\UndefinedElementClassException($finalClassName);
+            }
+        } catch (\Exception $e) {
+            throw new Component\Exception\UndefinedElementClassException($finalClassName, $e);
         }
-        $instance = new $className($appComponent, $this->container, $entity);
+        $instance = new $finalClassName($appComponent, $this->container, $entity);
         if (!$instance instanceof Component\Element) {
-            throw new Component\Exception\InvalidElementClassException($className);
+            throw new Component\Exception\InvalidElementClassException($finalClassName);
         }
         // @todo: check API conformance and generate deprecation warnings via trigger_error(E_USER_DEPRECATED, ...)
         return $instance;

--- a/src/Mapbender/CoreBundle/Component/ElementFactory.php
+++ b/src/Mapbender/CoreBundle/Component/ElementFactory.php
@@ -105,9 +105,9 @@ class ElementFactory
      */
     protected function instantiateComponent($className, Entity\Element $entity, Application $appComponent)
     {
-        /** @var ElementCompatibilityChecker $compatService */
-        $compatService = $this->container->get('mapbender.element_compatibility_checker.service');
-        $finalClassName = $compatService->getAdjustedElementClassName($className);
+        /** @var ElementInventoryService $inventoryService */
+        $inventoryService = $this->container->get('mapbender.element_inventory.service');
+        $finalClassName = $inventoryService->getAdjustedElementClassName($className);
         // The class_exists call itself may throw, depending on Composer version and promotion of warnings to
         // Exceptions via Symfony.
         try {

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -4,7 +4,7 @@
 namespace Mapbender\CoreBundle\Component;
 
 
-class ElementCompatibilityChecker
+class ElementInventoryService
 {
     /** @var string[] */
     protected $movedElementClasses = array(

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -14,6 +14,10 @@ class ElementInventoryService
     /** @var string[] */
     protected $movedElementClasses = array(
         'Mapbender\CoreBundle\Element\PrintClient' => 'Mapbender\PrintBundle\Element\PrintClient',
+        // see https://github.com/mapbender/data-source/tree/0.1.8/Element
+        'Mapbender\DataSourceBundle\Element\DataManagerElement' => 'Mapbender\DataManagerBundle\Element\DataManagerElement',
+        'Mapbender\DataSourceBundle\Element\DataStoreElement' => 'Mapbender\DataManagerBundle\Element\DataManagerElement',
+        'Mapbender\DataSourceBundle\Element\QueryBuilderElement' => 'Mapbender\QueryBuilderBundle\Element\QueryBuilderElement',
     );
 
     /** @var string[] */

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -4,12 +4,22 @@
 namespace Mapbender\CoreBundle\Component;
 
 
+/**
+ * Maintains inventory of Element Component classes
+ *
+ * Registered in container as mapbender.element_inventory.service
+ */
 class ElementInventoryService
 {
     /** @var string[] */
     protected $movedElementClasses = array(
         'Mapbender\CoreBundle\Element\PrintClient' => 'Mapbender\PrintBundle\Element\PrintClient',
     );
+
+    /** @var string[] */
+    protected $fullInventory = array();
+    /** @var string[] */
+    protected $noCreationClassNames = array();
 
     /**
      * @param string $classNameIn
@@ -23,5 +33,79 @@ class ElementInventoryService
         } else {
             return $classNameIn;
         }
+    }
+
+    /**
+     * @param string[] $classNames
+     */
+    public function setInventory($classNames)
+    {
+        // map value:value to ease array_intersect_key in getActiveInventory
+        $this->fullInventory = array_combine($classNames, $classNames);
+    }
+
+    /**
+     * Marks $classNameTo as the acting replacement for $classNameFrom.
+     *
+     * @param string $classNameFrom
+     * @param string $classNameTo
+     */
+    public function replaceElement($classNameFrom, $classNameTo)
+    {
+        if (!$classNameFrom || !$classNameTo) {
+            throw new \InvalidArgumentException("Empty class name");
+        }
+        if ($classNameFrom == $classNameTo) {
+            throw new \LogicException("Cannot replace {$classNameFrom} with itself");
+        }
+        // support layered replacements
+        while ($inMoved = array_search($classNameFrom, $this->movedElementClasses)) {
+            $this->movedElementClasses[$inMoved] = $classNameTo;
+        }
+        $this->movedElementClasses[$classNameFrom] = $classNameTo;
+        $circular = array_intersect(array_values($this->movedElementClasses), array_keys($this->movedElementClasses));
+        if ($circular) {
+            throw new \LogicException("Circular class replacement detected for " . implode(', ', $circular));
+        }
+    }
+
+    /**
+     * Disables the Element of given $className insofar that it can no longer be added to
+     * any applications.
+     *
+     * @param string $className
+     */
+    public function disableElementCreation($className)
+    {
+        if (!$className) {
+            throw new \InvalidArgumentException("Class name empty");
+        }
+        $this->noCreationClassNames[] = $className;
+        $this->noCreationClassNames = array_unique(array_merge($this->noCreationClassNames));
+    }
+
+    /**
+     * Returns the Element class inventory after taking into account renamed and disabled classes.
+     *
+     * @return string[]
+     */
+    public function getActiveInventory()
+    {
+        $moved = array_intersect_key($this->movedElementClasses, $this->fullInventory);
+        $inventoryCopy = $this->fullInventory + array();
+        foreach ($moved as $original => $replacement) {
+            $inventoryCopy[$original] = $replacement;
+        }
+        return array_unique(array_diff(array_values($inventoryCopy), $this->noCreationClassNames));
+    }
+
+    /**
+     * Returns the full, unmodified Element class inventory advertised by the sum of enabled MapbenderBundles.
+     *
+     * @return string[]
+     */
+    public function getRawInventory()
+    {
+        return array_values($this->fullInventory);
     }
 }

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RebuildElementInventoryPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RebuildElementInventoryPass.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+
+use Mapbender\CoreBundle\Component\ElementInventoryService;
+use Mapbender\CoreBundle\Component\MapbenderBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Initializes the combined inventory of all Mapbender Elements advertised by all active
+ * MapbenderBundles.
+ * Because the kernel is not available to compiler passes initialized from a bundle, this
+ * pass is actually initialized by the BaseKernel itself.
+ *
+ * @see ElementInventoryService::setInventory()
+ * @see BaseKernel::buildContainer()
+ */
+class RebuildElementInventoryPass implements CompilerPassInterface
+{
+    /** @var KernelInterface */
+    protected $kernel;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $allElementClasses = $this->collectElementClassNames($container);
+        $inventoryDefinition = $container->getDefinition('mapbender.element_inventory.service');
+        $inventoryDefinition->addMethodCall('setInventory', array($allElementClasses));
+    }
+
+    protected function collectElementClassNames(ContainerBuilder $container)
+    {
+        $classNameLists = array();
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if ($bundle instanceof MapbenderBundle) {
+                // Bundle may not have a container at this stage but may need it for
+                // configuration access (e.g. see MapbenderWmsBundle)
+                $bundle->setContainer($container);
+                $classNameLists[] = $bundle->getElements() ?: array();
+            }
+        }
+        if ($classNameLists) {
+            $allClassNames = \call_user_func_array('array_merge', $classNameLists);
+            return array_unique(array_values($allClassNames));
+        } else {
+            return array();
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Extension/ElementExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/ElementExtension.php
@@ -2,6 +2,7 @@
 
 namespace Mapbender\CoreBundle\Extension;
 
+use Mapbender\CoreBundle\Component\ElementCompatibilityChecker;
 use Mapbender\CoreBundle\Entity\Element;
 
 /**
@@ -9,7 +10,18 @@ use Mapbender\CoreBundle\Entity\Element;
  */
 class ElementExtension extends \Twig_Extension
 {
-    
+
+    /** @var ElementCompatibilityChecker */
+    protected $compatibilityChecker;
+
+    /**
+     * @param ElementCompatibilityChecker $compatiblityChecker
+     */
+    public function __construct(ElementCompatibilityChecker $compatiblityChecker)
+    {
+        $this->compatibilityChecker = $compatiblityChecker;
+    }
+
     /**
      * @inheritdoc
      */
@@ -36,8 +48,9 @@ class ElementExtension extends \Twig_Extension
     public function element_class_title($element)
     {
         $class = $element->getClass();
-        if(class_exists($class)) {
-            return $class::getClassTitle();
+        $adjustedClass = $this->compatibilityChecker->getAdjustedElementClassName($class);
+        if (class_exists($adjustedClass)) {
+            return $adjustedClass::getClassTitle();
         }
     }
 }

--- a/src/Mapbender/CoreBundle/Extension/ElementExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/ElementExtension.php
@@ -2,7 +2,7 @@
 
 namespace Mapbender\CoreBundle\Extension;
 
-use Mapbender\CoreBundle\Component\ElementCompatibilityChecker;
+use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\CoreBundle\Entity\Element;
 
 /**
@@ -11,15 +11,15 @@ use Mapbender\CoreBundle\Entity\Element;
 class ElementExtension extends \Twig_Extension
 {
 
-    /** @var ElementCompatibilityChecker */
-    protected $compatibilityChecker;
+    /** @var ElementInventoryService */
+    protected $inventoryService;
 
     /**
-     * @param ElementCompatibilityChecker $compatiblityChecker
+     * @param ElementInventoryService $inventoryService
      */
-    public function __construct(ElementCompatibilityChecker $compatiblityChecker)
+    public function __construct(ElementInventoryService $inventoryService)
     {
-        $this->compatibilityChecker = $compatiblityChecker;
+        $this->inventoryService = $inventoryService;
     }
 
     /**
@@ -47,8 +47,8 @@ class ElementExtension extends \Twig_Extension
      */
     public function element_class_title($element)
     {
-        $class = $element->getClass();
-        $adjustedClass = $this->compatibilityChecker->getAdjustedElementClassName($class);
+        $initialClass = $element->getClass();
+        $adjustedClass = $this->inventoryService->getAdjustedElementClassName($initialClass);
         if (class_exists($adjustedClass)) {
             return $adjustedClass::getClassTitle();
         }

--- a/src/Mapbender/CoreBundle/Mapbender.php
+++ b/src/Mapbender/CoreBundle/Mapbender.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityRepository;
 use Mapbender\CoreBundle\Component\Application;
 use Mapbender\CoreBundle\Component\ApplicationYAMLMapper;
 use Mapbender\CoreBundle\Component\Element;
+use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\CoreBundle\Component\MapbenderBundle;
 use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Component\UploadsManager;
@@ -36,9 +37,6 @@ class Mapbender
     /** @var ContainerInterface */
     private $container;
 
-    /** @var Element[] */
-    private $elements = array();
-
     /** @var Template[] */
     private $templates = array();
 
@@ -66,8 +64,6 @@ class Mapbender
             if (!is_subclass_of($bundle, 'Mapbender\CoreBundle\Component\MapbenderBundle')) {
                 continue;
             }
-
-            $this->elements           = array_merge($this->elements, $bundle->getElements());
             $this->templates          = array_merge($this->templates, $bundle->getTemplates());
             $this->repositoryManagers = array_merge($this->repositoryManagers, $bundle->getRepositoryManagers());
         }
@@ -83,7 +79,9 @@ class Mapbender
      */
     public function getElements()
     {
-        return $this->elements;
+        /** @var ElementInventoryService $inventoryService */
+        $inventoryService = $this->container->get('mapbender.element_inventory.service');
+        return $inventoryService->getActiveInventory();
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -27,7 +27,7 @@
         <parameter key="owsproxy.baseroute">owsproxy3_core_owsproxy_entrypoint</parameter>
         <parameter key="mapbender.asset_compiler.service.class">Mapbender\CoreBundle\Asset\AssetFactory</parameter>
         <parameter key="mapbender.application_asset.service.class">Mapbender\CoreBundle\Asset\ApplicationAssetService</parameter>
-        <parameter key="mapbender.element_compatibility_checker.service.class">Mapbender\CoreBundle\Component\ElementCompatibilityChecker</parameter>
+        <parameter key="mapbender.element_inventory.service.class">Mapbender\CoreBundle\Component\ElementInventoryService</parameter>
     </parameters>
 
     <services>
@@ -37,7 +37,7 @@
 
         <service id="mapbender.twig.element_class" class="Mapbender\CoreBundle\Extension\ElementExtension">
             <tag name="twig.extension"/>
-            <argument type="service" id="mapbender.element_compatibility_checker.service" />
+            <argument type="service" id="mapbender.element_inventory.service" />
         </service>
 
         <service id="target_element" class="Mapbender\CoreBundle\Element\Type\TargetElementType">
@@ -186,7 +186,7 @@
             <argument key="debug">%kernel.debug%</argument>
             <argument key="strict">%mapbender.strict.asset.bundle_scopes%</argument>
         </service>
-        <service id="mapbender.element_compatibility_checker.service" class="%mapbender.element_compatibility_checker.service.class%">
+        <service id="mapbender.element_inventory.service" class="%mapbender.element_inventory.service.class%">
             <!-- no arguments; element class changes are added via compiler passes; this is not configurable -->
         </service>
     </services>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -27,6 +27,7 @@
         <parameter key="owsproxy.baseroute">owsproxy3_core_owsproxy_entrypoint</parameter>
         <parameter key="mapbender.asset_compiler.service.class">Mapbender\CoreBundle\Asset\AssetFactory</parameter>
         <parameter key="mapbender.application_asset.service.class">Mapbender\CoreBundle\Asset\ApplicationAssetService</parameter>
+        <parameter key="mapbender.element_compatibility_checker.service.class">Mapbender\CoreBundle\Component\ElementCompatibilityChecker</parameter>
     </parameters>
 
     <services>
@@ -183,6 +184,9 @@
             <argument type="service" id="templating" />
             <argument key="debug">%kernel.debug%</argument>
             <argument key="strict">%mapbender.strict.asset.bundle_scopes%</argument>
+        </service>
+        <service id="mapbender.element_compatibility_checker.service" class="%mapbender.element_compatibility_checker.service.class%">
+            <!-- no arguments; element class changes are added via compiler passes; this is not configurable -->
         </service>
     </services>
 </container>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -37,6 +37,7 @@
 
         <service id="mapbender.twig.element_class" class="Mapbender\CoreBundle\Extension\ElementExtension">
             <tag name="twig.extension"/>
+            <argument type="service" id="mapbender.element_compatibility_checker.service" />
         </service>
 
         <service id="target_element" class="Mapbender\CoreBundle\Element\Type\TargetElementType">

--- a/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
+++ b/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
@@ -4,7 +4,7 @@
 namespace Mapbender\ManagerBundle\Component;
 
 
-use Mapbender\CoreBundle\Component\ElementCompatibilityChecker;
+use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\CoreBundle\Component\ExtendedCollection;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\ManagerBundle\Form\Type\YAMLConfigurationType;
@@ -22,8 +22,8 @@ class ElementFormFactory
 {
     /** @var FormFactoryInterface */
     protected $formFactory;
-    /** @var ElementCompatibilityChecker */
-    protected $compatibilityChecker;
+    /** @var ElementInventoryService */
+    protected $inventoryService;
     /** @var ContainerInterface */
     protected $container;
     /** @var bool */
@@ -31,16 +31,16 @@ class ElementFormFactory
 
     /**
      * @param FormFactoryInterface $formFactory
-     * @param ElementCompatibilityChecker $compatiblityChecker
+     * @param ElementInventoryService $inventoryService
      * @param ContainerInterface $container
      * @param bool $strict
      */
     public function __construct(FormFactoryInterface $formFactory,
-                                ElementCompatibilityChecker $compatiblityChecker,
+                                ElementInventoryService $inventoryService,
                                 ContainerInterface $container, $strict = false)
     {
         $this->formFactory = $formFactory;
-        $this->compatibilityChecker = $compatiblityChecker;
+        $this->inventoryService = $inventoryService;
         $this->container = $container;
         $this->setStrict($strict);
     }
@@ -101,7 +101,7 @@ class ElementFormFactory
      */
     protected function getComponentClass(Element $element)
     {
-        return $this->compatibilityChecker->getAdjustedElementClassName($element->getClass());
+        return $this->inventoryService->getAdjustedElementClassName($element->getClass());
     }
 
     /**

--- a/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
+++ b/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
@@ -4,6 +4,7 @@
 namespace Mapbender\ManagerBundle\Component;
 
 
+use Mapbender\CoreBundle\Component\ElementCompatibilityChecker;
 use Mapbender\CoreBundle\Component\ExtendedCollection;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\ManagerBundle\Form\Type\YAMLConfigurationType;
@@ -21,6 +22,8 @@ class ElementFormFactory
 {
     /** @var FormFactoryInterface */
     protected $formFactory;
+    /** @var ElementCompatibilityChecker */
+    protected $compatibilityChecker;
     /** @var ContainerInterface */
     protected $container;
     /** @var bool */
@@ -28,12 +31,16 @@ class ElementFormFactory
 
     /**
      * @param FormFactoryInterface $formFactory
+     * @param ElementCompatibilityChecker $compatiblityChecker
      * @param ContainerInterface $container
      * @param bool $strict
      */
-    public function __construct(FormFactoryInterface $formFactory, ContainerInterface $container, $strict = false)
+    public function __construct(FormFactoryInterface $formFactory,
+                                ElementCompatibilityChecker $compatiblityChecker,
+                                ContainerInterface $container, $strict = false)
     {
         $this->formFactory = $formFactory;
+        $this->compatibilityChecker = $compatiblityChecker;
         $this->container = $container;
         $this->setStrict($strict);
     }
@@ -67,7 +74,7 @@ class ElementFormFactory
             $configurationType = $this->getFallbackConfigurationFormType($element);
             $twigTemplate = 'MapbenderManagerBundle:Element:yaml-form.html.twig';
         } else {
-            $componentClassName = $element->getClass();
+            $componentClassName = $this->getComponentClass($element);
             $twigTemplate = $componentClassName::getFormTemplate();
         }
 
@@ -90,13 +97,22 @@ class ElementFormFactory
 
     /**
      * @param Element $element
+     * @return string
+     */
+    protected function getComponentClass(Element $element)
+    {
+        return $this->compatibilityChecker->getAdjustedElementClassName($element->getClass());
+    }
+
+    /**
+     * @param Element $element
      * @return FormTypeInterface|null
      * @throws \RuntimeException
      * @throws ServiceNotFoundException
      */
     public function getConfigurationFormType(Element $element)
     {
-        $componentClassName = $element->getClass();
+        $componentClassName = $this->getComponentClass($element);
         $type = $this->getServicyConfigurationFormType($element) ?: ($componentClassName::getType());
         if ($type === null) {
             return null;
@@ -137,7 +153,7 @@ class ElementFormFactory
      */
     protected function getServicyConfigurationFormType(Element $element)
     {
-        $componentClassName = $element->getClass();
+        $componentClassName = $this->getComponentClass($element);
         $typeDeclaration = $componentClassName::getType();
         if (is_string($typeDeclaration) && false !== strpos($typeDeclaration, '.')) {
             return $this->container->get($typeDeclaration);

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -729,25 +729,6 @@ class ApplicationController extends WelcomeController
     }
 
     /**
-     * Collect available elements
-     */
-    private function getElementList()
-    {
-        $available_elements = array();
-        /** @var Mapbender $mapbender */
-        $mapbender = $this->getMapbender();
-        foreach ($mapbender->getElements() as $elementClassName) {
-            $available_elements[$elementClassName] = array(
-                'title' => $elementClassName::getClassTitle(),
-                'description' => $elementClassName::getClassDescription(),
-                'tags' => $elementClassName::getClassTags());
-        }
-        asort($available_elements);
-
-        return $available_elements;
-    }
-
-    /**
      * Merge application, form and template default properties
      *
      * @param Application $application
@@ -853,7 +834,6 @@ class ApplicationController extends WelcomeController
             'aclManager'          => $this->get("fom.acl.manager"),
             'regions'             => $templateClass::getRegions(),
             'slug'                => $slug,
-            'available_elements'  => $this->getElementList(),
             'sources'             => $sources,
             'form'                => $form->createView(),
             'form_name'           => $form->getName(),

--- a/src/Mapbender/ManagerBundle/Controller/ElementController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ElementController.php
@@ -3,6 +3,7 @@ namespace Mapbender\ManagerBundle\Controller;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Mapbender\CoreBundle\Component\ElementFactory;
+use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\ManagerBundle\Component\ElementFormFactory;
 use Mapbender\ManagerBundle\Utils\WeightSortedCollectionUtil;
 use Symfony\Component\Form\FormInterface;
@@ -41,15 +42,15 @@ class ElementController extends Controller
         $application = $this->getMapbender()->getApplicationEntity($slug);
         $template    = $application->getTemplate();
         $region      = $request->get('region');
-        $whitelist   = null;
-        $classNames  = null;
+
+        /** @var ElementInventoryService $inventoryService */
+        $inventoryService = $this->container->get('mapbender.element_inventory.service');
+        $classNames = $inventoryService->getActiveInventory();
 
         // Dirty hack for deprecated Responsive template
         if (method_exists($template, 'getElementWhitelist')) {
             $regionWhitelist = $template::getElementWhitelist();
-            $classNames = $regionWhitelist[$region];
-        } else {
-            $classNames = $this->getMapbender()->getElements();
+            $classNames = array_intersect(array_values($regionWhitelist[$region]), $classNames);
         }
 
         $trans      = $this->container->get('translator');

--- a/src/Mapbender/ManagerBundle/Resources/config/services.xml
+++ b/src/Mapbender/ManagerBundle/Resources/config/services.xml
@@ -12,6 +12,7 @@
     <services>
         <service id="mapbender.manager.element_form_factory.service" class="%mapbender.manager.element_form_factory.service.class%">
             <argument type="service" id="form.factory" />
+            <argument type="service" id="mapbender.element_compatibility_checker.service" />
             <argument type="service" id="service_container" />
             <argument key="strict">%mapbender.strict.element_api.form_type%</argument>
         </service>

--- a/src/Mapbender/ManagerBundle/Resources/config/services.xml
+++ b/src/Mapbender/ManagerBundle/Resources/config/services.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="mapbender.manager.element_form_factory.service" class="%mapbender.manager.element_form_factory.service.class%">
             <argument type="service" id="form.factory" />
-            <argument type="service" id="mapbender.element_compatibility_checker.service" />
+            <argument type="service" id="mapbender.element_inventory.service" />
             <argument type="service" id="service_container" />
             <argument key="strict">%mapbender.strict.element_api.form_type%</argument>
         </service>


### PR DESCRIPTION
Absorbs bundle iteration for Element classes into a new service.  

Adds [a DI compiler entry point to completely replace an Element with another](https://github.com/mapbender/mapbender/blob/9ab9cabfa5dd8ba4c9ce5ddeb5431bf8fcb1e76b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php#L51), thus allowing a project to turn all instances of the base Element into their customized versions automatically.  
The same mechanism can also be used to mark Elements as ~"migrated somewhere else". The service comes with [a built-in curated list of such migrations](https://github.com/mapbender/mapbender/blob/9ab9cabfa5dd8ba4c9ce5ddeb5431bf8fcb1e76b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php#L14).

Adds [a separate DI compiler entry point to prevent creation of specific Element classes](https://github.com/mapbender/mapbender/blob/9ab9cabfa5dd8ba4c9ce5ddeb5431bf8fcb1e76b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php#L76), thus supporting projects that wish to turn off a built-in Element completely, without having to hack any built-in bundle code.
