### PR TITLE
Enh/print labels

### DIFF
--- a/src/Mapbender/PrintBundle/Component/GdCanvas.php
+++ b/src/Mapbender/PrintBundle/Component/GdCanvas.php
@@ -11,9 +11,6 @@ class GdCanvas extends BaseCanvas
     /** @var resource Gdish */
     public $resource;
 
-    /** @var int */
-    protected $transparent;
-
     public function __construct($width, $height)
     {
         $width = intval(round($width));
@@ -25,6 +22,14 @@ class GdCanvas extends BaseCanvas
         $bg = imagecolorallocate($this->resource, 255, 255, 255);
         imagefilledrectangle($this->resource, 0, 0, $width, $height, $bg);
         imagecolordeallocate($this->resource, $bg);
+    }
+
+    /**
+     * @return int GDish representation for fully white but also fully transparent color
+     */
+    public function getTransparent()
+    {
+        return IMG_COLOR_TRANSPARENT;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/GdSubCanvas.php
+++ b/src/Mapbender/PrintBundle/Component/GdSubCanvas.php
@@ -31,14 +31,6 @@ class GdSubCanvas extends GdCanvas
     }
 
     /**
-     * @return int GDish representation for fully white but also fully transparent color
-     */
-    public function getTransparent()
-    {
-        return IMG_COLOR_TRANSPARENT;
-    }
-
-    /**
      * Blends image back onto the parent canvas at the appropriate offset.
      * (see constructor)
      */
@@ -49,6 +41,22 @@ class GdSubCanvas extends GdCanvas
             $this->offsetX, $this->offsetY, 0,0,
             $this->getWidth(), $this->getHeight(),
             $this->getWidth(), $this->getHeight());
+    }
+
+    /**
+     * @return int
+     */
+    public function getOffsetX()
+    {
+        return $this->offsetX;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOffsetY()
+    {
+        return $this->offsetY;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -275,13 +275,7 @@ class LayerRendererGeoJson extends LayerRenderer
         $p[1] = round($p[1]);
 
         if (isset($style['label'])) {
-            // offset text to the right of the point
-            $textXy = array(
-                $p[0] + $resizeFactor * 1.5 * $style['pointRadius'],
-                // center vertically on original y
-                $p[1] + 0.5 * $this->getLabelFontSize($canvas, $style),
-            );
-            $this->drawFeatureLabel($canvas, $style, $style['label'], $textXy);
+            $this->drawFeatureLabel($canvas, $style, $style['label'], $p);
         }
 
         $diameter = max(1, round(2 * $style['pointRadius'] * $resizeFactor));

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -289,10 +289,6 @@ class LayerRendererGeoJson extends LayerRenderer
         $p[0] = round($p[0]);
         $p[1] = round($p[1]);
 
-        if (isset($style['label'])) {
-            $this->drawFeatureLabel($canvas, $style, $style['label'], $p);
-        }
-
         $diameter = max(1, round(2 * $style['pointRadius'] * $resizeFactor));
         if ($style['fillOpacity'] > 0) {
             $color = $this->getColor(
@@ -308,6 +304,9 @@ class LayerRendererGeoJson extends LayerRenderer
                 $this->drawCircleOutline($canvas, $p[0], $p[1], $diameter / 2, $strokeColor, $strokeWidth);
                 imagecolordeallocate($canvas->resource, $strokeColor);
             }
+        }
+        if (!empty($style['label'])) {
+            $this->drawFeatureLabel($canvas, $style, $style['label'], $p);
         }
     }
 

--- a/src/Mapbender/PrintBundle/Util/GdUtil.php
+++ b/src/Mapbender/PrintBundle/Util/GdUtil.php
@@ -56,4 +56,20 @@ class GdUtil
         return $image;
     }
 
+    /**
+     * @param string $fontName
+     * @param float $fontSize
+     * @param string $text
+     * @return float[] width and height (numerically indexed)
+     */
+    public static function getTtfTextSize($fontName, $fontSize, $text)
+    {
+        $labelBbox = imagettfbbox($fontSize, 0, $fontName, $text);
+        $width = $labelBbox[2] - $labelBbox[0];
+        $height = abs($labelBbox[5] - $labelBbox[3]);
+        return array(
+            $width,
+            $height,
+        );
+    }
 }


### PR DESCRIPTION
Mapbender has only ever printed / exported the labels generated in Redlining, with hand-tailored position calculations.  
This pull adds general support for labels in export and print. Labels now work on full suite of features ((Multi)Polygon, (Multi)LineString and Point). Positioning is based on calculated centroids. Label alignment and offset styles are taken into account. It also adds the missing support for font opacity (via compositing).

Newly supported / evaluated label-relevant styles include:
* `labelAlign`, all 9 potential values
* `labelXOffset`
* `labelYOffset`
* `fontOpacity`
* `labelOutlineOpacity`

([Reference](http://dev.openlayers.org/releases/OpenLayers-2.13.1/docs/files/OpenLayers/Feature/Vector-js.html#OpenLayers.Feature.Vector.Constants))

Browser view:  
![labels-browser](https://user-images.githubusercontent.com/24895932/53402437-07d6f280-39b2-11e9-91e9-4c469bddd372.png)

Resulting print:  
![labels-printed](https://user-images.githubusercontent.com/24895932/53402464-11605a80-39b2-11e9-953b-27b541f3d9b4.png)
