### PR TITLE
Fix WmsInstanceEntityHandler not respecting toggle settings

### DIFF
--- a/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceEntityHandler.php
@@ -78,8 +78,8 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
             ->setPriority($num)
             ->setSourceItem($layersourceroot)
             ->setSourceInstance($this->entity)
-            ->setToggle(false)
-            ->setAllowtoggle(true);
+            ->setToggle(!isset($configuration["toggle"]) ? false : $configuration["toggle"])
+            ->setAllowtoggle(!isset($configuration["allowtoggle"]) ? true : $configuration["allowtoggle"]);
         $this->entity->addLayer($rootInstLayer);
         foreach ($configuration["layers"] as $layerDef) {
             $num++;
@@ -116,7 +116,9 @@ class WmsInstanceEntityHandler extends SourceInstanceEntityHandler
                 ->setParent($rootInstLayer)
                 ->setSourceItem($layersource)
                 ->setSourceInstance($this->entity)
-                ->setAllowinfo($layerInst->getInfo() !== null && $layerInst->getInfo() ? true : false);
+                ->setAllowinfo($layerInst->getInfo() !== null && $layerInst->getInfo() ? true : false)
+                ->setToggle(!isset($layerDef["toggle"]) ? null : $layerDef["toggle"])
+                ->setAllowtoggle(!isset($layerDef["allowtoggle"]) ? null : $layerDef["allowtoggle"]);
             $rootInstLayer->addSublayer($layerInst);
             $this->entity->addLayer($layerInst);
         }


### PR DESCRIPTION
Just like in a database-based application, this fix allows toggleable root- and sublayers via yaml configuration.

![image](https://user-images.githubusercontent.com/6780575/53860921-cb734a00-3fe2-11e9-93fd-30dff7ff201a.png)

vs.

```yaml
osm:
    class: Mapbender\WmsBundle\Entity\WmsInstance
    title: OSM Demo
    url: https://osm-demo.wheregroup.com/service
    version: 1.3.0
    layers:
        30: { name: osm,    title : Germany OSM Demo WhereGroup,  visible: false, toggle: false, allowtoggle: true }
    info_format: text/html
    visible: true
    format: image/png
    transparent: true
    tiled: true
    opacity: 100
    toggle: false
    allowtoggle: true
```