### PR TITLE
#31 Fehler beim Aktivieren von Ebenen wird die Zeit nicht gesetzt

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -377,8 +377,8 @@ Mapbender.Model = {
         if (url) {
             source.configuration.options.url = url;
             var mqLayer = this.map.layersList[source.mqlid];
+            mqLayer.olLayer.url = url;
             if (mqLayer.olLayer.getVisibility()) {
-                mqLayer.olLayer.url = url;
                 if (reload) {
                     mqLayer.olLayer.redraw();
                 }


### PR DESCRIPTION
Fehler beim Aktivieren von neuen Ebenen wird die richtige Zeit nicht genommen.
Ursaches des Problemes:
der Url wird in 2 properties gespeichert:
- mqLayer.olLayer.url
- source.configuration.options.url

Jedes mal die Zeit im Feature Dimensions von den Benutzer geändert wird, wird NUR source.configuration.options.url mit dem neue Zeit angepasst (wenn der Checkbox im LayerTree nicht selected ist).
mqLayer.olLayer.url behaltet leider den alten Wert (und wird dieser Wert bunutzt um das WMS aufzurufen), wenn der Benutzer die Sichtbarkeit von einen Layer in LayerTree geändert ist.