### PR TITLE
Allow empty wms instance layer titles, use source layer titles as fallbacks

### DIFF
--- a/src/Mapbender/CoreBundle/Entity/SourceInstanceItem.php
+++ b/src/Mapbender/CoreBundle/Entity/SourceInstanceItem.php
@@ -15,7 +15,7 @@ abstract class SourceInstanceItem
 
     /**
      *
-     * @var SourceInstance a source instance
+     * @var SourceItem
      */
     protected $sourceItem;
 

--- a/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
+++ b/src/Mapbender/WmsBundle/Component/WmsInstanceLayerEntityHandler.php
@@ -194,7 +194,7 @@ class WmsInstanceLayerEntityHandler extends SourceInstanceItemEntityHandler
             "priority" => $entity->getPriority(),
             "name" => $sourceItem->getName() !== null ?
                 $sourceItem->getName() : "",
-            "title" => $entity->getTitle(),
+            "title" => $entity->getTitle() ?: $entity->getSourceItem()->getTitle(),
             "queryable" => $entity->getInfo(),
             "style" => $entity->getStyle(),
             "minScale" => $entity->getMinScale(true),

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -18,6 +18,7 @@ use Mapbender\CoreBundle\Entity\SourceInstance;
  * @ORM\Entity(repositoryClass="WmsInstanceLayerRepository")
  * @ORM\Table(name="mb_wms_wmsinstancelayer")
  * @ORM\HasLifeCycleCallbacks()
+ * @property WmsLayerSource $sourceItem
  */
 class WmsInstanceLayer extends SourceInstanceItem
 {
@@ -177,7 +178,7 @@ class WmsInstanceLayer extends SourceInstanceItem
     /**
      * Get title
      *
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -623,7 +624,6 @@ class WmsInstanceLayer extends SourceInstanceItem
     {
         $this->setSourceInstance($instance);
         $this->setSourceItem($layerSource);
-        $this->setTitle($layerSource->getTitle());
 
         $this->setMinScale($layerSource->getMinScale());
         $this->setMaxScale($layerSource->getMaxScale());

--- a/src/Mapbender/WmsBundle/Form/EventListener/FieldSubscriber.php
+++ b/src/Mapbender/WmsBundle/Form/EventListener/FieldSubscriber.php
@@ -55,6 +55,13 @@ class FieldSubscriber implements EventSubscriberInterface
         if (null === $data) {
             return;
         }
+        $form->remove('title');
+        $form->add('title', 'text', array(
+            'required' => false,
+            'attr' => array(
+                'placeholder' => $data->getSourceItem()->getTitle(),
+            ),
+        ));
 
         if ($data->getSublayer()->count() > 0) {
             $form->remove('toggle');


### PR DESCRIPTION
WMS instance layers with an empty title now fall back to the name of the source layer, which (only) changes if / when the source is reloaded.  
This fallback source title is used in the frontend (Layertree, Legend) if the instance layer does not have an explicitly overrridden name.  
This fallback source layer title is also displayed via the related text input's `placeholder` attribute in the instance backend, so if you empty the text field(s) completely, you can see the effective value.  
Because instance layer titles now have an appropriate fallback, instance creation logic is changed to no longer copy the layer source's title onto the instance layer. I.e. they stay empty by default, and the source layer's title applies.

The resulting layer titles on a freshly minted instance are equal to the previous behaviour of copying _until_ you either reload the source or enter an instance layer title manually.

If the administrator modifies an instance layer title explicitly, that value will remain even when the source is reloaded.  
If the admininstrator _doesn't_ explicitly replace an instance layer title, the title of that layer will automatically follow updates to the source's layer title(s) which may happen on reloading the source.  
The administrator can go back and forth between these two behaviours (sticky value vs auto-follow source) by simply entering a title (=sticky) or clearing a title (=auto follow) on a per-layer basis.
