### PR TITLE
Fix/adopt fom dependencies

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/AssetFactory.php
+++ b/src/Mapbender/CoreBundle/Asset/AssetFactory.php
@@ -35,6 +35,8 @@ class AssetFactory extends AssetFactoryBase
         '@FOMCoreBundle/Resources/public/js/widgets/radiobuttonExtended.js' => '@MapbenderCoreBundle/Resources/public/widgets/radiobuttonExtended.js',
         '@FOMCoreBundle/Resources/public/js/widgets/collection.js' => '@MapbenderManagerBundle/Resources/public/form/collection.js',
         '@FOMCoreBundle/Resources/public/js/components.js' => '@MapbenderManagerBundle/Resources/public/components.js',
+        '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js' => '@MapbenderCoreBundle/Resources/public/widgets/sidepane.js',
+        '@FOMCoreBundle/Resources/public/js/frontend/tabcontainer.js' => '@MapbenderCoreBundle/Resources/public/widgets/tabcontainer.js',
     );
 
     /**

--- a/src/Mapbender/CoreBundle/Asset/AssetFactory.php
+++ b/src/Mapbender/CoreBundle/Asset/AssetFactory.php
@@ -24,6 +24,18 @@ class AssetFactory extends AssetFactoryBase
     protected $templateEngine;
 
     /**
+     * Mark assets as moved, so refs can be rewritten
+     * This is a ~curated list, currently not intended for configurability.
+     * @var string[]
+     */
+    protected $migratedRefs = array(
+        '@FOMCoreBundle/Resources/public/js/widgets/checkbox.js' => '@MapbenderCoreBundle/Resources/public/widgets/checkbox.js',
+        '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js' => '@MapbenderCoreBundle/Resources/public/widgets/dropdown.js',
+        '@FOMCoreBundle/Resources/public/js/widgets/popup.js' => '@MapbenderCoreBundle/Resources/public/widgets/fom-popup.js',
+        '@FOMCoreBundle/Resources/public/js/widgets/radiobuttonExtended.js' => '@MapbenderCoreBundle/Resources/public/widgets/radiobuttonExtended.js',
+    );
+
+    /**
      * @param FileLocatorInterface $fileLocator
      * @param string $webDir
      * @param EngineInterface $templateEngine

--- a/src/Mapbender/CoreBundle/Asset/AssetFactory.php
+++ b/src/Mapbender/CoreBundle/Asset/AssetFactory.php
@@ -33,6 +33,8 @@ class AssetFactory extends AssetFactoryBase
         '@FOMCoreBundle/Resources/public/js/widgets/dropdown.js' => '@MapbenderCoreBundle/Resources/public/widgets/dropdown.js',
         '@FOMCoreBundle/Resources/public/js/widgets/popup.js' => '@MapbenderCoreBundle/Resources/public/widgets/fom-popup.js',
         '@FOMCoreBundle/Resources/public/js/widgets/radiobuttonExtended.js' => '@MapbenderCoreBundle/Resources/public/widgets/radiobuttonExtended.js',
+        '@FOMCoreBundle/Resources/public/js/widgets/collection.js' => '@MapbenderManagerBundle/Resources/public/form/collection.js',
+        '@FOMCoreBundle/Resources/public/js/components.js' => '@MapbenderManagerBundle/Resources/public/components.js',
     );
 
     /**

--- a/src/Mapbender/CoreBundle/Asset/AssetFactoryBase.php
+++ b/src/Mapbender/CoreBundle/Asset/AssetFactoryBase.php
@@ -15,6 +15,8 @@ class AssetFactoryBase
     /** @var FileLocatorInterface */
     protected $fileLocator;
 
+    protected $migratedRefs = array();
+
     /**
      * @param FileLocatorInterface $fileLocator
      * @param string $webDir
@@ -23,6 +25,16 @@ class AssetFactoryBase
     {
         $this->fileLocator = $fileLocator;
         $this->webDir = $webDir;
+    }
+
+    protected function getDebugHeader($finalPath, $originalRef)
+    {
+        return "\n"
+            . "/** \n"
+            . "  * BEGIN NEW ASSET INPUT -- {$finalPath}\n"
+            . "  * (original reference: {$originalRef})\n"
+            . "  */\n"
+        ;
     }
 
     /**
@@ -47,7 +59,7 @@ class AssetFactoryBase
                 $uniqueKey = str_replace(array('@', 'Resources/public/'), '', $input);
                 $uniqueKey = str_replace(array('/', '.', '-'), '__', $uniqueKey);
                 if ($debug) {
-                    $debugInfo = "\n/** BEGIN NEW ASSET INPUT -- {$realAssetPath} (original reference: {$input}) */\n";
+                    $debugInfo = $this->getDebugHeader($realAssetPath, $input);
                     $uniqueAssets["{$uniqueKey}+dbgInfo"] = new StringAsset($debugInfo);
                 }
                 $uniqueAssets[$uniqueKey] = $fileAsset;
@@ -66,6 +78,9 @@ class AssetFactoryBase
      */
     protected function locateAssetFile($input)
     {
+        while (!empty($this->migratedRefs[$input])) {
+            $input = $this->migratedRefs[$input];
+        }
         return $this->fileLocator->locate($this->getSourcePath($input));
     }
 

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RewriteFormThemeCompilerPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/RewriteFormThemeCompilerPass.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RewriteFormThemeCompilerPass implements CompilerPassInterface
+{
+    /** @var string, twig template reference */
+    protected $fromTheme;
+    /** @var string, twig template reference */
+    protected $toTheme;
+
+    public function __construct($fromTheme, $toTheme)
+    {
+        $this->fromTheme = $fromTheme;
+        $this->toTheme = $toTheme;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->patchTwigThemes($container, $this->fromTheme, $this->toTheme);
+        $this->patchResourceReferenceArray($container, 'twig.form.resources', $this->fromTheme, $this->toTheme);
+    }
+
+    public static function patchTwigThemes(ContainerBuilder $container, $from, $to)
+    {
+        $definition = $container->getDefinition('twig');
+        $initializer = $definition->getArgument(1);
+        if (array_key_exists('form_themes', $initializer)) {
+            $themeConfig = &$initializer['form_themes'];
+            foreach (array_keys($themeConfig) as $index) {
+                if ($themeConfig[$index] === $from) {
+                    $themeConfig[$index] = $to;
+                }
+            }
+            $initializer['form_themes'] = $themeConfig;
+        }
+        $definition->replaceArgument(1, $initializer);
+    }
+
+    public static function patchResourceReferenceArray(ContainerBuilder $container, $parameterKey, $from, $to)
+    {
+        $parameterValue = $container->getParameter($parameterKey);
+        foreach (array_keys($parameterValue) as $index) {
+            if ($parameterValue[$index] == $from) {
+                $parameterValue[$index] = $to;
+            }
+        }
+        $container->setParameter($parameterKey, $parameterValue);
+    }
+}

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -5,6 +5,7 @@ use Mapbender\CoreBundle\Component\MapbenderBundle;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\ContainerUpdateTimestampPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\MapbenderYamlCompilerPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\ProvideBrandingPass;
+use Mapbender\CoreBundle\DependencyInjection\Compiler\RewriteFormThemeCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -36,6 +37,10 @@ class MapbenderCoreBundle extends MapbenderBundle
         }
         $container->addCompilerPass(new ContainerUpdateTimestampPass());
         $container->addCompilerPass(new ProvideBrandingPass());
+
+        $formThemeOldLocation = 'FOMCoreBundle:Form:fields.html.twig';
+        $formThemeNewLocation = 'MapbenderCoreBundle:form:fields.html.twig';
+        $container->addCompilerPass(new RewriteFormThemeCompilerPass($formThemeOldLocation, $formThemeNewLocation));
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/checkbox.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/checkbox.js
@@ -1,0 +1,44 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/widgets
+ */
+var initCheckbox = function(){
+    var me = $(this);
+    var parent = me.parent(".checkWrapper");
+
+    if(me.is(":checked")){
+        parent.addClass("iconCheckboxActive");
+    }else{
+        parent.removeClass("iconCheckboxActive");
+    }
+
+    if(me.is(":disabled")){
+        parent.addClass("checkboxDisabled");
+    }else{
+        parent.removeClass("checkboxDisabled");
+    }
+};
+$(function(){
+    var toggleCheckBox = function(){
+        var me = $(this);
+        var checkbox = me.find(".checkbox");
+
+        if(checkbox.is(":disabled")){
+            me.addClass("checkboxDisabled");
+        }else{
+            if(checkbox.is(":checked")){
+                me.removeClass("iconCheckboxActive");
+                checkbox.get(0).checked = false;
+            }else{
+                me.addClass("iconCheckboxActive");
+                checkbox.get(0).checked = true;
+            }
+        }
+
+        checkbox.trigger('change');
+    };
+    $('.checkbox').each(function(){
+        initCheckbox.call(this);
+    });
+    $(document).on("click", ".checkWrapper", toggleCheckBox);
+});

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
@@ -1,0 +1,72 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/widgets
+ */
+var initDropdown = function () {
+    var me = $(this);
+    var dropdownList = me.find(".dropdownList");
+    if (dropdownList.children().length === 0) {
+        me.find("option").each(function (i, e) {
+            $(e).addClass("opt-" + i);
+            var node = $('<li class="item-' + i + '"></li>');
+            dropdownList.append(node);
+            node.text($(e).text());
+        });
+    }
+    var select = me.find("select").val();
+    me.find(".dropdownValue").text(me.find('option[value="'+select+'"]').text())
+};
+$(function () {
+    // init dropdown list --------------------------------------------------------------------
+
+    var toggleList = function () {
+        var me = $(this);
+        var list = me.find(".dropdownList");
+        var opts = me.find(".hiddenDropdown");
+        if (list.css("display") == "block") {
+            list.hide();
+        } else {
+            $(".dropdownList").hide();
+            list.show();
+            list.find("li").one("click", function (event) {
+                event.stopPropagation();
+                list.hide().find("li").off("click");
+                var me2 = $(this);
+                var opt = me2.attr("class").replace("item", "opt");
+                me.find(".dropdownValue").text(me2.text());
+                var val = opts.find("." + opt).prop("selected", true).val();
+                opts.val(val).trigger('change');
+            })
+        }
+
+        $(document).one("click", function () {
+            list.hide().find("li").off("mouseout").off("click");
+        });
+        return false;
+    }
+    $('.dropdown').each(function () {
+        initDropdown.call(this);
+    });
+    $(document).on("click", ".dropdown", toggleList);
+    $(document).on('mousewheel scroll DOMMouseScroll', '.dropdownList', function(e) {
+        var delta = e.originalEvent.detail;
+        var height = this.scrollTopMax;
+        var atTop = this.scrollTop === 0;
+        var atBottom = this.scrollTop === this.scrollTopMax;
+
+        if (!this.scrollTopMax) {
+            atBottom = this.scrollHeight === this.clientHeight + this.scrollTop;
+        }
+        if (e.originalEvent.deltaY) {
+            delta = e.originalEvent.deltaY;
+        }
+        if (e.originalEvent.wheelDelta) {
+            delta = -e.originalEvent.wheelDelta;
+        }
+        if (atTop && delta < 0 || atBottom && delta > 0) {
+            return false;
+        }
+        return undefined;
+    });
+
+});

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/fom-popup.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/fom-popup.js
@@ -1,0 +1,655 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/widgets
+ */
+
+/**
+ * FOM Popup
+ * Deprecated. Does not work without Mapbender CSS and is used exclusively in Mapbender.
+ *
+ * Mapbender will receive its own popup widget implementation so the multitude of interdependent
+ * markup-vs-css issues can be fixed in one place.
+ *
+ * This popup is not a jQuery UI widget, as thus would require to have the DOM
+ * setup before. Instead you call the Mapbender.Popup constructor with a options
+ * object and a JavaScript object will be created which knows it's own DOM,
+ * ready to be used.
+ *
+ * Everything can be configured at the start or set to a new value later on
+ * (except for the DOM template which is fixed after initialization).
+ *
+ * For all available default options which can be overriden in the constructor
+ * options, see the Popup.prototype.defaults object.
+ *
+ * Content can be a variety of things:
+ *   - Simple string
+ *   - DOM Node
+ *   - jQuery wrapped DOM nodes
+ *   - Ajax promise
+ *   - A array of all the above
+ *
+ * Events available on the element which you can get with .getElement:
+ *   - open    - before opening the dialog
+ *   - opened  - after the dialog has fully openend
+ *   - focus   - after the dialog becomes an focus
+ *   - close   - before closing the dialog
+ *   - closed  - after the dialog has been fully closed
+ *   - destroy - just before the popup is destroyed. Last dance, anyone?
+ *
+ * @TODOs:
+ *   - CSS for following classes:
+ *     - noTitle
+ *     - noSubTitle
+ *     - ajax content
+ *     - ajaxWaiting content
+ *     - ajaxFailed content
+ */
+(function($) {
+    var counter = 0;
+    var currentZindex = 10000;
+    /**
+     * Popup constructor.
+     *
+     * @param  {Object} options   Non-Default Options
+     * @return {Popup}  Popup instance
+     */
+    var Popup = function(options) {
+        var self = this;
+
+        // Create final options
+        this.options = $.extend({}, this.defaults, options);
+
+        // Create DOM element
+        this.$element = $(this.options.template)
+            .attr('id', 'mbpopup-' + counter++);
+
+        // use the options mechanism to set up most of the things
+        $.each(this.options, function(key, value) {
+            // Skip options which already have been used or have to be used late
+            if(key == 'template' || key == 'autoOpen') {
+                return;
+            }
+
+            self.option(key, value);
+        });
+
+        // focused on popup click
+        self.$element.on("click", $.proxy(self.focus, self));
+
+        // Open if required
+        if(this.options.autoOpen) {
+            this.open();
+        }
+    };
+
+    Popup.prototype = {
+        // Reference to the created popup
+        $element: null,
+
+        // Containing element
+        $container: $('body'),
+
+        /**
+         * Default options
+         * @type {Object}
+         */
+        defaults: {
+            template: [
+                '<div class="popupContainer fom-popup-container">',
+                '  <div class="popup fom-popup">',
+                '    <div class="popupHead">',
+                '      <span class="popupTitle"></span>',
+                '      <span class="popupSubTitle"></span>',
+                '      <span class="popupClose right iconCancel iconBig"></span>',
+                '    </div>',
+                '    <div class="popupScroll">',
+                '      <div class="clear popupContent"></div>',
+                '    </div>',
+                '    <div class="popupButtons"></div>',
+                '    <div class="clearContainer"></div>',
+                '  </div>',
+                '  <div class="overlay"></div>',
+                '</div>'].join("\n"),
+
+            // Is popup draggable (showHeader must be true)
+            draggable: false,
+            // Resizable, you can pass true or an object of resizable options
+            resizable: false,
+
+            header: true,
+            closeButton: true,
+
+            autoOpen: true,
+            closeOnESC: true,
+            detachOnClose: true,
+            closeOnOutsideClick: false,
+            closeOnPopupCloseClick: true,
+            destroyOnClose: false,
+            modal: true,
+
+            // Width, if not set, use custom CSS for cssClass
+            width: null,
+            // Height, if not set, use custom CSS for cssClass
+            height: null,
+            // CSS class(es) to give to popup
+            cssClass: null,
+
+            title: null,
+            subtitle: null,
+            // Content, can be simple string, DOM nodes, jQuery nodes or Ajax
+            content: null,
+
+            // Buttons, object with key which becomes identifier, label and
+            // callback
+            buttons: {
+                'ok': {
+                    label: 'Ok',
+                    callback: function() {
+                        this.close();
+                    }
+                }
+            }
+        },
+
+        option: function(key, value) {
+            var popup = $('.popup', this.$element.get(0));
+
+            switch(key) {
+                case 'header':
+                    if(undefined === value) {
+                        return this.options[key];
+                    }
+                    var header = $('.popupHead', this.$element.get(0));
+
+                    if(value) {
+                        header.removeClass('hidden');
+                    } else {
+                        header.addClass('hidden');
+                    }
+                break;
+
+                case 'closeButton':
+                    if(undefined === value) {
+                        return this.options[key];
+                    }
+                    if(value) {
+                        popup.removeClass('noCloseButton');
+                    } else {
+                        popup.addClass('noCloseButton');
+                    }
+                break;
+
+                // Some simple setter/getter options
+                case 'destroyOnClose':
+                    if(undefined === value) {
+                        return this.options[key];
+                    } else {
+                        this.options[key] = value;
+                    }
+                break;
+
+                case 'detachOnClose':
+                    if(undefined === value) {
+                        return this.options[key];
+                    } else {
+                        this.options[key] = value;
+                    }
+                break;
+
+                default:
+                    var fct = this[key];
+                    if(typeof fct == 'function') {
+                        this[key](value);
+                    } else {
+                        if(window.console) {
+                            console.error('No accessor for "' + key + '"');
+                        }
+                    }
+            }
+        },
+
+        /**
+         * Open the popup, optionally giving new content.
+         * This will insert the popup into the container.
+         *
+         * @param  {mixed}  content  New content, if any
+         */
+        open: function(content) {
+            var self = this;
+            var selfElement = this.$element;
+
+            if(content) {
+                this.content(content);
+            }
+
+            selfElement.trigger('open');
+            if(!this.options.detachOnClose || !$.contains(document, selfElement[0])) {
+                selfElement.appendTo(this.$container);
+            }
+            window.setTimeout(function() {
+                self.focus();
+                selfElement.trigger('openend');
+            }, 100);
+        },
+
+        /**
+         * Focus the popup.
+         * This will show popup on top.
+         *
+         * @fires "focus"
+         */
+        focus: function (event) {
+          var self = this;
+          var selfElement = this.$element;
+          selfElement.css("z-index",++currentZindex);
+          if(!event) {
+            // Only trigger event this method was called programmatically.
+            selfElement.trigger('focus');
+          }
+        },
+
+        /**
+         * Close the popup, removing it from the container.
+         * If the token passed with the close event returns
+         * true for the cancel property, closing the popup
+         * will be aborted.
+         */
+        close: function() {
+            var selfElement = this.$element;
+
+            var token = { cancel: false };
+            selfElement.trigger('close', token);
+            if(token.cancel) {
+              return;
+            }
+
+            selfElement.removeClass("show");
+            if(this.options.detachOnClose || this.options.destroyOnClose) {
+                selfElement.detach();
+            }
+            if(this.options.destroyOnClose) {
+                this.destroy();
+            }
+            selfElement.trigger('closed');
+        },
+
+        /**
+         * Destructor.
+         */
+        destroy: function() {
+            if(this.$element){
+                this.$element.trigger('destroy');
+                this.$element.remove();
+                this.$element = null;
+            }
+        },
+
+        /**
+         * Set or get buttons
+         * @param  {Object} buttons, null unsets, undefined gets
+         * @return {[type]}
+         */
+        buttons: function(buttons) {
+            if(undefined === buttons) {
+                return this.options.buttons;
+            }
+
+            if(null === buttons) {
+                $('.popupButtons', this.$element.get(0)).empty();
+            } else {
+                this.addButtons(buttons);
+            }
+            this.options.buttons = buttons;
+        },
+
+        addButtons: function(buttons, offset) {
+            var self = this,
+                buttonset = $('');
+
+            $.each(buttons, function(key, conf) {
+                var button = $('<a/>', {
+                    href: '#' + self.$element.attr('id') + '/button/' + key,
+                    html: conf.label
+                });
+
+                if(conf.cssClass) {
+                    button.addClass(conf.cssClass);
+                }
+
+                if(conf.callback) {
+                    button.on('click', function(event) {
+                        event.preventDefault();
+                        conf.callback.call(self, event);
+                    });
+                }
+
+                buttonset = buttonset.add(button);
+            });
+
+            // @todo use offset if given
+            $('.popupButtons', this.$element.get(0)).append(buttonset);
+        },
+
+        /**
+         * Set or get title
+         * @param  {string} title, null unsets, undefined gets
+         * @return {string}
+         */
+        title: function(title) {
+            var titleNode = $('.popupTitle', this.$element.get(0));
+
+            if(undefined === title) {
+                return this.options.title;
+            }
+
+            if(null === title) {
+                titleNode.empty().addClass("hidden");
+            } else {
+                titleNode.html(title);
+            }
+            this.options.title = title;
+        },
+
+        /**
+         * Set or get subtitle
+         * @param  {string} subtitle, null unsets, undefined gets
+         * @return {string}
+         */
+        subtitle: function(subtitle) {
+            var subtitleNode = $('.popupSubTitle', this.$element.get(0));
+
+            if(undefined === subtitle) {
+                return this.options.subtitle;
+            }
+
+            if(null === subtitle) {
+                subtitleNode.empty();
+            } else {
+                subtitleNode.html(subtitle);
+            }
+            this.options.subtitle = subtitle;
+        },
+
+        /**
+         * Set or get modal
+         * @param  {boolean} state, undefined gets
+         * @return {boolean}
+         */
+        modal: function(state) {
+            if(undefined === state) {
+                return this.options.modal;
+            }
+
+            if(state){
+              this.$element.addClass("modal");
+            }else{
+              this.$element.removeClass("modal");
+            }
+
+            this.options.modal = state;
+        },
+
+
+        /**
+         * Set or get resizable status
+         * @param {mixed} state, undefined gets, true or false sets state, an object of options for jQuery UI resizable
+         *                can also be passed
+         * @return {boolean}
+         */
+        resizable: function(state) {
+            if(undefined === state) {
+                return this.options.resizable;
+            }
+
+            if(state) {
+                $('.popup', this.$element).resizable($.isPlainObject(state) ? state : null);
+            } else {
+                var popup = $('.popup', this.$element);
+                if(popup.data('uiResizable')) {
+                    popup.resizable('destroy');
+                }
+            }
+        },
+
+
+        /**
+         * Set or get closeOnESC
+         * @param  {boolean} state, undefined gets
+         * @return {boolean}
+         */
+        closeOnESC: function(state) {
+            if(undefined === state) {
+                return this.options.closeOnESC;
+            }
+
+            if(state) {
+                var that = this;
+                $(document).on("keyup", function(e){
+                  if(e.keyCode == 27) that.close();
+                });
+            }
+
+            this.options.closeOnESC = state;
+        },
+
+
+        /**
+         * Set or get closeOnPopupCloseClick
+         * @param  {boolean} state, undefined gets
+         * @return {boolean}
+         */
+        closeOnPopupCloseClick: function(state) {
+            if(undefined === state) {
+                return this.options.closeOnPopupCloseClick;
+            }
+
+            if(state){
+                $('.popupClose', this.$element.get(0)).on('click', $.proxy(this.close, this));
+                $('.popupClose', this.$element.get(0)).removeClass('hidden');
+            }else{
+                $('.popupClose', this.$element.get(0)).off('click');
+                $('.popupClose', this.$element.get(0)).addClass('hidden');
+            }
+
+            this.options.closeOnPopupCloseClick = state;
+        },
+
+        /**
+         * Set or get closeOnOutsideClick
+         * @param  {boolean} state, undefined gets
+         * @return {boolean}
+         */
+        closeOnOutsideClick: function(state) {
+            if(undefined === state) {
+                return this.options.closeOnOutsideClick;
+            }
+
+            if(state){
+                $('.overlay', this.$element.get(0)).on('click', $.proxy(this.close, this));
+            }else{
+                $('.overlay', this.$element.get(0)).off('click');
+            }
+
+            this.options.closeOnOutsideClick = state;
+        },
+
+        /**
+         * Set or get draggable
+         * @param  {boolean} state, undefined gets
+         * @return {boolean}
+         */
+        draggable: function(state) {
+            var widget = this;
+            var options = widget.options;
+            var element = widget.$element;
+
+            if(!state) {
+                return options.draggable;
+            }
+
+            element.on('openend', function() {
+                var marginLeft = 100;
+                var marginTop = 80;
+                var popupContainer = $(">.popup", element);
+                var document = $("body");
+                element.draggable({
+                    handle:      $('.popupHead', element),//, //,
+                    containment: [
+                        -marginLeft,
+                        -marginTop,
+                        document.width() - popupContainer.width() - marginLeft,
+                        document.height() - popupContainer.height() - marginTop]
+                });
+            });
+
+            options.draggable = state;
+        },
+
+        /**
+         * Set or get contents
+         *
+         * Contents may be:
+         *   - simple string
+         *   - DOM Nodes
+         *   - jQuery wrappend DOM nodes
+         *   - Ajax promise
+         *   - Array of all the above
+         *
+         * @param  {mixed} content
+         */
+        content: function(content) {
+            if(undefined === content) {
+                return this.contents;
+            }
+
+            if($.isArray(content)) {
+                for(var i=0; i < content.length; i++) {
+                    this.addContent(content[i], 0 === i);
+                }
+            } else {
+                this.addContent(content, true);
+            }
+        },
+
+        /**
+         * Add content. Can be string, DOM node, jQuery node or Ajax
+         * @param  {mixed}    content     Content
+         * @param  {boolean}  emptyFirst  Empty content container before adding
+         */
+        addContent: function(content, emptyFirst) {
+            var contentContainer = $('.popupContent', this.$element.get(0));
+
+            if(emptyFirst) {
+                this.contents = [];
+                contentContainer.empty();
+            }
+
+            this.contents.push(content);
+
+            var contentItem = $('<div class="contentItem"/>');
+
+            var elementPrototype = typeof HTMLElement !== "undefined"
+                                   ? HTMLElement : Element;
+
+            if(typeof content === 'string') {
+                // parse into HTM first
+                contentItem.append($('<p>', {
+                    'html': content,
+                    'class': 'clear'
+                }));
+            } else if(content instanceof elementPrototype) {
+                contentItem.append(content);
+            } else if(content instanceof $) {
+                contentItem.append(content);
+            } else if(undefined !== content.readyState) {
+                // Ajax can be finished or not
+                if(4 === content.readyState) {
+                    // If finished, insert result or failure notice
+                    if(200 == content.status) {
+                        contentItem.append(content.responseText);
+                    } else {
+                        contentItem
+                            .addClass('ajax ajaxFailed')
+                            .html('Ajax failed.');
+                    }
+                } else {
+                    // If not finished, insert placeholder and wait until
+                    // request has returned
+                    contentItem
+                        .addClass('ajax ajaxWaiting')
+                        .html('Loading...');
+                    content
+                        .done(function(responseText, state, jqXHR) {
+                            contentItem
+                                .empty()
+                                .append(responseText)
+                                .removeClass('ajaxWaiting');
+
+                        })
+                        .fail(function(jqXHR, state, message) {
+                            contentItem
+                            .empty()
+                            .append(message)
+                            .removeClass('ajaxWaiting')
+                            .addClass('ajaxFailed');
+                        });
+                }
+            }
+            contentContainer.append(contentItem);
+        },
+
+        /**
+         * Set or get popup width.
+         * @param  {mixed}  width, null will unset
+         */
+        width: function(width) {
+            var popup = $('.popup', this.$element.get(0));
+
+            if(undefined === width) {
+                return this.options.width;
+            }
+
+            popup.css('width', (null === width ? '' : width));
+        },
+
+        /**
+         * Set popup height.
+         * @param  {mixed}  height, any falsy value will unset height
+         */
+        height: function(height) {
+            var popup = $('.popup', this.$element.get(0));
+
+            if(undefined === height) {
+                return this.options.height;
+            }
+
+            popup.css('height', (null === height ? '' : height));
+        },
+
+        /**
+         * Set or get css class on popup
+         * @param  {string}  cssClass, null unsets, undefined gets
+         */
+        cssClass: function(cssClass) {
+            var popup = $('.popup', this.$element.get(0));
+
+            if(undefined === cssClass) {
+                return this.options.cssClass;
+            }
+
+            if(null === cssClass) {
+                popup.removeClass(this.options.cssClass);
+            } else {
+                popup.addClass(cssClass);
+            }
+            this.options.cssClass = cssClass;
+        }
+    };
+
+    window.FOM = window.FOM || {};
+    window.FOM.Popup2 = Popup;
+    if (!window.Mapbender || !window.Mapbender.Popup2) {
+        window.Mapbender = window.Mapbender || {};
+        window.Mapbender.Popup2 = FOM.Popup2;
+    }
+})(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/radiobuttonExtended.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/radiobuttonExtended.js
@@ -1,0 +1,66 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/widgets
+ */
+var initRadioButton = function(nullable, newIcon) {
+    var me = $(this);
+    var parent = me.parent(".radioWrapper");
+    if (nullable) {
+        parent.attr('data-nullable', true);
+    }
+    if(newIcon){
+        var def = parent.attr('data-icon') ? parent.attr('data-icon') : "iconRadio";
+        parent.removeClass(def).removeClass(def + "Activ").attr("data-icon", newIcon).addClass(newIcon);
+    }
+    if (me.is(":checked")) {
+        parent.addClass(parent.attr('data-icon') + "Active");
+    } else {
+        parent.removeClass(parent.attr('data-icon') + "Active");
+    }
+
+    if (me.is(":disabled")) {
+        parent.addClass("radioboxDisabled");
+    } else {
+        parent.removeClass("radioboxDisabled");
+    }
+    if(!parent.attr("title") && parent.parent().find('label[for="'+me.attr('id')+'"]').text()){
+        parent.attr("title", parent.parent().find('label[for="'+me.attr('id')+'"]').text());
+    }
+};
+$(function() {
+    var toggleRadioBox = function() {
+        var me = $(this);
+        var radiobox = me.find(".radiobox");
+        $('input[type="radio"][name="' + radiobox.attr('name') + '"]').each(function() {
+            var rdb = $(this);
+            var rbgwrp = rdb.parents('.radioWrapper:first');
+            var nullable = rbgwrp.attr("data-nullable");
+            if (rdb.is(":disabled")) {
+                rbgwrp.addClass("radioboxDisabled");
+            } else {
+                if (rdb.attr('id') === radiobox.attr('id')) {
+                    if (nullable) {
+                        if (rdb.is(":checked")) {
+                            rbgwrp.removeClass(rbgwrp.attr('data-icon') + "Active");
+                            rdb.get(0).checked = false;
+                        } else {
+                            rbgwrp.addClass(rbgwrp.attr('data-icon') + "Active");
+                            rdb.get(0).checked = true;
+                        }
+                    } else {
+                        rbgwrp.addClass(rbgwrp.attr('data-icon') + "Active");
+                        rdb.get(0).checked = true;
+                    }
+                } else {
+                    rbgwrp.removeClass(rbgwrp.attr('data-icon') + "Active");
+                    rdb.get(0).checked = false;
+                }
+            }
+        });
+        radiobox.trigger('change');
+    };
+    $('.radiobox').each(function() {
+        initRadioButton.call(this);
+    });
+    $(document).on("click", ".radioWrapper", toggleRadioBox);
+});

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -1,0 +1,78 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/frontend
+ */
+$(function() {
+
+    var switchButton = $(".toggleSideBar");
+    var sidePane = switchButton.closest("div.sidePane");
+    var templateWrapper = $('.templateWrapper');
+    var speed = 300;
+    var animation = {};
+
+    sidePane.data('isOpened', true);
+
+    sidePane.css({
+        '-webkit-transition': 'none !important',
+        '-moz-transition':    'none !important',
+        '-o-transition':      'none !important',
+        '-ms-transition':     'none !important',
+        'transition':         'none !important'
+    });
+
+    // closing bugfix
+    sidePane.width(sidePane.width());
+
+    if(sidePane.data('closed')) {
+        sidePane.data('isOpened', false);
+        sidePane.find('.sideContent').css('display', 'none');
+        sidePane.css({
+            'transition': 'none'
+        });
+
+        if(sidePane.hasClass("right")) {
+            sidePane.css({right: (sidePane.outerWidth(true) * -1) + "px"});
+        } else {
+            sidePane.css({left: (sidePane.outerWidth(true) * -1) + "px"});
+        }
+
+    }
+    sidePane.width(sidePane.width());
+    sidePane.show(0);
+
+    switchButton.on('click', function() {
+        var isOpened = sidePane.data('isOpened');
+        var align = sidePane.hasClass('right') ? 'right' : 'left';
+        var onProgress = function(now, fx) {
+            sidePane.trigger("animate");
+        };
+        if(isOpened) {
+            animation[align] = "-" + sidePane.outerWidth(true) + "px"; //, "swing"];
+
+            sidePane.animate(animation, {
+                duration: speed,
+                progress: onProgress,
+                complete: function() {
+                    templateWrapper.removeClass("sidePaneOpened");
+                    sidePane.data('isOpened', !isOpened);
+                    sidePane.find('.sideContent').css('display', 'none');
+                    sidePane.trigger("animate");
+                    sidePane.trigger("switchSidepane");
+                }
+            });
+        } else {
+            templateWrapper.addClass("sidePaneOpened");
+            animation[align] = "0px";
+            sidePane.find(".sideContent").css('display', 'block');
+            sidePane.animate(animation, {
+                duration: speed,
+                progress: onProgress,
+                complete: function() {
+                    sidePane.data('isOpened', !isOpened);
+                    sidePane.trigger("animate");
+                    sidePane.trigger("switchSidepane");
+                }
+            });
+        }
+    });
+});

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/tabcontainer.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/tabcontainer.js
@@ -1,0 +1,79 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/frontend
+ */
+var initTabContainer = function ($context) {
+
+    $(".tabContainer, .tabContainerAlt").on('click', '.tab', function () {
+        var me = $(this);
+        me.parent().parent().find(".active").removeClass("active");
+        me.addClass("active");
+        $("#" + me.attr("id").replace("tab", "container")).addClass("active");
+    });
+
+    var accordion = $.extend($(".accordionContainer", $context), {
+        hasOutsideScroll: function() {
+            return this.parent().height() < this.height();
+        },
+        updateHeight:       function() {
+            var contentCells = $("> .container-accordion > .accordion-cell", this);
+            var tabCells = $("> .accordion", this);
+            var tabCellsHeight = this.parent().height();
+
+            $.each(tabCells, function(idx, el) {
+                var tabCell = $(el);
+                tabCellsHeight -= tabCell.height();
+            });
+            contentCells.height(tabCellsHeight);
+        }
+    });
+
+    // IE Scroll BugFix
+    if(accordion.hasOutsideScroll()){
+        accordion.updateHeight();
+        $(window).on('resize', $.proxy(accordion.updateHeight, accordion));
+    }
+
+    accordion.on('click', '.accordion', function(event) {
+        var me = $(this);
+        var tab = $(event.delegateTarget);
+        var isActive = me.hasClass('active');
+
+        if(isActive) {
+            return;
+        }
+
+        var previous = tab.find("> .active");
+        previous.removeClass("active");
+
+        if(me.hasClass('accordion')) {
+            if(isActive) {
+                me.removeClass('active');
+            } else {
+                me.addClass('active');
+                $("#" + me.attr("id").replace("accordion", "container"), tab).addClass("active");
+            }
+        } else {
+            me.addClass("active");
+            $("#" + me.attr("id").replace("tab", "container"), tab).addClass("active");
+        }
+
+        me.trigger('selected', {
+            current:    me,
+            currentTab: tab,
+            previous:   previous
+        });
+    });
+
+    accordion.bind('select', function(e, title) {
+        return $(e.currentTarget).find('.accordion > .tablecell:contains("' + title + '")').trigger('click');
+    });
+
+    accordion.data('ready',true);
+    accordion.trigger('ready');
+};
+
+$(function () {
+    // init tabcontainers --------------------------------------------------------------------
+    initTabContainer($('body'));
+});

--- a/src/Mapbender/CoreBundle/Resources/views/Welcome/list.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Welcome/list.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ "mb.manager.admin.applications" | trans }}{% endblock %}
 

--- a/src/Mapbender/CoreBundle/Resources/views/form/fields.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/form/fields.html.twig
@@ -1,0 +1,522 @@
+{#
+ Default Mapbender form theme
+ Migrated to Mapbender from FOM v3.0.6.3
+ See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/views/Form/
+#}
+
+{% block form_widget %}
+  {% spaceless %}
+    {% if compound %}
+      {{ block('form_widget_compound') }}
+    {% else %}
+      {{ block('form_widget_simple') }}
+    {% endif %}
+  {% endspaceless %}
+{% endblock form_widget %}
+
+{% block form_widget_simple %}
+  {% spaceless %}
+    {% set type = type|default('text') %}
+
+    {% if type != 'hidden'%}
+      <div class="inputWrapper {{ block('widget_attribute_class') }}">
+        {% spaceless %}
+          <input class="{% if type != 'file' %}input validationInput{% endif %}" {{block('widget_attributes')}} type="{{ type }}" {% if value is not empty %}value="{{ value }}" {% endif %}/>
+
+          {% if errors|length > 0 %}
+            <span class="validationMsgBox smallText">
+              {% for error in errors %}
+                {{
+                  error.messagePluralization is null
+                  ? error.messageTemplate|trans(error.messageParameters, 'validators')
+                  : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
+                }}
+              {% endfor %}
+            </span>
+          {% endif %}
+        {% endspaceless %}
+      </div>
+
+    {% else %}
+      <input class="hidden" {{block('widget_attributes')}} type="{{ type }}" {% if value is not empty %}value="{{ value }}" {% endif %}/>
+    {% endif %}
+  {% endspaceless %}
+{% endblock form_widget_simple %}
+
+{% block form_widget_compound %}
+  {% spaceless %}
+    <div {{ block('widget_container_attributes') }}>
+      {% if form.vars.prototype is defined  and form.vars.allow_add is defined %}
+      <a href="#add" class="collectionAdd iconAdd iconSmall"></a>
+      {% endif %}
+      {% if form.parent and 'allow_delete' in form.parent.vars | keys and form.parent.vars['allow_delete'] %}
+        <a href="#delete" class="collectionRemove iconSmall iconRemove"></a>
+      {% endif %}
+
+      {% if form.parent is empty %}
+      {{ form_errors(form) }}
+      {% endif %}
+      {{ block('form_rows') }}
+      {{ form_rest(form) }}
+    </div>
+
+  {% endspaceless %}
+{% endblock form_widget_compound %}
+
+{% block collection_widget %}
+  {% spaceless %}
+    {% if prototype is defined %}
+      {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
+      {% endif %}
+      {% if allow_delete %}
+      {% set attr = attr|merge({'data-allow-delete': 1 }) %}
+      {% endif %}
+      {{ block('form_widget') }}
+    {% endspaceless %}
+{% endblock collection_widget %}
+
+{% block textarea_widget %}
+  <div class="inputWrapper {{ block('widget_attribute_class') }}">
+    {% spaceless %}
+      <textarea class="input validationInput" {{ block('widget_attributes') }}>{{ value }}</textarea>
+      {% if errors|length > 0 %}
+        <span class="validationMsgBox smallText">
+          {% for error in errors %}
+            {{
+              error.messagePluralization is null
+              ? error.messageTemplate|trans(error.messageParameters, 'validators')
+              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
+            }}
+          {% endfor %}
+        </span>
+      {% endif %}
+    {% endspaceless %}
+  </div>
+{% endblock textarea_widget %}
+
+{% block choice_widget %}
+  {% spaceless %}
+    {% if expanded %}
+      {% if form.vars.attr is defined and form.vars.attr['data-sortable'] is defined %}
+        {{ block('choice_widget_expanded_sortable') }}
+      {% else %}
+        {{ block('choice_widget_expanded') }}
+      {% endif %}
+    {% else %}
+      {{ block('choice_widget_collapsed') }}
+    {% endif %}
+  {% endspaceless %}
+{% endblock choice_widget %}
+
+{% block choice_widget_expanded %}
+  {% spaceless %}
+  <div {{ block('widget_container_attributes') }}>
+    {% for child in form %}
+    {{ form_widget(child) }}
+    {{ form_label(child) }}
+    {% endfor %}
+  </div>
+  {% endspaceless %}
+{% endblock choice_widget_expanded %}
+
+{% block choice_widget_expanded_sortable %}
+  {% spaceless %}
+  <div class="{{ form.vars.attr['data-sortable'] }}" {{ block('widget_container_attributes') }}>
+    {% for child in form %}
+      <div class="sortableItem">
+        {{ form_widget(child) }}
+        {{ form_label(child) }}
+      </div>
+    {% endfor %}
+  </div>
+  {% endspaceless %}
+{% endblock choice_widget_expanded_sortable %}
+
+{% block choice_widget_collapsed %}
+  {% spaceless %}
+    {% if multiple %}
+      <select {{ block('widget_attributes') }} multiple="multiple">
+        {% if empty_value is not none %}
+          <option value="">{{ empty_value|trans({}, translation_domain) }}</option>
+        {% endif %}
+        {% if preferred_choices|length > 0 %}
+          {% set options = preferred_choices %}
+          {{ block('choice_widget_options') }}
+          {% if choices|length > 0 and separator is not none %}
+            <option disabled="disabled">{{ separator }}</option>
+          {% endif %}
+        {% endif %}
+        {% set options = choices %}
+        {{ block('choice_widget_options') }}
+      </select>
+    {% else %}
+      <div class="dropdown {{ block('widget_attribute_class') }}" >
+        {% set selectedValue = "" %}
+        {% set firstValue = "" %}
+
+        <select class="hiddenDropdown" {{ block('widget_attributes') }}>
+          {% if empty_value is defined and empty_value is not none %}
+            <option class="opt-0" selected="selected" value="">{{ empty_value|trans({}, translation_domain) }}</option>
+            {% set selectedValue = empty_value|trans({}, translation_domain) %}
+          {% endif %}
+
+          {% for choice in choices %}
+
+            {% if loop.index == 1 %}
+              {% set firstValue = choice.label %}
+            {% endif %}
+
+            {% if choice is selectedchoice(value) %}
+              {% set selectedValue = choice.label|trans({}, translation_domain) %}
+            {% endif %}
+
+            <option class="opt-{{ loop.index }}" {% if choice is selectedchoice(value) %} selected="selected" {% endif %} value="{{ choice.value }}">{{ choice.label|trans({}, translation_domain) }}</option>
+          {% endfor %}
+        </select>
+
+        <div class="dropdownValue iconDown">
+          {% if selectedValue|length == 0 %}
+            {% if empty_value is defined and empty_value is not none %}
+              {{ empty_value|trans({}, translation_domain) }}
+            {% else %}
+              {{ firstValue }}
+            {% endif %}
+          {% else %}
+            {{ selectedValue }}
+          {% endif %}
+        </div>
+        <ul class="dropdownList">
+          {% if empty_value is defined and empty_value is not none %}
+            <li class="item-0" value="">{{ empty_value|trans({}, translation_domain) }}</li>
+          {% endif %}
+          {% for choice in choices %}
+            <li class="item-{{ loop.index }}">{{ choice.label|trans({}, translation_domain) }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock choice_widget_collapsed %}
+
+{% block checkbox_widget %}
+  {% spaceless %}
+    <div class="checkWrapper left iconCheckbox{% if checked %} iconCheckboxActive{% endif %} {% if disabled %} checkboxDisabled{% endif %}" data-icon="iconCheckbox">
+      <input class="checkbox" type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    </div>
+  {% endspaceless %}
+{% endblock checkbox_widget %}
+
+{% block radio_widget %}
+  {% spaceless %}
+    <div class="radioWrapper left iconRadio{% if checked %} iconRadioActive{% endif %} {% if disabled %} radioboxDisabled{% endif %}" data-icon="iconRadio">
+      <input class="radiobox" type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    </div>
+  {% endspaceless %}
+{% endblock radio_widget %}
+
+{% block datetime_widget %}
+  {% spaceless %}
+    {% if widget == 'single_text' %}
+      {{ block('form_widget_simple') }}
+    {% else %}
+      <div {{ block('widget_container_attributes') }}>
+        {{ form_errors(form.date) }}
+        {{ form_errors(form.time) }}
+        {{ form_widget(form.date) }}
+        {{ form_widget(form.time) }}
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock datetime_widget %}
+
+{% block date_widget %}
+  {% spaceless %}
+    {% if widget == 'single_text' %}
+      {{ block('form_widget_simple') }}
+    {% else %}
+      <div {{ block('widget_container_attributes') }}>
+        {{ date_pattern|replace({
+        '{{ year }}':  form_widget(form.year),
+        '{{ month }}': form_widget(form.month),
+        '{{ day }}':   form_widget(form.day),
+      })|raw }}
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock date_widget %}
+
+{% block time_widget %}
+  {% spaceless %}
+    {% if widget == 'single_text' %}
+      {{ block('form_widget_simple') }}
+    {% else %}
+      <div {{ block('widget_container_attributes') }}>
+        {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock time_widget %}
+
+{% block number_widget %}
+  {% spaceless %}
+    {# type="number" doesn't work with floats #}
+    {% set type = type|default('text') %}
+    {{ block('form_widget_simple') }}
+  {% endspaceless %}
+{% endblock number_widget %}
+
+{% block integer_widget %}
+  {% spaceless %}
+    {% set type = type|default('number') %}
+    {{ block('form_widget_simple') }}
+  {% endspaceless %}
+{% endblock integer_widget %}
+
+{% block money_widget %}
+  {% spaceless %}
+    {{ money_pattern|replace({ '{{ widget }}': block('form_widget_simple') })|raw }}
+  {% endspaceless %}
+{% endblock money_widget %}
+
+{% block url_widget %}
+  {% spaceless %}
+    {% set type = type|default('url') %}
+    {{ block('form_widget_simple') }}
+  {% endspaceless %}
+{% endblock url_widget %}
+
+{% block search_widget %}
+  {% spaceless %}
+    {% set type = type|default('search') %}
+      {{ block('form_widget_simple') }}
+    {% endspaceless %}
+{% endblock search_widget %}
+
+{% block percent_widget %}
+  {% spaceless %}
+    {% set type = type|default('text') %}
+    {{ block('form_widget_simple') }} %
+  {% endspaceless %}
+{% endblock percent_widget %}
+
+{% block password_widget %}
+  {% spaceless %}
+    {% set type = type|default('password') %}
+    {{ block('form_widget_simple') }}
+    <div class="clearContainer"></div>
+  {% endspaceless %}
+{% endblock password_widget %}
+
+{% block hidden_widget %}
+  {% spaceless %}
+    {% set type = type|default('hidden') %}
+    {{ block('form_widget_simple') }}
+  {% endspaceless %}
+{% endblock hidden_widget %}
+
+{% block email_widget %}
+  {% spaceless %}
+    {% set type = type|default('email') %}
+    {{ block('form_widget_simple') }}
+  {% endspaceless %}
+{% endblock email_widget %}
+
+
+
+
+{# Labels #}
+
+{% block form_label %}
+  {% spaceless %}
+    {% if not compound %}
+      {% set label_attr = label_attr|merge({'for': id}) %}
+    {% endif %}
+    {% if required %}
+      {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+    {% endif %}
+    {% if label is empty %}
+      {% set label = name|humanize %}
+    {% endif %}
+    <label class="labelInput" {% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}{% if required %}<span class="required">*</span>{% endif %}</label>
+  {% endspaceless %}
+{% endblock form_label %}
+
+
+
+
+{# Rows #}
+
+{% block repeated_row %}
+  {% spaceless %}
+  {#
+  No need to render the errors here, as all errors are mapped
+  to the first child (see RepeatedTypeValidatorExtension).
+  #}
+  {{ block('form_rows') }}
+  {% endspaceless %}
+{% endblock repeated_row %}
+
+{% block form_row %}
+  {% spaceless %}
+    <div {% if 'collection' in form.parent.vars['block_prefixes'] %}class="collectionItem"{% endif %}>
+      {{ form_label(form) }}
+      {{ form_widget(form) }}
+
+    </div>
+  {% endspaceless %}
+{% endblock form_row %}
+
+{% block hidden_row %}
+  {{ form_widget(form) }}
+{% endblock hidden_row %}
+
+{# Misc #}
+
+{% block form_enctype %}
+  {% spaceless %}
+    {% if multipart %}enctype="multipart/form-data"{% endif %}
+  {% endspaceless %}
+{% endblock form_enctype %}
+
+{% block form_rest %}
+  {% spaceless %}
+    {% for child in form %}
+      {% if not child.rendered %}
+        {{ form_row(child) }}
+      {% endif %}
+    {% endfor %}
+  {% endspaceless %}
+{% endblock form_rest %}
+
+{% block acl_widget %}
+  {% spaceless %}
+
+    {% set prototype = form_widget(form.ace.vars.prototype) %}
+    <table id="listFilterPermission" class="listFilterContainer clear permissionsTable tableCore {% if form.ace|length == 0 %}hidePermissions{% endif %}">
+      <thead id="permissionsHead" data-prototype="{{ prototype }}">
+        <tr class="doNotFilter">
+          <th>
+            <label for="inputFilterPermission" class="labelInput left">{{"fom.core.fields.filter"|trans}}</label>
+            <input id="inputFilterPermission" type="text" class="input left listFilterInput"/>
+          </th>
+          {% for child in form.ace.vars.prototype %}
+            {% if child.vars.attr.class is defined %}
+              <th>
+                <div id="{{ child.vars.attr.class }}" class="headTagWrapper smallText {{ child.vars.attr.class }}">{{ child.vars.attr.class }}</div>
+              </th>
+            {% endif %}
+          {% endfor %}
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="permissionsBody">
+        {% for ace in form.ace %}
+          {{ form_widget(ace) }}
+        {% endfor %}
+      </tbody>
+    </table>
+
+    {% if form.ace|length == 0 %}
+      <p id="permissionsDescription" class="description left">{{"fom.core.fields.no_user_group_defined"|trans}}</p>
+    {% endif %}
+    <div class="clearContainer"></div>
+  {% endspaceless %}
+{% endblock %}
+
+{% block aclElement_widget %}
+  {% spaceless %}
+
+    {% set prototype = form_widget(form.ace.vars.prototype) %}
+    <table class="clear permissionsElementTable tableCore {% if form.ace|length == 0 %}hidePermissions{% endif %}">
+      <thead id="permissionsElementHead" data-prototype="{{ prototype }}">
+        <tr>
+          {% for child in form.ace.vars.prototype %}
+            {% if child.vars.attr.class is defined %}
+              <th>
+                <div id="{{ child.vars.attr.class }}" class="headTagWrapper smallText {{ child.vars.attr.class }}">{{ child.vars.attr.class }}</div>
+              </th>
+            {% endif %}
+          {% endfor %}
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="permissionsElementBody">
+        {% for ace in form.ace %}
+          {{ form_widget(ace) }}
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="clearContainer"></div>
+  {% endspaceless %}
+{% endblock %}
+
+{% block tagbox_widget %}
+  {% spaceless %}
+    <div data-perm-type="{{ form.vars.attr.class }}" class="checkWrapper smallText {{ form.vars.attr.class }} {% if form.vars.checked %} iconCheckboxActive {% endif %}">
+      {{ form.vars.attr.class }}
+      <input class="checkbox" type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    </div>
+  {% endspaceless %}
+{% endblock tagbox_widget %}
+
+{% block ace_widget %}
+  {% spaceless %}
+    <tr class="filterItem" {{ block('widget_container_attributes') }}>
+      {% for child in form %}
+        <td>
+          {% if child.vars.block_prefixes.1 == "text" %}
+              <div class="{% if child.vars.value|slice(0, 1) == "u" %}iconUser {% else %} iconGroup{% endif %} userType">
+              <span class="labelInput">{{ child.vars.value|slice(2)|split(':')|first }}</span>
+            </div>
+            {{ form_widget(child) }}
+          {% else %}
+              {% if child.vars.attr.class is defined %}
+                {{ form_widget(child) }}
+              {% endif %}
+          {% endif %}
+        </td>
+      {% endfor %}
+      <td class="iconColumn">
+        <span class="iconRemove removeUserGroup iconSmall"></span>
+      </td>
+    </tr>
+  {% endspaceless %}
+{% endblock %}
+
+
+
+
+
+{# Support #}
+
+{% block form_rows %}
+  {% spaceless %}
+    {% for child in form %}
+      {{ form_row(child) }}
+     <div class="clearContainer"></div>
+    {% endfor %}
+  {% endspaceless %}
+{% endblock form_rows %}
+
+{% block widget_attributes %}
+  {% spaceless %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
+    {% for attrname, attrvalue in attr %}{% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
+  {% endspaceless %}
+{% endblock widget_attributes %}
+
+{% block widget_container_attributes %}
+  {% spaceless %}
+    {% if id is not empty %}id="{{ id }}" {% endif %}
+    {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
+  {% endspaceless %}
+{% endblock widget_container_attributes %}
+
+{% block widget_attribute_class %}
+  {% set cssClass = block('widget_attributes')|split('class') %}
+
+  {# Get the class attribute from widget_attributes #}
+  {% if cssClass[1] is defined%}
+    {{ cssClass[1]|replace({'"': '', '=':''}) }}
+  {% endif %}
+{% endblock widget_attribute_class %}

--- a/src/Mapbender/ManagerBundle/Controller/IndexController.php
+++ b/src/Mapbender/ManagerBundle/Controller/IndexController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Mapbender\ManagerBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use FOM\ManagerBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Manager index controller.
+ * Redirects to first menu item.
+ * Provides menu via twig "render controller" construct.
+ *
+ * Copied into Mapbender from FOM v3.0.6.3
+ * see https://github.com/mapbender/fom/blob/v3.0.6.3/src/FOM/ManagerBundle/Controller/ManagerController.php
+ *
+ * @author Christian Wygoda
+ * @todo: render menu via twig extension + runtime https://symfony.com/doc/3.4/templating/twig_extension.html#creating-lazy-loaded-twig-extensions
+ */
+class IndexController extends Controller
+{
+    /**
+     * Simply redirect to the applications list.
+     *
+     * @Route("/")
+     * @Method("GET")
+     */
+    public function indexAction()
+    {
+        $controllers = $this->getManagerControllersDefinition();
+        return $this->redirect($this->generateUrl($controllers[0]['route']));
+    }
+
+    /**
+     * Renders the navigation menu
+     *
+     * @Template
+     * @param Request $request
+     * @return array
+     */
+    public function menuAction(Request $request)
+    {
+        $current_route = $request->attributes->get('_route');
+        $menu          = $this->getManagerControllersDefinition();
+
+        $this->setActive($menu, $current_route);
+
+        return array('menu' => $menu);
+    }
+
+    /**
+     * @param $routes
+     * @param $currentRoute
+     * @return bool
+     */
+    private function setActive(&$routes, $currentRoute) {
+        if(empty($routes)) return false;
+
+        $return = false;
+
+        foreach ($routes as &$route) {
+            if($currentRoute === $route['route']) {
+                $route['active'] = true;
+                $return = true;
+            }
+
+            if(isset($route['subroutes']) && $this->setActive($route['subroutes'], $currentRoute)) {
+                $route['active'] = true;
+                $return = true;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * @param $container
+     */
+    protected function pruneSubroutes(&$container)
+    {
+        if(is_array($container) && array_key_exists('subroutes', $container)) {
+            foreach($container['subroutes'] as $idx2 => &$route) {
+                if(array_key_exists('enabled', $route)) {
+                    $closure = $route['enabled'];
+                    if(!$closure($this->get('security.authorization_checker'))) {
+                        unset($container['subroutes'][$idx2]);
+                        continue;
+                    }
+                }
+                $this->pruneSubroutes($route);
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getManagerControllersDefinition()
+    {
+        $manager_controllers = array();
+        foreach($this->get('kernel')->getBundles() as $bundle) {
+            if(is_subclass_of($bundle, 'FOM\ManagerBundle\Component\ManagerBundle')) {
+                $controllers = $bundle->getManagerControllers();
+                if($controllers) {
+                    foreach($controllers as $idx => &$controller) {
+                        // Remove disabled main routes
+                        if(array_key_exists('enabled', $controller)) {
+                            $closure = $controller['enabled'];
+                            if(!$closure($this->get('security.authorization_checker'))) {
+                                unset($controllers[$idx]);
+                                continue;
+                            }
+                        }
+                        $this->pruneSubroutes($controllers[$idx]);
+                    }
+                    $manager_controllers = array_merge($manager_controllers, $controllers);
+                }
+            }
+        }
+
+        usort($manager_controllers, function($a, $b) {
+            if($a['weight'] == $b['weight']) {
+                return 0;
+            }
+
+            return ($a['weight'] < $b['weight']) ? -1 : 1;
+        });
+
+        if(count($manager_controllers) === 0) {
+            throw new \RuntimeException('No manager controllers registered');
+        }
+
+        return $manager_controllers;
+    }
+}
+

--- a/src/Mapbender/ManagerBundle/Resources/public/components.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/components.js
@@ -1,0 +1,302 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js
+ */
+$(function() {
+    //
+    // Add manually a string trim function for IE8 support
+    //
+    if(typeof String.prototype.trim !== 'function') {
+        String.prototype.trim = function() {
+            return this.replace(/^\s+|\s+$/g, '');
+        }
+    }
+
+    // init tabcontainers --------------------------------------------------------------------
+    var tabs = $(".tabContainer").find(".tab");
+    tabs.attr("tabindex", 0);
+    tabs.bind("click keypress", function(e) {
+        if(e.type == "keypress" && e.keyCode != 13) {
+            return;
+        }
+
+        var me = $(this);
+        var tabcont = me.parent().parent();
+        tabcont.find(".active").removeClass("active");
+        me.addClass("active");
+        $("#" + me.attr("id").replace("tab", "container"), tabcont).addClass("active");
+    });
+
+
+
+
+
+    // init filter inputs --------------------------------------------------------------------
+    $(document).on("keyup", ".listFilterInput", function(){
+        var me    = $(this);
+        var val   = $.trim(me.val());
+        var items = $("#" + me.attr("id").replace("input", "list")).find("li, tr");
+
+        if(val.length > 0){
+            var item = null;
+
+            $.each(items, function(i, e){
+                item = $(e);
+                if(!item.hasClass("doNotFilter")){
+                    (item.text().toUpperCase().indexOf(val.toUpperCase()) >= 0) ? item.show()
+                                                                                : item.hide();
+                }
+            });
+        }else{
+            items.show();
+        }
+    });
+
+
+
+
+
+
+    // init validation feedback --------------------------------------------------------------
+    $(document).on("keypress", ".validationInput", function(){
+      $(this).siblings(".validationMsgBox").addClass("hide");
+    });
+
+    var flashboxes = $(".flashBox").addClass("kill");
+    // kill all flashes ---------------------------------------------------------------------
+    flashboxes.each(function(idx, item){
+        if(idx === 0){
+            $(item).removeClass("kill");
+        }
+        setTimeout(function(){
+            $(item).addClass("kill");
+            if(flashboxes.length - idx !== 1){
+                $(flashboxes.get(idx + 1)).removeClass("kill");
+            }
+        }, (idx + 1) * 2000);
+    });
+
+
+    // init user box -------------------------------------------------------------------------
+    $("#accountOpen").bind("click", function(){
+        var menu = $("#accountMenu");
+        if(menu.hasClass("opened")){
+            menu.removeClass("opened");
+        }else{
+            menu.addClass("opened");
+        }
+    });
+
+
+
+
+
+    // init permissions table ----------------------------------------------------------------
+    // set permission root state
+    function setPermissionsRootState(className){
+        var root         = $("#" + className);
+        var permBody     = $("#permissionsBody");
+        var rowCount     = permBody.find("tr").length;
+        var checkedCount = permBody.find(".checkWrapper." + className + ".iconCheckboxActive").length;
+        root.removeClass("iconCheckboxActive").removeClass("multi");
+
+        if(rowCount == checkedCount){
+            root.addClass("iconCheckboxActive");
+        }else if(checkedCount == 0){
+            // do nothing!
+        }else{
+            root.addClass("multi");
+        }
+    }
+    // toggle all permissions
+    var toggleAllPermissions = function(){
+        var self           = $(this);
+        var className    = self.attr("id");
+        var permElements = $(".checkWrapper[data-perm-type=" + className + "]:visible");
+        var state        = !self.hasClass("iconCheckboxActive");
+        var me;
+
+        // change all tagboxes with the same permission type
+        permElements.find(".checkbox").each(function(i,e){
+            me = $(e);
+            me.get(0).checked = state;
+
+            if(state){
+                me.parent().addClass("iconCheckboxActive");
+            }else{
+                me.parent().removeClass("iconCheckboxActive");
+            }
+        });
+
+        // change root permission state
+        setPermissionsRootState(className);
+    }
+    // init permission root state
+    var initPermissionRoot = function(){
+        $(this).find(".headTagWrapper").each(function(){
+            setPermissionsRootState($(this).attr("id"));
+            $(this).bind("click", toggleAllPermissions);
+        });
+    }
+    $("#permissionsHead").one("load", initPermissionRoot).load();
+
+    // toggle permission Event
+    var togglePermission = function(){
+        setPermissionsRootState($(this).attr("data-perm-type"));
+    }
+    $(document).on("click", ".permissionsTable .checkWrapper", togglePermission);
+
+    var popup;
+
+    // add user or groups
+    $("#addPermission").bind("click", function(){
+        var self    = $(this);
+        var url     = self.attr("href");
+        var content = self.attr('title');
+
+        if(popup){
+            popup = popup.destroy();
+        }
+
+        if(url.length > 0){
+            popup = new Mapbender.Popup2({
+                title: Mapbender.trans('fom.core.components.popup.add_user_group.title'),
+                closeOnOutsideClick: true,
+                height: 400,
+                content: [
+                    $.ajax({
+                        url: url,
+                        complete: function() {
+                            var groupUserItem, roleName, me, groupUserType, groupName;
+
+                            $("#listFilterGroupsAndUsers").find(".filterItem").each(function(i, e){
+                                groupUserItem = $(e);
+                                groupUserType = (groupUserItem.find(".tdContentWrapper")
+                                                              .hasClass("iconGroup") ? "iconGroup"
+                                                                                     : "iconUser");
+                                $("#permissionsBody").find(".labelInput").each(function(i, e) {
+                                    me = $(e);
+                                    roleName = me.text().trim().toUpperCase();
+                                    groupName = $(".labelInput", groupUserItem).text().toUpperCase();
+                                    var isUserType = (me.parent().hasClass(groupUserType));
+
+                                    if(roleName.indexOf("ROLE_GROUP_") === 0) {
+                                        groupName = "ROLE_GROUP_" + groupName;
+                                    }
+
+                                    if(groupName == roleName && isUserType) {
+                                        groupUserItem.remove();
+                                    }
+                                });
+                            });
+                        }
+                    })
+                ],
+                buttons: {
+                    'cancel': {
+                        label: Mapbender.trans('fom.core.components.popup.add_user_group.btn.cancel'),
+                        cssClass: 'button buttonCancel critical right',
+                        callback: function() {
+                            this.close();
+                        }
+                    },
+                    'add': {
+                        label: Mapbender.trans('fom.core.components.popup.add_user_group.btn.add'),
+                        cssClass: 'button right',
+                        callback: function() {
+                            var proto = $("#permissionsHead").attr("data-prototype");
+
+                            if(proto.length > 0){
+                                var body  = $("#permissionsBody");
+                                var count = body.find("tr").length;
+                                var text, val, parent, newEl;
+
+                                $("#listFilterGroupsAndUsers").find(".iconCheckboxActive").each(function(i, e){
+                                    parent   = $(e).parent();
+                                    text     = parent.find(".labelInput").text().trim();
+                                    val      = parent.find(".hide").text().trim();
+                                    userType = parent.hasClass("iconGroup") ? "iconGroup" : "iconUser";
+                                    newEl = body.prepend(proto.replace(/__name__/g, count))
+                                                .find("tr:first");
+
+                                    newEl.addClass("new").find(".labelInput").text(text);
+                                    newEl.find(".input").attr("value", val);
+                                    newEl.find(".view.checkWrapper").trigger("click");
+                                    newEl.find(".userType")
+                                         .removeClass("iconGroup")
+                                         .removeClass("iconUser")
+                                         .addClass(userType);
+                                    ++count;
+                                });
+
+                                this.close();
+                                $(".permissionsTable").show();
+                                $("#permissionsDescription").hide();
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        return false;
+    });
+    var popup;
+
+    var deleteUserGroup = function(){
+        var self = $(this);
+        var parent = self.parent().parent();
+        var userGroup = ((parent.find(".iconUser").length == 1) ? "user " : "group ") + parent.find(".labelInput").text();
+
+        if(popup){
+            popup = popup.destroy();
+        }
+        popup = new Mapbender.Popup2({
+            title: Mapbender.trans('fom.core.components.popup.delete_user_group.title'),
+            closeOnOutsideClick: true,
+            content: [ Mapbender.trans('fom.core.components.popup.delete_user_group.content',{'userGroup': userGroup}) ],
+            buttons: {
+                'cancel': {
+                    label: Mapbender.trans('fom.core.components.popup.delete_user_group.btn.cancel'),
+                    cssClass: 'button buttonCancel critical right',
+                    callback: function() {
+                        this.close();
+                    }
+                },
+                'ok': {
+                    label: Mapbender.trans('fom.core.components.popup.delete_user_group.btn.ok'),
+                    cssClass: 'button right',
+                    callback: function() {
+                        parent.remove();
+                        this.close();
+                    }
+                }
+            }
+        });
+        return false;
+    }
+    $("#permissionsBody").on("click", '.iconRemove', deleteUserGroup);
+
+
+
+
+
+
+    // init open toggle trees ----------------------------------------------------------------
+    var toggleTree = function(){
+        var me     = $(this);
+        var parent = me.parent();
+        if(parent.hasClass("closed")){
+            me.removeClass("iconExpandClosed").addClass("iconExpand");
+            parent.removeClass("closed");
+        }else{
+            me.addClass("iconExpandClosed").removeClass("iconExpand");
+            parent.addClass("closed");
+        }
+    }
+    $(".openCloseTitle").bind("click", toggleTree);
+    $('.regionProperties .radiobox').each(function() {
+        $(this).parent(".radioWrapper").attr('data-icon')
+        initRadioButton.call(this, false, $(this).parent(".radioWrapper").attr('data-icon') + $(this).val());
+    });
+});

--- a/src/Mapbender/ManagerBundle/Resources/public/form/collection.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/form/collection.js
@@ -1,0 +1,47 @@
+/**
+ * Migrated to Mapbender from FOM v3.0.6.3
+ * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/widgets
+ */
+(function($) {
+
+function s4() {
+  return Math.floor((1 + Math.random()) * 0x10000)
+             .toString(16)
+             .substring(1);
+};
+
+function guid() {
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+         s4() + '-' + s4() + s4() + s4();
+}
+
+$(document).on('click', '.collectionAdd', function(event) {
+    event.preventDefault();
+
+    // Gather all needed information, like
+    //  collection we're handling right now...
+    var collection = $(event.target).parent(),
+        count = $('.collectionItem', collection).length,
+        // The prototype text for the new item...
+        prototype = collection.data('prototype'),
+        // And finally parse the prototype into a new clean item for insertion.
+        item = $($.parseHTML(prototype
+            .trim()
+            .replace(/__name__label__/g, '')
+            .replace(/__name__/g, count + '-' + guid()))[0])
+            .addClass('collectionItem');
+
+    // Now let's enter that item...
+    collection.append(item);
+});
+
+$(document).on('click', '.collectionRemove', function(event) {
+    event.preventDefault();
+
+    // Get the item...
+    var item = $(event.target).closest('.collectionItem');
+    // And remove it.
+    item.remove();
+});
+
+})(jQuery);

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/actions.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/actions.html.twig
@@ -11,4 +11,4 @@
     }
     %}
 {% endif %}
-{% include "FOMManagerBundle:Manager:actions.html.twig" %}
+{% include "MapbenderManagerBundle:Manager:actions.html.twig" %}

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/edit.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ application.title }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/export.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/export.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.manager.managerbundle.export_application' | trans }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/import.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/import.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.manager.managerbundle.import_application' | trans }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/new.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/new.html.twig
@@ -1,5 +1,5 @@
 {% set application = {'slug': 'manager'} %}
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ "mb.manager.admin.application.new.title" | trans}}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Index/menu.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Index/menu.html.twig
@@ -1,0 +1,38 @@
+{#
+  Copied into Mapbender from FOM v3.0.6.3
+  see https://github.com/mapbender/fom/blob/v3.0.6.3/src/FOM/ManagerBundle/Resources/views/Manager/menu.html.twig
+#}
+<ul class="navLevel1 navigation">
+  {% for k, itemLvlOne in menu %}
+
+    <li id="manager-{{ k }}" class="navItem {% if itemLvlOne.active is defined %} activeItem {% endif %}">
+      <a class="iconLinkButton" href="{{ path(itemLvlOne.route) }}">{{ itemLvlOne.title|trans }}</a>
+
+    {% if itemLvlOne.subroutes is defined %}
+      <ul class="navLevel2">
+
+        {% for itemLvlTwo in itemLvlOne.subroutes %}
+          <li class="{% if itemLvlTwo.active is defined %} activeItem {% endif %} navItem">
+            <a{% if itemLvlTwo.idx is defined %} id="{{ itemLvlTwo.idx }}"{% endif %} class="iconLinkButton" href="{{ path(itemLvlTwo.route) }}">{{ itemLvlTwo.title|trans }}</a>
+
+            {% if itemLvlTwo.subroutes is defined %}
+              <ul class="navLevel3">
+
+                {% for itemLvlThree in itemLvlTwo.subroutes %}
+                  <li class="navItem {% if itemLvlThree.active is defined %} activeItem {% endif %}">
+                    <a class="iconLinkButton" href="{{ path(itemLvlThree.route) }}">{{ itemLvlThree.title|trans }}</a>
+                  </li>
+                {% endfor %}
+
+              </ul>
+            {% endif %}
+
+          </li>
+
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    </li>
+  {% endfor %}
+</ul>

--- a/src/Mapbender/ManagerBundle/Resources/views/Index/menu.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Index/menu.html.twig
@@ -3,24 +3,24 @@
   see https://github.com/mapbender/fom/blob/v3.0.6.3/src/FOM/ManagerBundle/Resources/views/Manager/menu.html.twig
 #}
 <ul class="navLevel1 navigation">
-  {% for k, itemLvlOne in menu %}
+  {% for k, item in menu %}
 
-    <li id="manager-{{ k }}" class="navItem {% if itemLvlOne.active is defined %} activeItem {% endif %}">
-      <a class="iconLinkButton" href="{{ path(itemLvlOne.route) }}">{{ itemLvlOne.title|trans }}</a>
+    <li id="manager-{{ k }}" class="navItem {% if item.active is defined %} activeItem {% endif %}">
+      <a class="iconLinkButton" href="{{ path(item.route) }}">{{ item.title|trans }}</a>
 
-    {% if itemLvlOne.subroutes is defined %}
+    {% if item.subroutes is defined and item.subroutes %}
       <ul class="navLevel2">
 
-        {% for itemLvlTwo in itemLvlOne.subroutes %}
-          <li class="{% if itemLvlTwo.active is defined %} activeItem {% endif %} navItem">
-            <a{% if itemLvlTwo.idx is defined %} id="{{ itemLvlTwo.idx }}"{% endif %} class="iconLinkButton" href="{{ path(itemLvlTwo.route) }}">{{ itemLvlTwo.title|trans }}</a>
+        {% for item in item.subroutes %}
+          <li class="{% if item.active is defined and item.active %} activeItem {% endif %} navItem">
+            <a{% if item.idx is defined %} id="{{ item.idx }}"{% endif %} class="iconLinkButton" href="{{ path(item.route) }}">{{ item.title|trans }}</a>
 
-            {% if itemLvlTwo.subroutes is defined %}
+            {% if item.subroutes is defined and item.subroutes %}
               <ul class="navLevel3">
 
-                {% for itemLvlThree in itemLvlTwo.subroutes %}
-                  <li class="navItem {% if itemLvlThree.active is defined %} activeItem {% endif %}">
-                    <a class="iconLinkButton" href="{{ path(itemLvlThree.route) }}">{{ itemLvlThree.title|trans }}</a>
+                {% for item in item.subroutes %}
+                  <li class="navItem {% if item.active is defined and item.active %} activeItem {% endif %}">
+                    <a class="iconLinkButton" href="{{ path(item.route) }}">{{ item.title|trans }}</a>
                   </li>
                 {% endfor %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Manager/actions.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Manager/actions.html.twig
@@ -1,0 +1,10 @@
+{% if actions is defined %}
+    {% for k,v in actions %}
+    {% if v.display is defined and v.display %}
+    {% set attr %}
+    {% if v.attr is defined %}{% for k,v in v.attr %} {{k}}="{{v}}"{% endfor %}{% endif %}
+    {% endset %}
+    <a id="action-{{ k }}" href="{{ v.url }}"{{ attr }} title="{{ v.title | trans }}" tabindex="-1"></a>
+    {% endif %}
+    {% endfor %}
+{% endif %}

--- a/src/Mapbender/ManagerBundle/Resources/views/Manager/menu.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Manager/menu.html.twig
@@ -1,0 +1,34 @@
+<ul class="navLevel1 navigation">
+  {% for k, itemLvlOne in menu %}
+
+    <li id="manager-{{ k }}" class="navItem {% if itemLvlOne.active is defined %} activeItem {% endif %}">
+      <a class="iconLinkButton" href="{{ path(itemLvlOne.route) }}">{{ itemLvlOne.title|trans }}</a>
+
+    {% if itemLvlOne.subroutes is defined %}
+      <ul class="navLevel2">
+
+        {% for itemLvlTwo in itemLvlOne.subroutes %}
+          <li class="{% if itemLvlTwo.active is defined %} activeItem {% endif %} navItem">
+            <a{% if itemLvlTwo.idx is defined %} id="{{ itemLvlTwo.idx }}"{% endif %} class="iconLinkButton" href="{{ path(itemLvlTwo.route) }}">{{ itemLvlTwo.title|trans }}</a>
+
+            {% if itemLvlTwo.subroutes is defined %}
+              <ul class="navLevel3">
+
+                {% for itemLvlThree in itemLvlTwo.subroutes %}
+                  <li class="navItem {% if itemLvlThree.active is defined %} activeItem {% endif %}">
+                    <a class="iconLinkButton" href="{{ path(itemLvlThree.route) }}">{{ itemLvlThree.title|trans }}</a>
+                  </li>
+                {% endfor %}
+
+              </ul>
+            {% endif %}
+
+          </li>
+
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    </li>
+  {% endfor %}
+</ul>

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/index.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/index.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.manager.admin.sources' | trans }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/new.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/new.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.manager.admin.source.new.add' | trans }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/updateform.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/updateform.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.manager.admin.source.update' | trans }}{% endblock %}
 

--- a/src/Mapbender/ManagerBundle/Resources/views/fields.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/fields.html.twig
@@ -1,8 +1,0 @@
-
-{% block extent_widget %}
-    <div class="form-inline">
-        {% for child in form %}
-            {{ form_widget(child) }}
-        {% endfor %}
-    </div>
-{% endblock %}

--- a/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
@@ -23,7 +23,7 @@
           <a href="{{ path('mapbender_core_welcome_list') }}"><img class="logo" alt="Mapbender 3 Manager" src="{{ asset(fom.server_logo)}}" /></a>
         </div>
         {% if app.user != "" %}
-          {% render controller("FOMManagerBundle:Manager:menu", { "request": app.request }) %}
+          {% render(controller("MapbenderManagerBundle:Index:menu", { "request": app.request })) %}
         {% endif %}
       </div>
 

--- a/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
@@ -1,0 +1,62 @@
+{% extends "MapbenderCoreBundle::index.html.twig" %}
+
+{% set title %}{% block title %}{{ title|default('') }}{% endblock %}{% endset %}
+
+{% block favicon %}{{ asset('favicon.png') }}{% endblock %}
+
+{% block css %}
+  <link rel="stylesheet" href="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'css'}) }}"/>
+{% endblock %}
+
+{% block js %}
+  {{parent()}}
+  <script type="text/javascript" src="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'js'}) }}"></script>
+  <script type="text/javascript" src="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'trans'}) }}"></script>
+{% endblock %}
+
+{% block content %}
+  <div class="head"><hr class="dekoSeperator"></div>
+    <div id="wrapper" class="page">
+
+      <div class="leftPane">
+        <div class="logoContainer">
+          <a href="{{ path('mapbender_core_welcome_list') }}"><img class="logo" alt="Mapbender 3 Manager" src="{{ asset(fom.server_logo)}}" /></a>
+        </div>
+        {% if app.user != "" %}
+          {% render controller("FOMManagerBundle:Manager:menu", { "request": app.request }) %}
+        {% endif %}
+      </div>
+
+      <div class="rightPane">
+
+        {# flash me baby #}
+        {% for key, flash in app.session.bag('flashes') %}
+          <div class="flashBox {{ key }}">
+            {{ flash | first }}
+          </div>
+        {% endfor %}
+
+        <div class="accountBar shadowBox">
+          {% if app.user != "" %}
+            <ul id="accountMenu" class="accountMenu">
+                <li id="accountOpen" class="iconDown smallText">{{ "fom.core.manager.logged_as"|trans}}: {{ app.user.username }}<span class="openedIcon"></span></li>
+                {% if app.user.password != "" %} <li><a class="linkButton iconSettings" href="{{ path('fom_user_user_edit', {'id': app.user.id}) }}">{{ "fom.core.manager.you_account"|trans }}</a></li>{% endif %}
+                <li><a class="linkButton iconSignOut" href="{{ path('fom_user_login_logout') }}">{{ "fom.core.manager.btn.logout"|trans }}</a></li>
+            </ul>
+          {% else %}
+            <a class="linkButton iconSignIn" href="{{ path('fom_user_login_login') }}">{{ "fom.core.manager.btn.login"|trans}}</a>
+          {% endif %}
+        </div>
+        <div class="contentPane">
+          <div id="version" class="mapbenderVersion smallText">v. {{ fom.server_version }}</div>
+          <div class="content shadowBox">
+            <h1 class="contentTitle">{{ title|trans }}</h1>
+
+            {% block manager_content %}{% endblock %}
+          </div>
+           
+        </div>
+      </div>
+    </div>
+
+{% endblock %}

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.wms.wmsloader.repo.instance.title.wmsinstance' | trans }} ({{instance.source.id}}/{{ instance.id }}) - {{ instance.source.title }}{% endblock %}
 

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/new.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/new.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.wms.wmsloader.repo.new.label.addservice' | trans }}{% endblock %}
 

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/preview.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/preview.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.wms.wmsloader.repo.preview.title.servicerepository' | trans }}{% endblock %}
 

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/view.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/view.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 {% from "MapbenderWmsBundle:Repository:macros.html.twig" import requestinformation  %}
 
 {% block title %}{{ wms.type }} {{ wms.title }}{% endblock %}

--- a/src/Mapbender/WmtsBundle/Resources/views/Repository/instance.html.twig
+++ b/src/Mapbender/WmtsBundle/Resources/views/Repository/instance.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ form.vars.value.type }} {{ 'mb.wmts.wmtsloader.repo.instance.title.instance' | trans }} - {{ form.vars.value.title }}{% endblock %}
 

--- a/src/Mapbender/WmtsBundle/Resources/views/Repository/new.html.twig
+++ b/src/Mapbender/WmtsBundle/Resources/views/Repository/new.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.wmts.wmtsloader.repo.new.label.addservice' | trans }}{% endblock %}
 

--- a/src/Mapbender/WmtsBundle/Resources/views/Repository/preview.html.twig
+++ b/src/Mapbender/WmtsBundle/Resources/views/Repository/preview.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 
 {% block title %}{{ 'mb.wmts.wmtsloader.repo.preview.title.servicerepository' | trans }}{% endblock %}
 

--- a/src/Mapbender/WmtsBundle/Resources/views/Repository/view.html.twig
+++ b/src/Mapbender/WmtsBundle/Resources/views/Repository/view.html.twig
@@ -1,4 +1,4 @@
-{% extends "FOMManagerBundle::manager.html.twig" %}
+{% extends "MapbenderManagerBundle::manager.html.twig" %}
 {% import "MapbenderWmtsBundle:Repository:macros.html.twig" as view %}
 
 {% block title %}{{ wmts.type }} {{ wmts.title }}{% endblock %}


### PR DESCRIPTION
### BC impact
Drop-replacements for manager.html.twig (in app/Resources) will have to be moved (or safer yet, duplicated) to new directory structure to remain effective.  
* A customized `app/Resources/FOM/ManagerBundle/Resources/views/manager.html.twig` should be duplicated to `app/Resources/Mapbender/ManagerBundle/Resources/views/manager.html.twig`
* A customized `app/Resources/FOM/CoreBundle/Resources/views/Form/fields.html.twig` should be duplicated to `app/Resources/Mapbender/CoreBundle/Resources/views/form/fields.html.twig`
* A customized `app/Resources/FOM/CoreBundle/Resources/views/Manager/menu.html.` should be duplicated to `app/Resources/Mapbender/ManagerBundle/Resources/views/menu.html.twig`


Twig `extends` and `include` clauses for manager.html.twig will be kept safe and working. The other two templates `fields.html.twig` and `menu.html.twig` will vanish completely from their original locations.

## Change summary
This brings in the following assets from FOM v3.0.6.3:
* fields.html.twig (the default form theme)
* manager.html.twig (the backend layout)
* menu.html.twig (skin for the backend sidepane menu)
* checkbox.js
* dropdown.js
* radiobuttonExtended.js
* collection.js
* components.js
* tabcontainer.js
* sidepane.js

It also brings in the `FOM\ManagerBundle\ManagerController`, renamed to `Mapbender\ManagerBundle\IndexController`.

### Updating of references
There is generally no need to manually update anything on the project level, except for cases of drop-in twig replacements already described on top.

Includes of the twigs in Mapbender scope have been updated manually.

The form theme is carefully auto-rewritten based on [previous work](https://github.com/mapbender/mapbender/pull/1030). This change of default theme location only happens if the configured default theme was FOM's.  
Enterprising types who have already configured their system with, say, a Bootstrap 3 form theme, will not be impacted in any way.
Doing this automatically frees us from attempting a "simultaneous" commit into the Mapbender Starter repository.

References to the JavaScript assets are auto-updated on the AssetFactory level. This ensures custom Element and Template classes will move along automatically, with no need to rewrite the asset references.

Standard Mapbender routing configuration loads Mapbender ManagerBundle controllers before FOM ManagerBundle controllers, so the adopted new IndexController will take precedence automatically.

### Rationale
1) Nothing in FOM even references any of the JavaScript assets. They are only referenced by the manager template _in_ _Mapbender_, frontend Templates also _in_ _Mapbender_ and assorted Elements, of which FOM has no concept at all. As such, it makes no sense that FOM should control how these widgets work.
2) FOM only has a teeny tiny bit of backend section of its own, for users and ACLs. The bulk of the backend is in _Mapbender_'s ManagerBundle. As such it makes no sense that FOM should control the layout of the _Mapbender_ backend.
3) FOM's form theme has numerous limitations and quirks that can only reasonably be fixed in conjunction with its CSS, which is in Mapbender, along with the vast majority of form types and form templates.
