### PR TITLE
Fix/revert html element to html element

### DIFF
--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -98,15 +98,4 @@ class HTMLElement extends Element
     {
         return 'MapbenderCoreBundle:ElementAdmin:htmlelement.html.twig';
     }
-
-    /**
-     * @inheritdoc
-     */
-    static public function listAssets()
-    {
-        return array(
-            'js'  => array('/bundles/mapbendercore/mapbender.element.htmlelement.js'),
-            'css' => array(),
-        );
-    }
 }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -187,19 +187,4 @@ class HTMLElement extends Element
         }
         return $configuration;
     }
-
-    /**
-     * Get asset list and add JS file if 'jsSrc' keyword configured.
-     *
-     * @inheritdoc
-     */
-    public function getAssets()
-    {
-        $configuration = $this->getConfiguration();
-        $assets        = $this::listAssets();
-        if (isset($configuration['jsSrc'])) {
-            $assets['js'][] = $configuration['jsSrc'];
-        }
-        return $assets;
-    }
 }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -33,16 +33,6 @@ class HTMLElement extends Element
         );
     }
 
-    public function getAssets()
-    {
-        $configuration = $this->getConfiguration();
-        $assets = parent::getAssets();
-        if(isset($configuration['js'])){
-            $assets['js'][] = $configuration['js'];
-        }
-        return $assets;
-    }
-
     /**
      * @inheritdoc
      */

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -111,8 +111,9 @@ class HTMLElement extends Element
      * @param $items
      * @return array
      * @deprecated will be removed in 3.0.8.0
+     * @internal param $configuration
      */
-    public function prepareItems($items)
+    protected function prepareItems($items)
     {
         if (!is_array($items)) {
             return $items;
@@ -153,6 +154,7 @@ class HTMLElement extends Element
 
                     unset($item['sql']);
                     unset($item['connection']);
+
                     /** @var Connection $dbal */
                     $dbal = $this->container->get("doctrine.dbal.{$connectionName}_connection");
                     foreach ($dbal->fetchAll($sql) as $option) {

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -198,11 +198,7 @@ class HTMLElement extends Element
         $configuration = $this->getConfiguration();
         $assets        = $this::listAssets();
         if (isset($configuration['jsSrc'])) {
-            if (is_array($configuration['jsSrc'])) {
-                $assets['js'] = array_merge($assets['js'], $configuration['jsSrc']);
-            } else {
-                $assets['js'][] = $configuration['jsSrc'];
-            }
+            $assets['js'][] = $configuration['jsSrc'];
         }
         return $assets;
     }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -83,11 +83,11 @@ class HTMLElement extends Element
     /**
      * @inheritdoc
      */
-    public static function listAssets()
+    static public function listAssets()
     {
         return array(
             'js'  => array('/bundles/mapbendercore/mapbender.element.htmlelement.js'),
-            'css' => array('/bundles/mapbendercore/sass/element/htmlelement.scss')
+            'css' => array(),
         );
     }
 }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -2,10 +2,8 @@
 
 namespace Mapbender\CoreBundle\Element;
 
-use Doctrine\DBAL\Connection;
 use Mapbender\CoreBundle\Component\Element;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * HTMLElement.
@@ -101,103 +99,5 @@ class HTMLElement extends Element
             'js'  => array('/bundles/mapbendercore/mapbender.element.htmlelement.js'),
             'css' => array('/bundles/mapbendercore/sass/element/htmlelement.scss')
         );
-    }
-
-    /**
-     * Is associative array given?
-     * @param $arr
-     * @return bool
-     * @deprecated will be removed in 3.0.8.0
-     */
-    protected static function isAssoc(&$arr)
-    {
-        return array_keys($arr) !== range(0, count($arr) - 1);
-    }
-
-    /**
-     * Prepare elements recursive.
-     *
-     * @param $items
-     * @return array
-     * @deprecated will be removed in 3.0.8.0
-     * @internal param $configuration
-     */
-    protected function prepareItems($items)
-    {
-        if (!is_array($items)) {
-            return $items;
-        } elseif (self::isAssoc($items)) {
-            $items = $this->prepareItem($items);
-        } else {
-            foreach ($items as $key => $item) {
-                $items[$key] = $this->prepareItem($item);
-            }
-        }
-        return $items;
-    }
-
-    /**
-     * Prepare element by type
-     *
-     * @param $item
-     * @return mixed
-     * @internal
-     * @deprecated will be removed in 3.0.8.0
-     */
-    protected function prepareItem($item)
-    {
-        if(!isset($item["type"])){
-            return $item;
-        }
-
-        if (isset($item["items"])) {
-            $item["items"] = $this->prepareItems($item["items"]);
-        }
-
-        switch ($item['type']) {
-            case 'select':
-                if (isset($item['sql'])) {
-                    $connectionName = isset($item['connection']) ? $item['connection'] : 'default';
-                    $sql            = $item['sql'];
-                    $options        = isset($item["options"]) ? $item["options"] : array();
-
-                    unset($item['sql']);
-                    unset($item['connection']);
-
-                    /** @var Connection $dbal */
-                    $dbal = $this->container->get("doctrine.dbal.{$connectionName}_connection");
-                    foreach ($dbal->fetchAll($sql) as $option) {
-                        $options[current($option)] = end($option);
-                    }
-
-                    $item["options"] = $options;
-                }
-                break;
-        }
-        return $item;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function httpAction($action)
-    {
-        switch ($action) {
-            case 'configuration':
-                return new JsonResponse($this->getConfiguration());
-        }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getConfiguration()
-    {
-        $configuration = parent::getConfiguration();
-
-        if (isset($configuration['items'])) {
-            $configuration['items'] = $this->prepareItems($configuration['items']);
-        }
-        return $configuration;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -186,13 +186,6 @@ class HTMLElement extends Element
                 $assets['js'][] = $configuration['jsSrc'];
             }
         }
-        if (isset($configuration['css'])) {
-            if (is_array($configuration['css'])) {
-                $assets['css'] = array_merge($assets['css'], $configuration['css']);
-            } else {
-                $assets['css'][] = $configuration['css'];
-            }
-        }
         return $assets;
     }
 

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -35,6 +35,16 @@ class HTMLElement extends Element
         );
     }
 
+    public function getAssets()
+    {
+        $configuration = $this->getConfiguration();
+        $assets = parent::getAssets();
+        if(isset($configuration['js'])){
+            $assets['js'][] = $configuration['js'];
+        }
+        return $assets;
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -35,12 +35,51 @@ class HTMLElement extends Element
         );
     }
 
+    /**
+     * @inheritdoc
+     */
+    public static function getType()
+    {
+        return 'mapbender.form_type.element.htmlelement';
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function getDefaultConfiguration()
     {
         return array(
             'classes' => 'html-element-inline',
             'content' => ''
         );
+    }
+
+    /**
+     * Render markup.
+     * Because the entire template is user-configurable, we add some error handling here.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        /** @var LoggerInterface $logger */
+        $logger = $this->container->get('logger');
+
+        try {
+            return parent::render();
+        } catch (\Twig_Error $e) {
+            $message = "Invalid content in " . get_class($this) . " caused " . get_class($e);
+            $logger->warning($message . ", suppressing content", $this->getConfiguration());
+            return "<div id=\"{$this->getEntity()->getId()}\"><!-- $message --></div>";
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getFormTemplate()
+    {
+        return 'MapbenderCoreBundle:ElementAdmin:htmlelement.html.twig';
     }
 
     /**
@@ -81,7 +120,7 @@ class HTMLElement extends Element
             $items = $this->prepareItem($items);
         } else {
             foreach ($items as $key => $item) {
-                $items[ $key ] = $this->prepareItem($item);
+                $items[$key] = $this->prepareItem($item);
             }
         }
         return $items;
@@ -117,7 +156,7 @@ class HTMLElement extends Element
                     /** @var Connection $dbal */
                     $dbal = $this->container->get("doctrine.dbal.{$connectionName}_connection");
                     foreach ($dbal->fetchAll($sql) as $option) {
-                        $options[ current($option) ] = end($option);
+                        $options[current($option)] = end($option);
                     }
                     $item["options"] = $options;
                 }
@@ -137,8 +176,8 @@ class HTMLElement extends Element
                     $dataStoreInfo = $item['dataStore'];
                     $dataStore     = $this->container->get('data.source')->get($dataStoreInfo["id"]);
                     $options       = array();
-                    foreach ($dataStore->search() as $dataItem) {
-                        $options[ $dataItem->getId() ] = $dataItem->getAttribute($dataStoreInfo["text"]);
+                    foreach($dataStore->search() as $dataItem){
+                        $options[$dataItem->getId()] = $dataItem->getAttribute($dataStoreInfo["text"]);
                     }
                     $item['options'] = $options;
                 }
@@ -187,25 +226,5 @@ class HTMLElement extends Element
             }
         }
         return $assets;
-    }
-
-    /**
-     * Render markup.
-     * Because the entire template is user-configurable, we add some error handling here.
-     *
-     * @return string
-     */
-    public function render()
-    {
-        /** @var LoggerInterface $logger */
-        $logger = $this->container->get('logger');
-
-        try {
-            return parent::render();
-        } catch (\Twig_Error $e) {
-            $message = "Invalid content in " . get_class($this) . " caused " . get_class($e);
-            $logger->warning($message . ", suppressing content", $this->getConfiguration());
-            return "<div id=\"{$this->getEntity()->getId()}\"><!-- $message --></div>";
-        }
     }
 }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -95,7 +95,6 @@ class HTMLElement extends Element
 
     /**
      * Is associative array given?
-     *
      * @param $arr
      * @return bool
      * @deprecated will be removed in 3.0.8.0
@@ -137,12 +136,12 @@ class HTMLElement extends Element
      */
     protected function prepareItem($item)
     {
-        if (!isset($item["type"])) {
+        if(!isset($item["type"])){
             return $item;
         }
 
-        if (isset($item["children"])) {
-            $item["children"] = $this->prepareItems($item["children"]);
+        if (isset($item["items"])) {
+            $item["items"] = $this->prepareItems($item["items"]);
         }
 
         switch ($item['type']) {
@@ -160,6 +159,7 @@ class HTMLElement extends Element
                     foreach ($dbal->fetchAll($sql) as $option) {
                         $options[current($option)] = end($option);
                     }
+
                     $item["options"] = $options;
                 }
                 break;
@@ -184,8 +184,9 @@ class HTMLElement extends Element
     public function getConfiguration()
     {
         $configuration = parent::getConfiguration();
-        if (isset($configuration['children'])) {
-            $configuration['children'] = $this->prepareItems($configuration['children']);
+
+        if (isset($configuration['items'])) {
+            $configuration['items'] = $this->prepareItems($configuration['items']);
         }
         return $configuration;
     }

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -160,27 +160,6 @@ class HTMLElement extends Element
                     }
                     $item["options"] = $options;
                 }
-
-                if (isset($item['service'])) {
-                    $serviceInfo = $item['service'];
-                    $serviceName = isset($serviceInfo['serviceName']) ? $serviceInfo['serviceName'] : 'default';
-                    $method      = isset($serviceInfo['method']) ? $serviceInfo['method'] : 'get';
-                    $args        = isset($serviceInfo['args']) ? $item['args'] : '';
-                    $service     = $this->container->get($serviceName);
-                    $options     = $service->$method($args);
-
-                    $item['options'] = $options;
-                }
-
-                if (isset($item['dataStore'])) {
-                    $dataStoreInfo = $item['dataStore'];
-                    $dataStore     = $this->container->get('data.source')->get($dataStoreInfo["id"]);
-                    $options       = array();
-                    foreach($dataStore->search() as $dataItem){
-                        $options[$dataItem->getId()] = $dataItem->getAttribute($dataStoreInfo["text"]);
-                    }
-                    $item['options'] = $options;
-                }
                 break;
         }
         return $item;

--- a/src/Mapbender/CoreBundle/Element/HTMLElement.php
+++ b/src/Mapbender/CoreBundle/Element/HTMLElement.php
@@ -52,6 +52,25 @@ class HTMLElement extends Element
         );
     }
 
+    public function getFrontendTemplateVars()
+    {
+        $config = $this->entity->getConfiguration();
+        if (!empty($config['classes'])) {
+            $cssClassNames = array_map('trim', explode(' ', $config['classes']));
+        } else {
+            $cssClassNames = array();
+        }
+        if (in_array('html-element-inline', $cssClassNames)) {
+            $tagName = 'span';
+        } else {
+            $tagName = 'div';
+        }
+        return array(
+            'configuration' => $config,
+            'tagName' => $tagName,
+        );
+    }
+
     /**
      * Render markup.
      * Because the entire template is user-configurable, we add some error handling here.

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
@@ -15,13 +15,13 @@
              */
             function findItem(type, name, children) {
                 var r = [];
-                children = children ? children : (hasItems ? options.children : []);
+                items = items ? items : (hasItems ? options.items : []);
 
-                if(children && !$.isArray(children)) {
-                    children = [children];
+                if(items && !$.isArray(items)) {
+                    items = [items];
                 }
 
-                $.each(children, function(i, item) {
+                $.each(items, function(i, item) {
                     if(!item.hasOwnProperty('type')) {
                         return;
                     }
@@ -30,8 +30,8 @@
                         r.push(item);
                     }
 
-                    if(item.hasOwnProperty('children')) {
-                        $.merge(r, findItem(type, name, item['children']));
+                    if(item.hasOwnProperty('items')) {
+                        $.merge(r, findItem(type, name, item['items']));
                     }
                 });
                 return r;
@@ -42,11 +42,11 @@
              */
             function render() {
                 if(hasItems) {
-                    var children = $.isArray(options.children) ? options.children : [options.children];
-                    if(children[0].type == "popup") {
+                    var items = $.isArray(options.items) ? options.items : [options.items];
+                    if(items[0].type == "popup") {
                         element = $("<div/>");
                     }
-                    element.generateElements({children: children});
+                    element.generateElements({items: items});
                 }
             }
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
@@ -40,7 +40,7 @@
             /**
              * @deprecated, to be removed in 3.0.8.0
              */
-            function render() {
+            function render(){
                 if(hasItems) {
                     var items = $.isArray(options.items) ? options.items : [options.items];
                     if(items[0].type == "popup") {
@@ -59,7 +59,7 @@
                         render();
                     }
                 });
-            } else {
+            }else{
                 render();
             }
         }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
@@ -9,58 +9,13 @@
             var widget = this;
             var element = $(widget.element);
             var options = widget.options;
-            var hasItems = options.hasOwnProperty('children');
-            /**
-             * @deprecated, to be removed in 3.0.8.0
-             */
-            function findItem(type, name, children) {
-                var r = [];
-                items = items ? items : (hasItems ? options.items : []);
 
-                if(items && !$.isArray(items)) {
-                    items = [items];
+            if(options.hasOwnProperty('items')) {
+                var items = $.isArray(options.items) ? options.items : [options.items];
+                if(items[0].type == "popup") {
+                    element = $("<div/>");
                 }
-
-                $.each(items, function(i, item) {
-                    if(!item.hasOwnProperty('type')) {
-                        return;
-                    }
-
-                    if(item.type == type || type == '*') {
-                        r.push(item);
-                    }
-
-                    if(item.hasOwnProperty('items')) {
-                        $.merge(r, findItem(type, name, item['items']));
-                    }
-                });
-                return r;
-            }
-
-            /**
-             * @deprecated, to be removed in 3.0.8.0
-             */
-            function render(){
-                if(hasItems) {
-                    var items = $.isArray(options.items) ? options.items : [options.items];
-                    if(items[0].type == "popup") {
-                        element = $("<div/>");
-                    }
-                    element.generateElements({items: items});
-                }
-            }
-
-            if(options.hasOwnProperty('js')) {
-                $.ajax({
-                    url:      Mapbender.configuration.application.urls.asset + options.js,
-                    dataType: 'text',
-                    success:  function(script) {
-                        eval(script);
-                        render();
-                    }
-                });
-            }else{
-                render();
+                element.generateElements({items: items});
             }
         }
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
@@ -1,22 +1,3 @@
 (function($) {
-    $.widget("mapbender.mbHTMLElement", {
-        /**
-         * @todo 3.0.8.0: this widget should do absolutely nothing. Its 'content' is rendered server side.
-         *   mapbender/data-source's "BaseElement" is the lowest point where vis-ui may be required, not
-         *   core mapbender, not in a simple HTML element.
-         */
-        _create: function() {
-            var widget = this;
-            var element = $(widget.element);
-            var options = widget.options;
-
-            if(options.hasOwnProperty('items')) {
-                var items = $.isArray(options.items) ? options.items : [options.items];
-                if(items[0].type == "popup") {
-                    element = $("<div/>");
-                }
-                element.generateElements({items: items});
-            }
-        }
-    });
+    $.widget("mapbender.mbHTMLElement", {});
 })(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.htmlelement.js
@@ -1,3 +1,0 @@
-(function($) {
-    $.widget("mapbender.mbHTMLElement", {});
-})(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/htmlelement.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/htmlelement.scss
@@ -1,9 +1,0 @@
-.mb-element-htmlelement {
-    &.html-element-inline {
-        display: inline-block;
-        // for special snowflake mobile template which doesn't include bootstrap.css
-        &.hidden {
-            display: none;
-        }
-    }
-}

--- a/src/Mapbender/CoreBundle/Resources/views/Element/htmlelement.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/htmlelement.html.twig
@@ -1,3 +1,3 @@
-<div id="{{ id }}" class="mb-element mb-element-htmlelement {{ configuration.classes }}" data-title="{{ entity.title }}">
+<{{ tagName }} id="{{ id }}" class="mb-element mb-element-htmlelement {{ configuration.classes }}" data-title="{{ entity.title }}">
     {{ include(template_from_string(configuration.content)) }}
-</div>
+</{{ tagName }}>


### PR DESCRIPTION
HTMLElement was used as a stomping ground for certain developments before vis-ui.js and data-source were spun off. It has accumulated a lot of logic that is only really relevant for Digitizer and certain other data-sourcey Mapbender Elements.

[Data Source 0.1.11](https://github.com/mapbender/data-source/releases/tag/0.1.11) has everything it needs to keep even quite old Digitizer versions running happily, with no more need for any supporting magic in HTMLElement. In fact, as of 0.1.11, DataSource's BaseElement doesn't inherit from HTMLElement anymore.

As such, it is now safe to restore HTMLElement to its original purpose: a thing that renders a piece of markup.

This pull removes data-sourcey configuration preprocessing magic prepareItem, prepareItems, isAssoc.   

This pull removes processing logic for `jsSrc` and `css` options. These have never actually been configurable. Through the entire history of the repository, the HTMLElement form type has never defined form fields with these names. We can only speculate that a child class or two may have defined them, but never HTMLElement itself. We will provide instructions for these cases in UPGRADING.md shortly.

This pull restores
* Explicit getType implementation (backend form type class)
* Explicit getFormTemplate implementation (backend form twig)

This pull changes the rendering logic for `html-element-inline` to emit a span instead of a div. This resolved certain CSS gotchas, and actually allowed the complete removal of the HTMLElement CSS rules.

The remaining HTMLElement only renders the markup defined in its `content` option, which may also use Twig functionality by the way. It doesn't have a JavaScript widget constructor, and it doesn't have any predefined CSS rules.