### PR TITLE
Fix/digitizer bring your own printdata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "psr-4": {"Mapbender\\": "src/Mapbender"}
     },
     "conflict": {
+        "mapbender/digitizer": "<1.1.68",
         "mapbender/data-source": "<0.1.11",
         "mapbender/wmts": "*"
     },


### PR DESCRIPTION
Changes mbPrintClient.printDigitizerFeature API to expect an attribute mapping (preferred), or alternatively a native OpenLayers feature.

Old-style invocations with just a Digitizerish feature id and Digitizerish "schema" name are no longer allowed and will throw an error.

This frees the Mapbender print backend from looking up FeatureType / DataStore services, which is completely unsafe anyway.

Every Digitizer Element can potentially define its FeatureType set in its backend configuration. Service lookup is not possible in those cases.

See https://github.com/mapbender/mapbender-digitizer/pull/69
