### PR TITLE
Fix/urlutil js

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -479,7 +479,7 @@ Mapbender.Util.Url = function(urlString){
     };
     /**
      * Reconstruct url
-     * @param {boolean} withoutUser to omit credentials
+     * @param {boolean} [withoutUser] to omit credentials (default false)
      * @returns {String}
      */
     this.asString = function(withoutUser) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -470,16 +470,25 @@ Mapbender.Util.Url = function(urlString){
      */
     this.asString = function(withoutUser) {
         var parts = [this.protocol, '//'];
-        var str = parts.join('');
-        str += (!withoutUser && self.username ? self.username + ':' + (self.password ? self.password : '') + '@' : '');
-        str += self.hostname + (self.port ? ':' + self.port : '') + self.pathname;
-        var params = '';
-        if(typeof (self.parameters) === 'object') {
-            for(var key in self.parameters) {
-                params += '&' + key + '=' + self.parameters[key];
-            }
+        if (!withoutUser && this.username) {
+            parts.push(this.username, ':', this.password || '', '@');
         }
-        return str + (params.length ? '?' + params.substr(1) : '') + (self.hash ? self.hash : '');
+        parts.push(this.hostname);
+        if (this.port) {
+            parts.push(':', this.port);
+        }
+        parts.push(this.pathname);
+        var params = [];
+        var paramKeys = Object.keys(this.parameters || {});
+        for (var i = 0; i < paramKeys.length; ++i) {
+            var key = paramKeys[i];
+            params.push([key, '=', this.parameters[key]].join(''));
+        }
+        if (params.length) {
+            parts.push('?', params.join('&'));
+        }
+        parts.push(this.hash || '');
+        return parts.join('');
     };
     /**
      * Gets a GET parameter value from a giving parameter name.

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -482,7 +482,12 @@ Mapbender.Util.Url = function(urlString){
         var paramKeys = Object.keys(this.parameters || {});
         for (var i = 0; i < paramKeys.length; ++i) {
             var key = paramKeys[i];
-            params.push([key, '=', this.parameters[key]].join(''));
+            var val = this.parameters[key];
+            if (val) {
+                params.push([key, '=', val].join(''));
+            } else {
+                params.push(key);
+            }
         }
         if (params.length) {
             parts.push('?', params.join('&'));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -453,7 +453,7 @@ Mapbender.Util.Url = function(urlString){
     this.host = tmp.host;
     this.hostname = tmp.hostname;
     this.port = tmp.port;
-    this.pathname = tmp.pathname.charAt(0) === '/' ? tmp.pathname : '/' + tmp.pathname;
+    this.pathname = tmp.pathname;
     this.parameters = OpenLayers.Util.getParameters(urlString);
     this.hash = tmp.hash;
     /**
@@ -464,12 +464,13 @@ Mapbender.Util.Url = function(urlString){
         return  !(!self.hostname || !self.protocol);// TODO ?
     };
     /**
-     * Gets an url object as string.
-     * @returns {String} url as string
+     * Reconstruct url
+     * @param {boolean} withoutUser to omit credentials
+     * @returns {String}
      */
-    this.asString = function(withoutUser){
-        var str = self.protocol + (self.protocol === 'http:' || self.protocol === 'https:' || self.protocol === 'ftp:'
-                ? '//' : (self.protocol === 'file:' ? '///' : ''));// TODO for other protocols
+    this.asString = function(withoutUser) {
+        var parts = [this.protocol, '//'];
+        var str = parts.join('');
         str += (!withoutUser && self.username ? self.username + ':' + (self.password ? self.password : '') + '@' : '');
         str += self.hostname + (self.port ? ':' + self.port : '') + self.pathname;
         var params = '';

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -454,7 +454,21 @@ Mapbender.Util.Url = function(urlString){
     this.hostname = tmp.hostname;
     this.port = tmp.port;
     this.pathname = tmp.pathname;
-    this.parameters = OpenLayers.Util.getParameters(urlString);
+    this.parameters = {};
+    var rawParams = (tmp.search || '?').substr(1).split('&');
+    for (var i = 0; i < rawParams.length; ++i) {
+        var rawParam = rawParams[i];
+        var eqAt = rawParam.indexOf('=');
+        var paramName, paramValue;
+        if (eqAt !== -1) {
+            paramName = decodeURIComponent(rawParam.substr(0, eqAt));
+            paramValue = decodeURIComponent(rawParam.substr(eqAt + 1));
+        } else {
+            paramName = rawParam;
+            paramValue = '';
+        }
+        this.parameters[paramName] = paramValue;
+    }
     this.hash = tmp.hash;
     /**
      * Checks if a url object is valid.
@@ -484,9 +498,9 @@ Mapbender.Util.Url = function(urlString){
             var key = paramKeys[i];
             var val = this.parameters[key];
             if (val) {
-                params.push([key, '=', val].join(''));
+                params.push([encodeURIComponent(key), '=', encodeURIComponent(val)].join(''));
             } else {
-                params.push(key);
+                params.push(encodeURIComponent(key));
             }
         }
         if (params.length) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -448,8 +448,8 @@ Mapbender.Util.Url = function(urlString){
     var tmp = document.createElement("a");
     tmp.href = urlString;
     this.protocol = tmp.protocol;
-    this.username = tmp.username;
-    this.password = tmp.password;
+    this.username = decodeURIComponent(tmp.username || '') || null;
+    this.password = decodeURIComponent(tmp.password || '') || null;
     this.host = tmp.host;
     this.hostname = tmp.hostname;
     this.port = tmp.port;
@@ -471,7 +471,7 @@ Mapbender.Util.Url = function(urlString){
     this.asString = function(withoutUser) {
         var parts = [this.protocol, '//'];
         if (!withoutUser && this.username) {
-            parts.push(this.username, ':', this.password || '', '@');
+            parts.push(encodeURIComponent(this.username), ':', encodeURIComponent(this.password || ''), '@');
         }
         parts.push(this.hostname);
         if (this.port) {


### PR DESCRIPTION
Update JavaScript-side Mapbender.Util.Url processing to no longer rely on OpenLayers 2 utility methods, and resolves some collaterals.

1) Avoid undesired special treatment of get parameters that are comma-separated lists, ihnerited from OpenLayers 2 method. All extracted parameters are now scalars. No known usage of Mapbender.Util.Url expects or handles Array-style parameters.   
This fixes the multi-value `visiblelayers` param extraction issue from [#1082](https://github.com/mapbender/mapbender/issues/1082). 

2) Decode username / password and all parameters on parsing, reencode on reconstruction. This should  fix any issues where these properties are modified between parsing and reconstruction, such as WmsLoader adding username and password, then reconstructing the url.

4) Fix loss of parameters-in-parameters on parsing + reconstruction. E.g. the `url` parameter in Owsproxy-style URLs bares an internal `_sginature` parameter, which would previously not survive Util.Url processing. Now it does.

5) Repeated or nested sequences of `(new Mapbender.Util.Url(someUrl)).asString()` are now idempotent. The first reconstruction may produce small inconsequential deviations (such as escaped forward slashes in query parameters where that is not strictly required). Every further repeat of the sequence, and every nesting depth (`(new Mapbender.Util.Url((new Mapbender.Util.Url(someUrl)).asString())).asString()`) now yields the same result as the input.

6) Add RFC 1738-conformant support for empty-valued query parameters (`scheme://host/?hat&cat&quaternion`)

7) Fix quadruple slash `file:////something` generated when reconstructing a parsed file-scheme URL


