### PR TITLE
Fix/legend grouped layer title option 1127

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Legend.php
+++ b/src/Mapbender/CoreBundle/Element/Legend.php
@@ -2,13 +2,15 @@
 namespace Mapbender\CoreBundle\Element;
 
 use Mapbender\CoreBundle\Component\Element;
+use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
+use Mapbender\CoreBundle\Entity;
 
 /**
  * The Legend class shows legends of the map's layers.
  * 
  * @author Paul Schmidt
  */
-class Legend extends Element
+class Legend extends Element implements ConfigMigrationInterface
 {
 
     /**
@@ -68,7 +70,8 @@ class Legend extends Element
             "tooltip" => "Legend",
             "showSourceTitle" => true,
             "showLayerTitle" => true,
-            "showGrouppedTitle" => true);
+            "showGroupedLayerTitle" => true,
+        );
     }
 
     /**
@@ -112,4 +115,18 @@ class Legend extends Element
         return 'MapbenderCoreBundle:ElementAdmin:legend.html.twig';
     }
 
+    public static function updateEntityConfig(Entity\Element $entity)
+    {
+        $config = $entity->getConfiguration() ?: array();
+        if (!isset($config['showGroupedLayerTitle'])) {
+            $defaults = static::getDefaultConfiguration();
+            if (isset($config['showGrouppedTitle'])) {
+                $config['showGroupedLayerTitle'] = !!$config['showGrouppedTitle'];
+            } else {
+                $config['showGroupedLayerTitle'] = $defaults['showGroupedLayerTitle'];
+            }
+        }
+        unset($config['showGrouppedTitle']);
+        $entity->setConfiguration($config);
+    }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/LegendAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LegendAdminType.php
@@ -41,7 +41,13 @@ class LegendAdminType extends AbstractType
                 'choices' => array(
                     "dialog" => "dialog",
                     "blockelement" => "blockelement")))
-            ->add('autoOpen', 'checkbox', array('required' => false))
+            ->add('autoOpen', 'checkbox', array(
+                'required' => false,
+                'label' => 'mb.core.admin.legend.label.autoopen',
+                'label_attr' => array(
+                    'class' => 'labelCheck',
+                ),
+            ))
             ->add('displayType', 'choice',
                 array(
                 'required' => true,
@@ -53,9 +59,28 @@ class LegendAdminType extends AbstractType
                 'application' => $options['application'],
                 'property_path' => '[target]',
                 'required' => false))
-            ->add('showSourceTitle', 'checkbox', array('required' => false))
-            ->add('showLayerTitle', 'checkbox', array('required' => false))
-            ->add('showGrouppedTitle', 'checkbox', array('required' => false));
+            ->add('showSourceTitle', 'checkbox', array(
+                'required' => false,
+                'label' => 'mb.core.admin.legend.label.showsourcetitle',
+                'label_attr' => array(
+                    'class' => 'labelCheck',
+                ),
+            ))
+            ->add('showLayerTitle', 'checkbox', array(
+                'required' => false,
+                'label' => 'mb.core.admin.legend.label.showlayertitle',
+                'label_attr' => array(
+                    'class' => 'labelCheck',
+                ),
+            ))
+            ->add('showGrouppedTitle', 'checkbox', array(
+                'required' => false,
+                'label' => 'mb.core.admin.legend.label.showgroupedlayertitle',
+                'label_attr' => array(
+                    'class' => 'labelCheck',
+                ),
+            ))
+        ;
     }
 
 }

--- a/src/Mapbender/CoreBundle/Element/Type/LegendAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LegendAdminType.php
@@ -73,7 +73,7 @@ class LegendAdminType extends AbstractType
                     'class' => 'labelCheck',
                 ),
             ))
-            ->add('showGrouppedTitle', 'checkbox', array(
+            ->add('showGroupedLayerTitle', 'checkbox', array(
                 'required' => false,
                 'label' => 'mb.core.admin.legend.label.showgroupedlayertitle',
                 'label_attr' => array(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -8,7 +8,7 @@
             displayType:              "list",
             showSourceTitle:          true,
             showLayerTitle:           true,
-            showGroupedTitle:         true
+            showGroupedLayerTitle: true
         },
 
         callback:       null,
@@ -203,7 +203,7 @@
             var $li = $('<li/>').addClass('ebene' + layer.level);
 
             if (layer.children.length) {
-                if (this.options.showGroupedTitle) {
+                if (this.options.showGroupedLayerTitle) {
                     $li.append(this.createTitle(layer));
                 }
                 var $ul = $('<ul/>').addClass('ebene' + layer.level);

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/legend.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/legend.html.twig
@@ -15,6 +15,6 @@
     <div class="clearContainer"></div>
     {{ form_row(form.configuration.showLayerTitle) }}
     <div class="clearContainer"></div>
-    {{ form_row(form.configuration.showGrouppedTitle) }}
+    {{ form_row(form.configuration.showGroupedLayerTitle) }}
     <div class="clearContainer"></div>
 </div>

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/legend.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/legend.html.twig
@@ -1,7 +1,5 @@
 <div class="elementFormLegend elementForm">
-    <div class="left">
-        {{ form_widget(form.configuration.autoOpen) }}<label for="{{form.configuration.autoOpen.vars.id}}" class="labelCheck">{{"mb.core.admin.legend.label.autoopen"|trans}}</label>
-    </div>
+    {{ form_row(form.configuration.autoOpen) }}
     <div class="clearContainer"></div>
     {{ form_label(form.title) }}{{ form_widget(form.title) }}
     <div class="clearContainer"></div>
@@ -13,10 +11,10 @@
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.target) }}{{ form_widget(form.configuration.target) }}
     <div class="clearContainer"></div>
-    {{ form_widget(form.configuration.showSourceTitle) }}<label for="{{form.configuration.showSourceTitle.vars.id}}" class="labelCheck">{{"mb.core.admin.legend.label.showsourcetitle"|trans}}</label>
+    {{ form_row(form.configuration.showSourceTitle) }}
     <div class="clearContainer"></div>
-    {{ form_widget(form.configuration.showLayerTitle) }}<label for="{{form.configuration.showLayerTitle.vars.id}}" class="labelCheck">{{"mb.core.admin.legend.label.showlayertitle"|trans}}</label>
+    {{ form_row(form.configuration.showLayerTitle) }}
     <div class="clearContainer"></div>
-    {{ form_widget(form.configuration.showGrouppedTitle) }}<label for="{{form.configuration.showGrouppedTitle.vars.id}}" class="labelCheck">{{"mb.core.admin.legend.label.showgroupedlayertitle"|trans}}</label>
+    {{ form_row(form.configuration.showGrouppedTitle) }}
     <div class="clearContainer"></div>
 </div>


### PR DESCRIPTION
Fixes #1127.

Reverts name of Legend option `showGrouppedTitle` [sic] back to `showGroupedLayerTitle`, as seen in current YAML demo applications. Migrates previously misspelled configuration values automatically.

In an Element entity configuration carries values for _both_ `showGrouppedTitle` and `showGroupedLayerTitle`, the value of `showGrouppedTitle` is discarded. This may lead to one-time changes in effective configuration. This is intentional. There is no objectively best way to reconcile these two values, should they contradict.
