### PR TITLE
Enh/zoom to feature abstraction

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.redlining.js
@@ -13,22 +13,25 @@
                 'strokeWidth': '3'
             }
         },
+        mbMap: null,
         map: null,
         layer: null,
         activeControl: null,
         geomCounter: 0,
         rowTemplate: null,
-        _create: function(){
-            if(!Mapbender.checkTarget("mbRedlining", this.options.target)) {
-                return;
-            }
+        _create: function() {
             var self = this;
-            this.elementUrl = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/';
-            Mapbender.elementRegistry.onElementReady(this.options.target, $.proxy(self._setup, self));
+            Mapbender.elementRegistry.waitReady(this.options.target).then(function(mbMap) {
+                self.mbMap = mbMap;
+                self._setup();
+            }, function() {
+                Mapbender.checkTarget("mbRedlining", self.options.target);
+            });
         },
         _setup: function(){
             var $geomTable = $('.geometry-table', this.element);
-            this.map = $('#' + this.options.target).data('mapbenderMbMap').map.olMap;
+            // @todo: remove direct access to OpenLayers 2 map
+            this.map = this.mbMap.map.olMap;
             this.rowTemplate = $('tr', $geomTable).remove();
             if(this.options.auto_activate || this.options.display_type === 'element'){
                 this.activate();
@@ -282,8 +285,7 @@
         _zoomToFeature: function(e){
             this._deactivateControl();
             var feature = this.layer.getFeatureById($(e.target).parents("tr:first").attr('data-id'));
-            var bounds = feature.geometry.getBounds();
-            this.map.zoomToExtent(bounds);
+            this.mbMap.getModel().zoomToFeature(feature);
         },
         _generateTextStyle: function(label){
             var style = OpenLayers.Util.applyDefaults(null, OpenLayers.Feature.Vector.style['default']);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
@@ -576,34 +576,17 @@
                 return;
             }
             var row = $(event.currentTarget),
-                feature = row.data('feature').getFeature(),
-                map = this.mbMap.map.olMap
+                feature = row.data('feature').getFeature()
             ;
-            var featureExtent = $.extend({},feature.geometry.getBounds());
-
-            // buffer, if needed
-            if(callbackConf.options && callbackConf.options.buffer){
-                var radius = callbackConf.options.buffer;
-                featureExtent.top += radius;
-                featureExtent.right += radius;
-                featureExtent.bottom -= radius;
-                featureExtent.left -= radius;
-            }
-
-            // get zoom for buffered extent
-            var zoom = map.getZoomForExtent(featureExtent);
-
-            var centerLonLat = featureExtent.getCenterLonLat();
-            var x = centerLonLat.x, y = centerLonLat.y;
-
-            var centerOptions = {
-                zoom: zoom
-            };
+            var zoomToFeatureOptions;
             if (callbackConf.options) {
-                centerOptions.maxScale = parseInt(callbackConf.maxScale) || null;
-                centerOptions.minScale = parseInt(callbackConf.minScale) || null;
+                zoomToFeatureOptions = {
+                    maxScale: parseInt(callbackConf.options.maxScale) || null,
+                    minScale: parseInt(callbackConf.options.minScale) || null,
+                    buffer: parseInt(callbackConf.options.buffer) || null
+                };
             }
-            this.mbMap.getModel().centerXy(x, y, centerOptions);
+            this.mbMap.getModel().zoomToFeature(feature, zoomToFeatureOptions);
         },
         _onSrsChange: function(event, data) {
             if (this.highlightLayer) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -10,11 +10,13 @@ $.widget('mapbender.mbSimpleSearch', {
         label_attribute: null,
         geom_attribute: null,
         geom_format: null,
-        result_buffer: null,
-        result_minscale: null,
-        result_maxscale: null,
-        result_icon_url: null,
-        result_icon_offset: null,
+        result: {
+            buffer: null,
+            minscale: null,
+            maxscale: null,
+            icon_url: null,
+            icon_offset: null
+        },
         delay: 0
     },
 
@@ -53,36 +55,28 @@ $.widget('mapbender.mbSimpleSearch', {
     },
     _onAutocompleteSelected: function(evt, evtData) {
         var format = new OpenLayers.Format[this.options.geom_format]();
-        var self = this;
-        if(!evtData.data[self.options.geom_attribute]) {
+        if(!evtData.data[this.options.geom_attribute]) {
             $.notify( Mapbender.trans("mb.core.simplesearch.error.geometry.missing"));
             return;
         }
 
-        var feature = format.read(evtData.data[self.options.geom_attribute]);
+        var feature = format.read(evtData.data[this.options.geom_attribute]);
         var mbMap = this._getMbMap();
-        var olMap = mbMap.getModel().map.olMap;
-        var bounds = feature.geometry.getBounds();
 
-        if(self.options.result.buffer > 0) {
-            bounds.top += self.options.result.buffer;
-            bounds.right += self.options.result.buffer;
-            bounds.bottom -= self.options.result.buffer;
-            bounds.left -= self.options.result.buffer;
-        }
-
-        var zoom = olMap.getZoomForExtent(bounds);
-
-        var centerLonLat = bounds.getCenterLonLat();
-        var x = centerLonLat.x, y = centerLonLat.y;
-
-        var centerOptions = {
-            zoom: zoom
+        var zoomToFeatureOptions = this.options.result && {
+            maxScale: parseInt(this.options.result.maxscale) || null,
+            minScale: parseInt(this.options.result.minscale) || null,
+            buffer: parseInt(this.options.result.buffer) || null
         };
-        if (self.options.result) {
-            centerOptions.maxScale = parseInt(self.options.result.maxScale) || null;
-            centerOptions.minScale = parseInt(self.options.result.minScale) || null;
-        }
+        mbMap.getModel().zoomToFeature(feature, zoomToFeatureOptions);
+        this._hideMobile();
+        this._setFeatureMarker(feature);
+    },
+    _setFeatureMarker: function(feature) {
+        var olMap = this._getMbMap().getModel().map.olMap;
+        var self = this;
+
+        var bounds = feature.geometry.getBounds();
 
         // Add marker
         if(self.options.result.icon_url) {
@@ -119,11 +113,6 @@ $.widget('mapbender.mbSimpleSearch', {
                 self.marker.moveTo(newPx);
             }
         }
-        self._hideMobile();
-
-        // finally, zoom
-        mbMap.getModel().centerXy(x, y, centerOptions);
-
     },
 
     _hideMobile: function() {


### PR DESCRIPTION
Adds `Mapbender.Model.zoomToFeature`, with support for buffering and scale limits.  
Replaces (near identical) zoom-to-feature logic in SearchRouter, SimpleSearch and Redlining with a call to the new method. This should ease porting to new map engines down the road.

Fixes #1145.
Also fixes SimpleSearch minscale / maxscale evaluation.

