### PR TITLE
Amend previously detected WMS version onto originUrl when reloading source

### DIFF
--- a/src/Mapbender/CoreBundle/Utils/UrlUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/UrlUtil.php
@@ -52,6 +52,29 @@ class UrlUtil
     }
 
     /**
+     * @param string $url
+     * @param string $paramName
+     * @param mixed $default
+     * @return mixed
+     * @throws \InvalidArgumentException on empty $paramName
+     */
+    public static function getQueryParameterCaseInsensitive($url, $paramName, $default = null)
+    {
+        if (!$paramName) {
+            throw new \InvalidArgumentException("Empty parameter name");
+        }
+        $lcParamName = strtolower($paramName);
+        $urlParams = array();
+        parse_str(parse_url($url, PHP_URL_QUERY), $urlParams);
+        foreach ($urlParams as $urlParam => $value) {
+            if (strtolower($urlParam) == $lcParamName) {
+                return $value;
+            }
+        }
+        return $default;
+    }
+
+    /**
      * Inverse of parse_url.
      * This is a drop-in for a single-argument http_build_url as provided by the (rarely installed) "http" PECL
      * extension.


### PR DESCRIPTION
Closes #1148 

Value is appended when building the reload form, which allows inspection and editing by the operator naturally. If the previously used originUrl already had a version in it, nothing changes at all.

Change only applies to WMS.
