### PR TITLE
Fix/skip wms document validation

### DIFF
--- a/src/Mapbender/CoreBundle/Utils/UrlUtil.php
+++ b/src/Mapbender/CoreBundle/Utils/UrlUtil.php
@@ -52,6 +52,29 @@ class UrlUtil
     }
 
     /**
+     * @param string $url
+     * @param string $paramName
+     * @param mixed $default
+     * @return mixed
+     * @throws \InvalidArgumentException on empty $paramName
+     */
+    public static function getQueryParameterCaseInsensitive($url, $paramName, $default = null)
+    {
+        if (!$paramName) {
+            throw new \InvalidArgumentException("Empty parameter name");
+        }
+        $lcParamName = strtolower($paramName);
+        $urlParams = array();
+        parse_str(parse_url($url, PHP_URL_QUERY), $urlParams);
+        foreach ($urlParams as $urlParam => $value) {
+            if (strtolower($urlParam) == $lcParamName) {
+                return $value;
+            }
+        }
+        return $default;
+    }
+
+    /**
      * Inverse of parse_url.
      * This is a drop-in for a single-argument http_build_url as provided by the (rarely installed) "http" PECL
      * extension.

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -49,6 +49,8 @@ class Importer
      * @param bool $onlyValid
      * @return \Mapbender\WmsBundle\Component\Wms\Importer\Response
      * @throws XmlParseException
+     * @throws \Mapbender\CoreBundle\Component\Exception\NotSupportedVersionException
+     * @throws \Mapbender\WmsBundle\Component\Exception\WmsException
      */
     public function evaluateServer(WmsOrigin $serviceOrigin, $onlyValid=true)
     {
@@ -66,6 +68,7 @@ class Importer
      * @param boolean $onlyValid
      * @return \Mapbender\WmsBundle\Component\Wms\Importer\Response
      * @throws XmlParseException
+     * @throws \Mapbender\CoreBundle\Component\Exception\NotSupportedVersionException
      */
     public function evaluateCapabilitiesDocument(\DOMDocument $document, $onlyValid=true)
     {
@@ -87,6 +90,9 @@ class Importer
     /**
      * @param WmsOrigin $serviceOrigin
      * @return \DOMDocument
+     * @throws XmlParseException
+     * @throws \Mapbender\CoreBundle\Component\Exception\NotSupportedVersionException
+     * @throws \Mapbender\WmsBundle\Component\Exception\WmsException
      */
     public function loadCapabilitiesDocument(WmsOrigin $serviceOrigin)
     {

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -2,17 +2,17 @@
 
 namespace Mapbender\WmsBundle\Component\Wms;
 
-use Buzz\Message\Response;
+use Mapbender\Component\Transport\HttpTransportInterface;
 use Mapbender\CoreBundle\Component\Exception\InvalidUrlException;
 use Mapbender\CoreBundle\Component\Exception\XmlParseException;
 use Mapbender\CoreBundle\Component\XmlValidator;
+use Mapbender\CoreBundle\Utils\UrlUtil;
 use Mapbender\WmsBundle\Component\Wms\Importer\DeferredValidation;
 use Mapbender\WmsBundle\Component\WmsCapabilitiesParser;
 use Mapbender\WmsBundle\Entity\WmsOrigin;
 use Mapbender\WmsBundle\Entity\WmsSource;
-use OwsProxy3\CoreBundle\Component\CommonProxy;
-use OwsProxy3\CoreBundle\Component\ProxyQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Service class that produces WmsSource entities by evaluating a "GetCapabilities" document, either directly
@@ -28,12 +28,16 @@ class Importer
 
     /** @var ContainerInterface */
     protected $container;
+    /** @var HttpTransportInterface */
+    protected $transport;
 
     /**
+     * @param HttpTransportInterface $transport
      * @param ContainerInterface $container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(HttpTransportInterface $transport, ContainerInterface $container)
     {
+        $this->transport = $transport;
         $this->container = $container;
     }
 
@@ -81,24 +85,13 @@ class Importer
     }
 
     /**
-     * @return string[]
-     */
-    public static function requestDefaults()
-    {
-        return array(
-            'request' => 'GetCapabilities',
-            'service' => 'WMS',
-        );
-    }
-
-    /**
      * @param WmsOrigin $serviceOrigin
      * @return \DOMDocument
      */
     public function loadCapabilitiesDocument(WmsOrigin $serviceOrigin)
     {
         static::validateUrl($serviceOrigin->getUrl());
-        $serviceResponse = $this->capabilitiesRequest($serviceOrigin, static::requestDefaults());
+        $serviceResponse = $this->capabilitiesRequest($serviceOrigin);
         $capsDocument = WmsCapabilitiesParser::createDocument($serviceResponse->getContent());
         return $capsDocument;
     }
@@ -115,25 +108,19 @@ class Importer
 
     /**
      * @param WmsOrigin $serviceOrigin
-     * @param array $params
      * @return Response
      */
-    protected function capabilitiesRequest(WmsOrigin $serviceOrigin, $params)
+    protected function capabilitiesRequest(WmsOrigin $serviceOrigin)
     {
-        $proxy_config = $this->container->getParameter("owsproxy.proxy");
-        $proxy_query  = ProxyQuery::createFromUrl($serviceOrigin->getUrl(), $serviceOrigin->getUserName(), $serviceOrigin->getPassword());
-        /** @TODO: we REQUIRE a GetCapabilities request, so this should be a forced replacement of the "request" param */
-        /** @TODO: evaluate $params instead of hard-coding, so this thing actually becomes flexible enough for reuse */
-        if ($proxy_query->getGetPostParamValue("request", true) === null) {
-            $proxy_query->addQueryParameter("request", "GetCapabilities");
+        $addParams = array();
+        $url = $serviceOrigin->getUrl();
+        $addParams['REQUEST'] = 'GetCapabilities';
+        if (!UrlUtil::getQueryParameterCaseInsensitive($url, 'service')) {
+            $addParams['SERVICE'] = 'WMS';
         }
-        if ($proxy_query->getGetPostParamValue("service", true) === null) {
-            $proxy_query->addQueryParameter("service", "WMS");
-        }
-        $proxy = new CommonProxy($proxy_config, $proxy_query, $this->container->get("logger"));
-        /** @var Response $response */
-        $response = $proxy->handle();
-        return $response;
+        $url = UrlUtil::validateUrl($url, $addParams);
+        $url = UrlUtil::addCredentials($url, $serviceOrigin->getUserName(), $serviceOrigin->getPassword());
+        return $this->transport->getUrl($url);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Controller/RepositoryController.php
+++ b/src/Mapbender/WmsBundle/Controller/RepositoryController.php
@@ -89,14 +89,13 @@ class RepositoryController extends Controller
 
         $form      = $this->createForm(new WmsSourceSimpleType(), $wmssource_req);
         $form->submit($request);
-        $onlyvalid = $form->get('onlyvalid')->getData();
         if ($form->isValid()) {
             /** @var Importer $importer */
             $importer = $this->container->get('mapbender.importer.source.wms.service');
             $origin = new WmsOrigin($wmssource_req->getOriginUrl(), $wmssource_req->getUsername(), $wmssource_req->getPassword());
 
             try {
-                $importerResponse = $importer->evaluateServer($origin, $onlyvalid);
+                $importerResponse = $importer->evaluateServer($origin, false);
             } catch (\Exception $e) {
                 $this->get("logger")->err($e->getMessage());
                 $this->get('session')->getFlashBag()->set('error', $e->getMessage());
@@ -104,11 +103,6 @@ class RepositoryController extends Controller
             }
 
             $wmssource = $importerResponse->getWmsSourceEntity();
-            $validationError = $importerResponse->getValidationError();
-            if ($validationError) {
-                $this->get("logger")->warn($validationError->getMessage());
-                $this->get('session')->getFlashBag()->set('warning', $validationError->getMessage());
-            }
 
             /** @TODO: this path can never be entered. Why is it here? */
             if (!$wmssource) {

--- a/src/Mapbender/WmsBundle/Form/Type/WmsSourceSimpleType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/WmsSourceSimpleType.php
@@ -25,12 +25,6 @@ class WmsSourceSimpleType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            // Base data
-            ->add('onlyvalid', 'checkbox', array(
-                'mapped' => false,
-                'data' => false,
-                'label' => 'mb.wms.wmsloader.repo.form.label.onlyvalid',
-            ))
             ->add('originUrl', 'text', array(
                 'required' => true,
                 'label' => 'mb.wms.wmsloader.repo.form.label.serviceurl',

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -13,6 +13,7 @@
     </parameters>
     <services>
         <service id="mapbender.importer.source.wms.service" class="%mapbender.importer.source.wms.service.class%">
+            <argument type="service" id="mapbender.http_transport.service" />
             <argument type="service" id="service_container" />
         </service>
         <service id="mapbender.source.wms.service" class="%mapbender.source.wms.service.class%">

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/form.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/form.html.twig
@@ -9,13 +9,6 @@
   {# This only option to prevent browser auto fill inputs. Sad but true. More info: #4814 #}
   <input style="position: absolute; display: block; top: -1000px; left: 0" type="text" name="somefakename" tabindex="-1"/>
   <input style="position: absolute; display: block; top: -1000px; left: 0" type="password" name="anotherfakename" tabindex="-1"/>
-  {# special snowflake FOM checkbox widget doesn't even add the correct class name to the label, and ignores label_attr #}
-  {# {{ form_row(form.onlyvalid) }} #}
-  <div>
-    {{ form_widget(form.onlyvalid) }}<label for="{{form.onlyvalid.vars['id']}}" class="labelCheck">{{ form.onlyvalid.vars.label | trans }}</label>
-    {# checkbox widget added a float: left ... #}
-    <div class="clear"></div>
-  </div>
   {{ form_row(form.originUrl) }}
   {{ form_row(form.username) }}
   {{ form_row(form.password) }}


### PR DESCRIPTION
Closes #1149 

Time for loading the rather trivial Wheregroup OSM demo service (2 layers) with version=1.3.0 drops from 15 seconds to 0.25 seconds.

This completes removal of formal Wms capabilities validation (already removed from WmsLoader and Wms reload).

The validation path can now only be triggered with the `mapbender:wms:validate:url ` console command.