### PR TITLE
Fix/featureinfo configurable count

### DIFF
--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -45,15 +45,18 @@ class FeatureInfo extends Element
     /**
      * @inheritdoc
      */
-    public function getConfiguration()
+    public function getPublicConfiguration()
     {
-        $config = parent::getConfiguration();
+        $config = $this->entity->getConfiguration();
         $defaults = self::getDefaultConfiguration();
         if (empty($config['width'])) {
             $config['width'] = $defaults['width'];
         }
         if (empty($config['height'])) {
             $config['height'] = $defaults['height'];
+        }
+        if (empty($config['maxCount']) || $config['maxCount'] < 0) {
+            $config['maxCount'] = $defaults['maxCount'];
         }
         return $config;
     }
@@ -74,7 +77,8 @@ class FeatureInfo extends Element
             "displayType" => 'tabs',
             "target" => null,
             "width" => 700,
-            "height" => 500
+            "height" => 500,
+            "maxCount" => 100,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -25,7 +25,8 @@ class FeatureInfoAdminType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'application' => null
+            'application' => null,
+            'maxCount' => 100,
         ));
     }
 
@@ -52,6 +53,10 @@ class FeatureInfoAdminType extends AbstractType
                 'property_path' => '[target]',
                 'required' => false))
             ->add('width', 'integer', array('required' => true))
-            ->add('height', 'integer', array('required' => true));
+            ->add('height', 'integer', array('required' => true))
+            ->add('maxCount', 'integer', array(
+                'required' => false,
+            ))
+        ;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -56,6 +56,9 @@ class FeatureInfoAdminType extends AbstractType
             ->add('height', 'integer', array('required' => true))
             ->add('maxCount', 'integer', array(
                 'required' => false,
+                'attr' => array(
+                    'placeholder' => 100,
+                ),
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -10,6 +10,7 @@
             printResult: false,
             showOriginal: false,
             onlyValid: false,
+            maxCount: 100,
             width: 700,
             height: 500
         },
@@ -151,19 +152,17 @@
             $('#js-error-featureinfo').addClass('hidden');
             $.each(this.target.getModel().getSources(), function(idx, src) {
                 var layerTitle = self._getTabTitle(src);
-                if (Mapbender.source[src.type]) {
-                    var url = Mapbender.source[src.type].featureInfoUrl(src, x, y);
-                    if (url) {
-                        self.queries[src.mqlid] = url;
-                        if (!self.options.onlyValid) {
-                            self._addContent(src.mqlid, layerTitle, 'wird geladen');
-                            self._open();
-                        }
-                        called = true;
-                        self._setInfo(src, url);
-                    } else {
-                        self._removeContent(src.mqlid);
+                var url = src.getPointFeatureInfoUrl(x, y, self.options.maxCount);
+                if (url) {
+                    self.queries[src.mqlid] = url;
+                    if (!self.options.onlyValid) {
+                        self._addContent(src.mqlid, layerTitle, 'wird geladen');
+                        self._open();
                     }
+                    called = true;
+                    self._setInfo(src, url);
+                } else {
+                    self._removeContent(src.mqlid);
                 }
             });
             if (!called) {

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -19,6 +19,7 @@
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.displayType) }}{{ form_widget(form.configuration.displayType) }}
     <div class="clearContainer"></div>
+    {{ form_row(form.configuration.maxCount) }}
     {{ form_label(form.configuration.width) }}{{ form_widget(form.configuration.width) }}
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.height) }}{{ form_widget(form.configuration.height) }}

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -145,7 +145,7 @@ window.Mapbender.WmsSource = (function() {
             var newStyles = (olLayer.params.STYLES || '').toString() !== layerParams.styles.toString();
             return newLayers || newStyles;
         },
-        getPointFeatureInfoUrl: function(x, y) {
+        getPointFeatureInfoUrl: function(x, y, maxCount) {
             var olLayer = this.getNativeLayer(0);
             if (!(olLayer && olLayer.getVisibility())) {
                 return false;
@@ -158,7 +158,7 @@ window.Mapbender.WmsSource = (function() {
                 url: Mapbender.Util.removeProxy(olLayer.url),
                 layers: [olLayer],
                 queryVisible: true,
-                maxFeatures: 1000
+                maxFeatures: maxCount || 100
             });
             wmsgfi.map = olLayer.map;
             var reqObj = wmsgfi.buildWMSOptions(

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -170,7 +170,7 @@ window.Mapbender.WmtsTmsBaseSource = (function() {
                 return !!(layerParams.layers && layerParams.layers.length);
             }
         },
-        getPointFeatureInfoUrl: function(x, y) {
+        getPointFeatureInfoUrl: function(x, y, maxCount) {
             // not implemented
             return null;
         },


### PR DESCRIPTION
Resolves #1099 

Reduces default FEATURE_COUNT sent when passing WMS GetFeatureInfo requests to 100.

Adds configuration field `maxCount` to FeatureInfo element to allow different values.

Putting this configuration onto the source instance was considered, but would have required database migration, unlike an extended Element configuration.