### PR TITLE
Enh/sitelinks

### DIFF
--- a/src/Mapbender/CoreBundle/Controller/LoginController.php
+++ b/src/Mapbender/CoreBundle/Controller/LoginController.php
@@ -1,0 +1,79 @@
+<?php
+namespace Mapbender\CoreBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * User controller.
+ * Copied into Mapbender from FOM v3.0.6.4.
+ * See https://github.com/mapbender/fom/blob/v3.0.6.4/src/FOM/UserBundle/Controller/LoginController.php
+ *
+ * @author Christian Wygoda
+ * @author Paul Schmidt
+ */
+class LoginController extends Controller
+{
+    /**
+     * User login
+     *
+     * @Route("/user/login")
+     * @Template()
+     * @Method("GET")
+     */
+    public function loginAction()
+    {
+        $request = $this->get('request_stack')->getCurrentRequest();
+        /*
+        if($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        } else {
+            $error = $request->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
+        }
+        */
+
+        $session = $request->getSession();
+
+        // get the login error if there is one
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(
+                Security::AUTHENTICATION_ERROR
+            );
+        } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $session->get(Security::AUTHENTICATION_ERROR);
+            $session->remove(Security::AUTHENTICATION_ERROR);
+        } else {
+            $error = '';
+        }
+
+        // last username entered by the user
+        $lastUsername = (null === $session) ? '' : $session->get(Security::LAST_USERNAME);
+
+        return array(
+            'last_username' => $lastUsername,
+            'error' => $error,
+            'selfregister' => $this->container->getParameter("fom_user.selfregister"),
+            'reset_password' => $this->container->getParameter("fom_user.reset_password")
+        );
+    }
+
+    /**
+     * @Route("/user/login/check")
+     */
+    public function loginCheckAction()
+    {
+        //Don't worry, this is actually intercepted by the security layer.
+    }
+
+    /**
+     * @Route("/user/logout")
+     */
+    public function logoutAction()
+    {
+        //Don't worry, this is actually intercepted by the security layer.
+    }
+}

--- a/src/Mapbender/CoreBundle/Controller/LoginController.php
+++ b/src/Mapbender/CoreBundle/Controller/LoginController.php
@@ -1,12 +1,10 @@
 <?php
 namespace Mapbender\CoreBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 /**
  * User controller.
@@ -21,44 +19,22 @@ class LoginController extends Controller
     /**
      * User login
      *
-     * @Route("/user/login")
-     * @Template()
-     * @Method("GET")
+     * @Route("/user/login", methods={"GET"})
+     * @return Response
      */
     public function loginAction()
     {
-        $request = $this->get('request_stack')->getCurrentRequest();
-        /*
-        if($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
-        } else {
-            $error = $request->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
-        }
-        */
+        /** @var AuthenticationUtils $authenticationUtils */
+        $authenticationUtils = $this->get('security.authentication_utils');
+        $error = $authenticationUtils->getLastAuthenticationError(true);
+        $lastUsername = $authenticationUtils->getLastUsername();
 
-        $session = $request->getSession();
-
-        // get the login error if there is one
-        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(
-                Security::AUTHENTICATION_ERROR
-            );
-        } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
-            $error = $session->get(Security::AUTHENTICATION_ERROR);
-            $session->remove(Security::AUTHENTICATION_ERROR);
-        } else {
-            $error = '';
-        }
-
-        // last username entered by the user
-        $lastUsername = (null === $session) ? '' : $session->get(Security::LAST_USERNAME);
-
-        return array(
+        return $this->render('@MapbenderCore/Login/login.html.twig', array(
             'last_username' => $lastUsername,
             'error' => $error,
-            'selfregister' => $this->container->getParameter("fom_user.selfregister"),
-            'reset_password' => $this->container->getParameter("fom_user.reset_password")
-        );
+            'selfregister' => $this->getParameter("fom_user.selfregister"),
+            'reset_password' => $this->getParameter("fom_user.reset_password"),
+        ));
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Extension/SitelinksExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/SitelinksExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Extension;
+
+
+class SitelinksExtension extends \Twig_Extension
+{
+    /** @var string[][] */
+    protected $linkConfig;
+
+    /**
+     * @param string[][] $linkConfig
+     */
+    public function __construct($linkConfig)
+    {
+        $this->linkConfig = $linkConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return 'mapbender_sitelinks';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('get_sitelinks', array($this, 'get_sitelinks')),
+        );
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function get_sitelinks()
+    {
+        return $this->linkConfig;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
@@ -27,3 +27,7 @@ parameters:
     branding.project_name: ~
     branding.project_version: ~
     branding.logo: ~                # web-relative path
+
+    # Sitelinks displayed below login box and backend content
+    # Should be a list of items each with keys 'link' and 'text'
+    mapbender.sitelinks: []

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -41,6 +41,11 @@
             <argument type="service" id="mapbender.element_inventory.service" />
         </service>
 
+        <service id="mapbender.twig.sitelinks" class="Mapbender\CoreBundle\Extension\SitelinksExtension">
+            <tag name="twig.extension"/>
+            <argument>%mapbender.sitelinks%</argument>
+        </service>
+
         <service id="target_element" class="Mapbender\CoreBundle\Element\Type\TargetElementType">
             <argument type="service" id="service_container" />
             <tag name="form.type" alias="target_element"/>

--- a/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
@@ -42,11 +42,13 @@
     <div class="head">
       <hr class="dekoSeperator">
     </div>
-    <div class="logoContainer">
-      <a href="{{ path('mapbender_core_welcome_list') }}"><img class="logo" alt="Mapbender 3"
-                                                               src="{{ asset(fom.server_logo) }}"/></a>
+    <div class="login-wrapper">
+      <div class="logoContainer">
+        <a href="{{ path('mapbender_core_welcome_list') }}"><img class="logo" alt="Mapbender 3"
+                                                                 src="{{ asset(fom.server_logo) }}"/></a>
+      </div>
+      {% block box_content %}{% endblock %}
     </div>
-    {% block box_content %}{% endblock %}
   </div>
 {% endblock %}
 </body>

--- a/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
@@ -48,6 +48,14 @@
                                                                  src="{{ asset(fom.server_logo) }}"/></a>
       </div>
       {% block box_content %}{% endblock %}
+      {% set sitelinks = get_sitelinks() %}
+      {% if sitelinks %}
+      <ul class="sitelinks">
+        {% for sitelink in sitelinks %}
+          <li>{{ loop.first ? '' : '| ' }}<a href="{{ asset(sitelink.link) }}">{{ sitelink.text | trans }}</a></li>
+        {% endfor %}
+      </ul>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
@@ -1,0 +1,53 @@
+{% set application = {'slug': 'manager'} %}
+<!DOCTYPE html>
+<html class="no-js" lang="{{ app.request.locale }}">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>{% block title %}{% endblock %}</title>
+  <meta name="description" content="Mapbender 3">
+  <script language="JavaScript">
+    if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+      document.write('<meta name="viewport" content="width=device-width; initial-scale=1; maximum-scale=1; minimum-scale=1; user-scalable=no;target-densityDpi=240dpi"/>');
+    }
+  </script>
+  {##}
+  <link rel="shortcut icon" href="{% block favicon %}{% endblock %}"/>
+
+  {% block css %}
+    <link rel="stylesheet"
+          href="{{ path('mapbender_core_application_assets', {'slug': 'mb3-login', 'type': 'css'}) }}"/>
+
+  {% endblock %}
+
+  {% block trans %}
+    <script type="text/javascript"
+            src="{{ path('mapbender_core_application_assets', {'slug': application.slug, 'type': 'trans'}) }}"></script>
+    <script type="text/javascript">
+      var Mapbender = Mapbender || {};
+      Mapbender.configuration = {elements: {}};
+    </script>
+  {% endblock %}
+
+  {% block js %}
+    <script src="{{ asset('components/jquery/jquery.min.js') }}"></script>
+    <script src="{{ asset('components/jquery-ui/jquery-ui.min.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ path('mapbender_core_application_assets', {'slug': application.slug, 'type': 'js'}) }}"></script>
+  {% endblock %}
+</head>
+<body class="{% if app.debug %}debug{% endif %}">
+{% block content %}
+  <div class="authWrapper">
+    <div class="head">
+      <hr class="dekoSeperator">
+    </div>
+    <div class="logoContainer">
+      <a href="{{ path('mapbender_core_welcome_list') }}"><img class="logo" alt="Mapbender 3"
+                                                               src="{{ asset(fom.server_logo) }}"/></a>
+    </div>
+    {% block box_content %}{% endblock %}
+  </div>
+{% endblock %}
+</body>
+</html>

--- a/src/Mapbender/CoreBundle/Resources/views/Login/login.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/login.html.twig
@@ -1,0 +1,54 @@
+{% extends "MapbenderCoreBundle:Login:box.html.twig" %}
+{% block css %}
+  <link rel="stylesheet" href="{{ path('mapbender_core_application_assets', {'slug': 'mb3-login', 'type': 'css'}) }}"/>
+  <link rel="stylesheet" type="text/css" href="{{ asset('components/cookieconsent/build/cookieconsent.min.css') }}"/>
+{% endblock %}
+
+{% block title %}{{ 'fom.user.login.login.title' | trans}}{% endblock %}
+
+{% block box_content %}
+  <div class="loginBox login">
+    <h2 class="contentTitle">{{ 'fom.user.login.login.caption' | trans }}</h2>
+
+    <form action="{{ path("fom_user_login_logincheck") }}" method="post" id="login" novalidate="novalidate">
+      {% if error %}
+        <div class="messageBox error">
+          {% if error.message == "Bad credentials" %}
+            {{ 'fom.user.login.errors.bad-credentials' | trans }}
+          {% else %}
+            {{ error.message | trans }}
+          {% endif %}
+        </div>
+      {% endif %}
+
+      <label class="left labelInput" for="username">{{ 'fom.user.login.login.username' | trans}}:</label>
+      <input class="input" id="username" type="text" name="_username" value="{{ last_username }}" autofocus />
+
+      <div class="clearContainer"></div>
+
+      <label class="left labelInput" for="password">{{ 'fom.user.login.login.password' | trans}}:</label>
+      <input class="input" type="password" id="password" name="_password" />
+
+      <div class="clearContainer"></div>
+
+      {% if selfregister == true %}
+      <a class="linkButton iconLinkButton left" href="{{ path('fom_user_registration_form') }}">{{ 'fom.user.login.login.register' | trans}}</a>
+      {% endif %}
+      {% if reset_password == true %}
+      <a class="linkButton iconLinkButton left" href="{{ path('fom_user_password_form') }}">{{ 'fom.user.login.login.forgot_password' | trans}}?</a>
+      {% endif %}
+
+      <input type="submit" class="right button" value="{{ 'fom.user.login.login.login' | trans}}" />
+      <div class="clearContainer"></div>
+    </form>
+  </div>
+  <script type="text/javascript">
+    if(top != window) {
+      top.location.href = location.href;
+      top.location.reload();
+    }
+    var Mapbender = Mapbender || {};
+    Mapbender.configuration = {elements:{}};
+  </script>
+    {% include 'MapbenderCoreBundle::cookieconsent.html.twig' %}
+{% endblock %}

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
@@ -16,28 +16,27 @@
     }
 
 
-    > .loginBox {
+    .loginBox {
 
-      > .contentTitle {
+      .contentTitle {
         margin-bottom: 10px;
         font-size: $fontSize * 2;
       }
 
-      > form {
-        > .labelInput {
+      form {
+        .labelInput {
           margin-top: 0.7em;
           font-size: $fontSize * 1.1;
           margin-bottom: 0.4em;
         }
 
-        > .labelText {
+        .labelText {
           font-size: $fontSize;
           line-height: $fontSize;
           margin-bottom: 0.2em;
         }
 
-        > .inputWrapper > input,
-        > input {
+        input {
           font-size: $fontSize * 1.4;
           line-height: 2em;
           height: auto;
@@ -45,30 +44,25 @@
           padding-bottom: 0;
           vertical-align: middle;
         }
-
-        > .linkButton, > .button {
-          font-size: $fontSize;
-          height: auto;
-          line-height: 270%;
-          vertical-align: middle;
-          display: inline-block;
-          padding-top: 0;
-          padding-bottom: 0;
-        }
+      }
+      .linkButton, .button {
+        font-size: $fontSize;
+        height: auto;
+        line-height: 270%;
+        vertical-align: middle;
+        display: inline-block;
+        padding-top: 0;
+        padding-bottom: 0;
       }
     }
   }
 }
 
 .authWrapper {
-  @include transition(all 0.6s ease-in-out);
-
   position: absolute;
   top: 15%;
   right: 0;
   left: 0;
-
-  @include transition(all 0.6s ease-in-out);
 
   > .head {
     position: absolute;
@@ -85,14 +79,16 @@
       @include absolute('' 0 0 0);
     }
   }
-
-  > .loginBox {
+  .login-wrapper {
     position: relative;
-    padding: $space;
     width: 90%;
     max-width: 340px;
+    margin: 0 auto;
+  }
+
+  .loginBox {
+    padding: $space;
     background: lighten($contentColor, 2%) url($managerContentPatternUrl);
-    margin: 15px auto 0;
     border: {
       top: solid 1px $secondColor;
       left: solid 1px $thirdColor;
@@ -101,15 +97,15 @@
       radius: $containerBorderRadius;
     }
 
-    > .contentTitle {
+    .contentTitle {
       margin-bottom: 10px;
 
     }
     .input {
-      width: 100% !important;
+      width: 100%;
     }
     .labelInput {
-      width: 100% !important;
+      width: 100%;
       line-height: 10px;
     }
 
@@ -126,13 +122,14 @@
   .logoContainer {
     text-align: center;
     display: block;
-    position: relative;
-    margin-top: 20px;
     height: auto;
     .logo {
       max-height: 120px;
 
     }
+  }
+  .logoContainer, .loginBox {
+    margin-top: 15px;
   }
 
   .labelInput {

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
@@ -145,6 +145,14 @@
     margin-right: $space/2;
   }
 
-
+  .sitelinks {
+    text-align: right;
+    li {
+      display: inline-block;
+      a, a:visited {
+        color: inherit;
+      }
+    }
+  }
 }
 

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/manager.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/manager.scss
@@ -91,18 +91,32 @@ $pageWidth: $contentPaneWidth + $navWidth;
   hr{@include absolute('' 0 0 0);}
 }
 
+.account-bar-wrap {
+  float: right;
+}
+.sitelinks {
+  margin-top: 0.5em;
+  li {
+    display: inline-block;
+    a, a:visited {
+      color: inherit;
+    }
+    a:hover, a:focus {
+      color: $lightFontColor;
+    }
+  }
+}
 .accountBar {
+  display: inline-block;
   color: $middleFontColor;
   cursor: pointer;
   padding: ($space/4) ($space/2) ($space/4) ($space/2);
   background-color: $contentColor;
   border-bottom-left-radius: $containerBorderRadius;
   border-bottom-right-radius: $containerBorderRadius;
-  @include absolute(0 0 '' '');
   > .accountMenu {
     height: 20px;
     overflow: hidden;
-    position: relative;
     @include transition(all 0.2s ease-in-out);
 
     &.opened {
@@ -188,6 +202,9 @@ $pageWidth: $contentPaneWidth + $navWidth;
 .rightPane {
   width: $contentPaneWidth;
   @include absolute(0 0 '' $navWidth);
+  .top {
+    height: $space * 6;
+  }
 }
 
 textarea, input[type=text], input[type=submit], input[type=password],  a.button, button, div.dropdown {
@@ -246,9 +263,6 @@ ul.dropdownList{
 }
 
 .contentPane {
-  $top: $space*5;
-  padding-top: $top + $space;
-
   > .content {
     min-height: 600px;
     position: relative;

--- a/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
@@ -28,28 +28,39 @@
       </div>
 
       <div class="rightPane">
+          <div class="top">
+              <div class="account-bar-wrap">
+                  <div class="accountBar">
+                    {% if app.user != "" %}
+                      <ul id="accountMenu" class="accountMenu">
+                          <li id="accountOpen" class="iconDown smallText">{{ "fom.core.manager.logged_as"|trans}}: {{ app.user.username }}<span class="openedIcon"></span></li>
+                          {% if app.user.password != "" %} <li><a class="linkButton iconSettings" href="{{ path('fom_user_user_edit', {'id': app.user.id}) }}">{{ "fom.core.manager.you_account"|trans }}</a></li>{% endif %}
+                          <li><a class="linkButton iconSignOut" href="{{ path('fom_user_login_logout') }}">{{ "fom.core.manager.btn.logout"|trans }}</a></li>
+                      </ul>
+                    {% else %}
+                      <a class="linkButton iconSignIn" href="{{ path('fom_user_login_login') }}">{{ "fom.core.manager.btn.login"|trans}}</a>
+                    {% endif %}
+                  </div>
+              </div>
+              {% set sitelinks = get_sitelinks() %}
+              {% if sitelinks %}
+              <ul class="sitelinks">
+                {% for sitelink in sitelinks %}
+                  <li>{{ loop.first ? '' : '| ' }}<a href="{{ asset(sitelink.link) }}">{{ sitelink.text | trans }}</a></li>
+                {% endfor %}
+              </ul>
+              {% endif %}
 
-        {# flash me baby #}
-        {% for key, flash in app.session.bag('flashes') %}
-          <div class="flashBox {{ key }}">
-            {{ flash | first }}
+            {% for key, flash in app.session.bag('flashes') %}
+              <div class="flashBox {{ key }}">
+                {{ flash | first }}
+              </div>
+            {% endfor %}
+
           </div>
-        {% endfor %}
-
-        <div class="accountBar shadowBox">
-          {% if app.user != "" %}
-            <ul id="accountMenu" class="accountMenu">
-                <li id="accountOpen" class="iconDown smallText">{{ "fom.core.manager.logged_as"|trans}}: {{ app.user.username }}<span class="openedIcon"></span></li>
-                {% if app.user.password != "" %} <li><a class="linkButton iconSettings" href="{{ path('fom_user_user_edit', {'id': app.user.id}) }}">{{ "fom.core.manager.you_account"|trans }}</a></li>{% endif %}
-                <li><a class="linkButton iconSignOut" href="{{ path('fom_user_login_logout') }}">{{ "fom.core.manager.btn.logout"|trans }}</a></li>
-            </ul>
-          {% else %}
-            <a class="linkButton iconSignIn" href="{{ path('fom_user_login_login') }}">{{ "fom.core.manager.btn.login"|trans}}</a>
-          {% endif %}
-        </div>
         <div class="contentPane">
           <div id="version" class="mapbenderVersion smallText">v. {{ fom.server_version }}</div>
-          <div class="content shadowBox">
+          <div class="content">
             <h1 class="contentTitle">{{ title|trans }}</h1>
 
             {% block manager_content %}{% endblock %}


### PR DESCRIPTION
Adds machinations to emit configurable site links to the backend and login layouts.  
Site links are configured by setting the `mapbender.sitelinks` parameter. Expected value is a collection of items with `link` and `text` keys. E.g. you could put the following into parameters.yml:
```yaml
     mapbender.sitelinks:
       - link: https://some-domain.org/
         text: External absolute link
       - link: relative-path/something.png
         text: Relative link under application/web
       - link: /absolute-path/something-else.html
         text: Absolute link to something on the same host
```
Site link item `text` values are piped through the twig translation filter to support localization.

By default, there are no site links configured.

This machinery can be used to link to existing imprint and site meta information pages.


### Customization impact
The implementation takes the LoginController and the relevant base templates from FOM into Mapbender, similar to the [recent adoption of the manager.html.twig template](https://github.com/mapbender/mapbender/pull/1120). This may cause some surprises with customization to the login template, or its outer box template.

If present, the following drop-in template replacements (in app/resources) will need to be reviewed and copied to the new paths:
* `FOMUserBundle/views/Login/box.html.twig` => `MapbenderCoreBundle/views/Login/box.html.twig`
* `FOMUserBundle/views/Login/login.html.twig` => `MapbenderCoreBundle/views/Login/login.html.twig`
