### PR TITLE
Enh/print feature markers

### DIFF
--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -321,6 +321,13 @@ class LayerRendererGeoJson extends LayerRenderer
         if (!empty($style['label'])) {
             $this->drawFeatureLabel($canvas, $style, $style['label'], $p);
         }
+        if (!empty($style['externalGraphic'])) {
+            $anchorXy = array(
+                'x' => $p[0],
+                'y' => $p[1],
+            );
+            $this->markerRenderer->addFeatureGraphic($canvas, $anchorXy, $style);
+        }
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -3,7 +3,6 @@
 
 namespace Mapbender\PrintBundle\Component;
 
-use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\PrintBundle\Component\Export\Box;
 use Mapbender\PrintBundle\Component\Export\ExportCanvas;
 use Mapbender\PrintBundle\Component\Geometry\LineLoopIterator;
@@ -114,6 +113,7 @@ class LayerRendererGeoJson extends LayerRenderer
      */
     protected function getDefaultFeatureStyle($type)
     {
+        // see http://dev.openlayers.org/releases/OpenLayers-2.13.1/docs/files/OpenLayers/Feature/Vector-js.html#OpenLayers.Feature.Vector.Constants
         return array(
             'strokeWidth' => 1,
             'strokeOpacity' => 1,
@@ -124,6 +124,8 @@ class LayerRendererGeoJson extends LayerRenderer
             'labelXOffset' => 0,
             'labelYOffset' => 0,
             'fontOpacity' => 1,
+            'pointRadius' => 6,
+            'fillOpacity' => 0.4,
         );
     }
 
@@ -297,14 +299,14 @@ class LayerRendererGeoJson extends LayerRenderer
         $p[1] = round($p[1]);
 
         $diameter = max(1, round(2 * $style['pointRadius'] * $resizeFactor));
-        if ($style['fillOpacity'] > 0) {
+        if (isset($style['fillColor']) && $style['fillOpacity'] > 0) {
             $color = $this->getColor(
                 $style['fillColor'],
                 $style['fillOpacity'],
                 $canvas->resource);
             $canvas->drawFilledCircle($p[0], $p[1], $color, $diameter);
         }
-        if ($style['strokeOpacity'] > 0 && $style['strokeWidth']) {
+        if (isset($style['strokeColor']) && $style['strokeOpacity'] > 0 && $style['strokeWidth']) {
             $strokeWidth = max(0, intval(round($style['strokeWidth'] * $canvas->featureTransform->lineScale)));
             if ($strokeWidth > 0) {
                 $strokeColor = $this->getColor($style['strokeColor'], $style['strokeOpacity'], $canvas->resource);

--- a/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererGeoJson.php
@@ -19,13 +19,17 @@ class LayerRendererGeoJson extends LayerRenderer
 {
     /** @var string */
     protected $fontPath;
+    /** @var LayerRendererMarkers */
+    protected $markerRenderer;
 
     /**
      * @param string $fontPath
+     * @param LayerRendererMarkers $markerRenderer
      */
-    public function __construct($fontPath)
+    public function __construct($fontPath, LayerRendererMarkers $markerRenderer)
     {
         $this->fontPath = rtrim($fontPath, '/');
+        $this->markerRenderer = $markerRenderer;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererMarkers.php
@@ -4,6 +4,7 @@
 namespace Mapbender\PrintBundle\Component;
 
 
+use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\PrintBundle\Component\Export\Box;
 use Mapbender\PrintBundle\Component\Export\ExportCanvas;
 use Mapbender\PrintBundle\Util\GdUtil;
@@ -43,6 +44,27 @@ class LayerRendererMarkers extends LayerRenderer
             $transformedCoords = $transform->transformXy($markerDef['coordinates']);
             $this->addIcon($canvas, $image, $transformedCoords,
                 $markerDef['offset'], $markerDef['width'], $markerDef['height']);
+            imagedestroy($image);
+        }
+    }
+
+    /**
+     * @param ExportCanvas $canvas
+     * @param float[] $anchorXy in canvas pixel space
+     * @param array $featureStyle
+     */
+    public function addFeatureGraphic(ExportCanvas $canvas, $anchorXy, $featureStyle)
+    {
+        $iconPath = rtrim($this->imageRoot, '/') . '/' . ltrim($featureStyle['externalGraphic'], '/');
+        $image = $this->getImage($iconPath, ArrayUtil::getDefault($featureStyle, 'graphicOpacity', 1));
+        if ($image) {
+            $offsetXy = array(
+                'x' => ArrayUtil::getDefault($featureStyle, 'graphicXOffset', 0),
+                'y' => ArrayUtil::getDefault($featureStyle, 'graphicYOffset', 0),
+            );
+            $iconWidth = ArrayUtil::getDefault($featureStyle, 'graphicWidth', imagesx($image));
+            $iconHeight = ArrayUtil::getDefault($featureStyle, 'graphicHeight', imagesy($image));
+            $this->addIcon($canvas, $image, $anchorXy, $offsetXy, $iconWidth, $iconHeight);
             imagedestroy($image);
         }
     }

--- a/src/Mapbender/PrintBundle/Resources/config/services.xml
+++ b/src/Mapbender/PrintBundle/Resources/config/services.xml
@@ -66,6 +66,7 @@
         </service>
         <service id="mapbender.imageexport.renderer.geojson" class="%mapbender.imageexport.renderer.geojson.class%">
             <argument>%mapbender.imageexport.resource_dir%/fonts</argument>
+            <argument type="service" id="mapbender.imageexport.renderer.markers" />
         </service>
         <service id="mapbender.print.service" class="%mapbender.print.service.class%">
             <argument type="collection" key="layerRenderers">

--- a/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/mapbender.element.imageExport.js
@@ -236,6 +236,9 @@
             if (geometry.style.fillOpacity > 0 || geometry.style.strokeOpacity > 0) {
                 return true;
             }
+            if (geometry.style.externalGraphic) {
+                return true;
+            }
             if (geometry.style.label !== undefined) {
                 return true;
             }


### PR DESCRIPTION
Adds support for marker icons on point vector features for image export and print. Previously, only markers on marker layers were supported.

