### PR TITLE
Feature/simpleSearch simpleSearch srs and label-string configurable

### DIFF
--- a/src/Mapbender/CoreBundle/Element/SimpleSearch.php
+++ b/src/Mapbender/CoreBundle/Element/SimpleSearch.php
@@ -56,6 +56,7 @@ class SimpleSearch extends Element
             'label_attribute' => 'label',
             'geom_attribute'  => 'geom',
             'geom_format'     => 'WKT',
+            'geom_srs'        => '4326',
             'delay'           => 300,
         );
     }

--- a/src/Mapbender/CoreBundle/Element/Type/SimpleSearchAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/SimpleSearchAdminType.php
@@ -72,6 +72,9 @@ class SimpleSearchAdminType extends AbstractType
                     'WKT' => 'WKT',
                     'GeoJSON' => 'GeoJSON'),
                 'required' => true))
+            ->add('geom_srs', 'number', array(
+                'property_path' => '[geom_srs]',
+                'required' => true))
             ->add('delay', 'number', array(
                 'property_path' => '[delay]',
                 'required' => true))

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -10,6 +10,7 @@ $.widget('mapbender.mbSimpleSearch', {
         label_attribute: null,
         geom_attribute: null,
         geom_format: null,
+        geom_srs: null,
         result: {
             buffer: null,
             minscale: null,
@@ -24,17 +25,31 @@ $.widget('mapbender.mbSimpleSearch', {
     layer: null,
 
     _create: function() {
-        var self = this;
+        var self = outerSelf = this;
         var searchInput = $('.searchterm', this.element);
         var url = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/search';
 
         // Set up autocomplete
-        this.autocomplete = new Mapbender.Autocomplete(searchInput, {
+        self.autocomplete = new Mapbender.Autocomplete(searchInput, {
             url: url,
-            delay: this.options.delay,
-            dataTitle: this.options.label_attribute,
+            delay: self.options.delay,
             dataIdx: null,
-            preProcessor: $.proxy(this._tokenize, this)
+            preProcessor: $.proxy(self._tokenize, self),
+            open: function(data){
+                this.selected = null;
+                if(data.length > 0){
+                    var self = this;
+                    self.data = data;
+                    var res = "<ul>";
+                    $.each(data, function(idx, item){
+                        var itemIndex = self.options.dataIdx ? item[outerSelf.options.dataIdx] : idx;
+                        res += '<li data-idx="' + itemIndex + '">' + outerSelf._labelize(outerSelf.options.label_attribute,item) + '</li>';
+                    });
+                    res += "</ul>";
+                    this.autocompleteList.html(res).show();
+                    this.autocompleteList.find('li').on('click', $.proxy(self.select, self));
+                }
+            },
         });
 
         // On manual submit (enter key, submit button), trigger autocomplete manually
@@ -54,23 +69,54 @@ $.widget('mapbender.mbSimpleSearch', {
         return (Mapbender.elementRegistry.listWidgets())['mapbenderMbMap'];
     },
     _onAutocompleteSelected: function(evt, evtData) {
-        var format = new OpenLayers.Format[this.options.geom_format]();
+        var self = this,
+            format = new OpenLayers.Format[self.options.geom_format](),
+            srs = self.options.geom_srs,
+            requestProj = null,
+            feature = null,
+            zoomToFeatureOptions = null,
+            mbMap = self._getMbMap();
+
+        var olMap = mbMap.map.olMap;
+        var mapProj = olMap.getProjectionObject();
+
         if(!evtData.data[this.options.geom_attribute]) {
             $.notify( Mapbender.trans("mb.core.simplesearch.error.geometry.missing"));
             return;
         }
 
-        var feature = format.read(evtData.data[this.options.geom_attribute]);
-        var mbMap = this._getMbMap();
+        if(! srs) {
+            console.warn("srs from search value hav not a srs reference. Now set default EPSG:4326", "EPSG:"+srs);
+            requestProj = new OpenLayers.Projection('EPSG:4326');
+        }else{
+            requestProj = new OpenLayers.Projection('EPSG:' + srs);
+        }
 
-        var zoomToFeatureOptions = this.options.result && {
-            maxScale: parseInt(this.options.result.maxscale) || null,
-            minScale: parseInt(this.options.result.minscale) || null,
-            buffer: parseInt(this.options.result.buffer) || null
+        if (self.options.geom_format === 'GeoJSON'){
+            feature = format.read(evtData.data,'Feature');
+        }else{
+            feature = format.read(evtData.data[this.options.geom_attribute]);
+        }
+
+        // transform request features
+        if (requestProj.projCode !== mapProj.projCode) {
+            var transCoord = self._transformCoordinates(
+                [feature.geometry.x, feature.geometry.y],
+                requestProj,
+                mapProj);
+
+            feature.geometry.x = transCoord[0];
+            feature.geometry.y = transCoord[1];
+        }
+
+        zoomToFeatureOptions = self.options.result && {
+            maxScale: parseInt(self.options.result.maxscale) || null,
+            minScale: parseInt(self.options.result.minscale) || null,
+            buffer: parseInt(self.options.result.buffer) || null
         };
         mbMap.getModel().zoomToFeature(feature, zoomToFeatureOptions);
-        this._hideMobile();
-        this._setFeatureMarker(feature);
+        self._hideMobile();
+        self._setFeatureMarker(feature);
     },
     _setFeatureMarker: function(feature) {
         var olMap = this._getMbMap().getModel().map.olMap;
@@ -134,7 +180,23 @@ $.widget('mapbender.mbSimpleSearch', {
         }
 
         return tokens.join(' ');
-    }
+    },
+
+    /**
+     * Transforms coordinate pair
+     * @param coordinatePair Array [lon, lat] (from point array)
+     * @param fromProj String olMap.getProjectionObject() "EPSG:xxxx"
+     * @param toProj String olMap.getProjectionObject() "EPSG:xxxx"
+     * @returns Array new projected point
+     * @private
+     */
+    _transformCoordinates: function(coordinatePair, fromProj, toProj) {
+        var olLonLat = new OpenLayers.LonLat(coordinatePair[0], coordinatePair[1]);
+        var olPoint =  olLonLat.transform(fromProj, toProj);
+        return [olPoint.lon, olPoint.lat];
+    },
+
+
 });
 
 })(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -196,7 +196,44 @@ $.widget('mapbender.mbSimpleSearch', {
         return [olPoint.lon, olPoint.lat];
     },
 
+    /**
+     * create label string for autocomplete
+     * @param input
+     * @param object
+     * @returns {*|string}
+     * @private
+     */
+    _labelize: function (input,object) {
 
+        var itemNormalize = function (labelstring, object) {
+            console.assert(typeof labelstring == "string" && typeof object == "object" && !Array.isArray(object),"Wrong input!");
+
+            var split = labelstring.split(".");
+            var subObject = object;
+            split.forEach(function(prop){
+                subObject = subObject && subObject[prop];
+            });
+
+            if (!subObject) {
+                console.warn("Property "+labelstring+" not found in object:",object);
+                return '';
+            }
+
+            return subObject;
+        };
+
+        var labels = input.split("+");
+
+        var str = "";
+
+        labels.forEach(function(label) {
+
+            str += itemNormalize(label.trim(),object) + ' ';
+        });
+
+        return str.trim();
+
+    }
 });
 
 })(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/simple_search.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/simple_search.html.twig
@@ -23,6 +23,8 @@
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.geom_format) }}{{ form_widget(form.configuration.geom_format) }}
     <div class="clearContainer"></div>
+    {{ form_label(form.configuration.geom_srs) }}{{ form_widget(form.configuration.geom_srs) }}
+    <div class="clearContainer"></div>
     {{ form_label(form.configuration.delay) }}{{ form_widget(form.configuration.delay) }}
     <div class="clearContainer"></div>
     {{ form_label(form.configuration.result_buffer) }}{{ form_widget(form.configuration.result_buffer) }}


### PR DESCRIPTION
An extension of the simple search:

- Now the objects can be transformed on the client side in projection.

- In the backend, the SRS can now be adjusted for the search

- In addition, it is possible to query Geojson objects via the search

- In addition, the label string in the backend can be adjusted by user-defined settings.

`properties.name + properties.street + properties.housenumber + properties.city + properties.postcode`


Example:

![grafik](https://user-images.githubusercontent.com/9570545/59549662-2e209e00-8f61-11e9-8bc8-e96a0503d8e3.png)
