### PR TITLE
Revert YamlApp changes

### DIFF
--- a/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
@@ -5,6 +5,8 @@ namespace Mapbender\CoreBundle\Command;
 
 
 use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\CoreBundle\Mapbender;
+use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,14 +27,15 @@ class ApplicationCloneCommand extends AbstractApplicationTransportCommand
             'slug' => $slug,
         ));
         if (!$application) {
-            $application = $this->getYamlApplication($slug);
-        }
-        if (!$application) {
             throw new \RuntimeException("No application with slug {$slug}");
         }
 
         $importHandler = $this->getApplicationImporter();
-        $clonedApp = $importHandler->duplicateApplication($application);
+        $newApplications = $importHandler->duplicateApplication($application);
+        if (count($newApplications) !== 1) {
+            echo "Uh-oh!\n";
+        }
+        $clonedApp = $newApplications[0];
         $output->writeln("Application cloned to new slug {$clonedApp->getSlug()}, id {$clonedApp->getId()}");
     }
 }

--- a/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
+++ b/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
@@ -90,7 +90,6 @@ class ApplicationYAMLMapper
         $application = new Application();
         $application
                 ->setSlug($slug)
-                ->setId($slug)
                 ->setTitle(isset($definition['title'])?$definition['title']:'')
                 ->setDescription(isset($definition['description'])?$definition['description']:'')
                 ->setTemplate($definition['template'])

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -33,11 +33,11 @@ class MapbenderCoreBundle extends MapbenderBundle
 
         $kernelPath = $container->getParameter('kernel.root_dir');
         $yamlAppDir = $kernelPath . "/config/applications";
-        $loginAppDir = dirname(__FILE__) . '/Resources/config/applications';
-        $container->addCompilerPass(new MapbenderYamlCompilerPass($loginAppDir));
         if (is_dir($yamlAppDir)) {
             $container->addCompilerPass(new MapbenderYamlCompilerPass($yamlAppDir));
         }
+        $loginAppDir = dirname(__FILE__) . '/Resources/config/applications';
+        $container->addCompilerPass(new MapbenderYamlCompilerPass($loginAppDir));
         $container->addCompilerPass(new ContainerUpdateTimestampPass());
         $container->addCompilerPass(new ProvideBrandingPass());
 


### PR DESCRIPTION
Please revert this changes. We cannot run the yaml-apps of two of our customers.
Different reasons:
- Loading parameters from application.yml fails. (parameters 'outside' the application tag)
- Loading parameters from parameters.yml into application configuration also fails.
- View permissions 
