### PR TITLE
Fix missing permissions after coping an application

### DIFF
--- a/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
@@ -8,6 +8,7 @@ use Mapbender\CoreBundle\Entity\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
 class ApplicationCloneCommand extends AbstractApplicationTransportCommand
 {
@@ -35,6 +36,9 @@ class ApplicationCloneCommand extends AbstractApplicationTransportCommand
         $clonedApp = $importHandler->duplicateApplication($application);
         if ($application->getSource() !== Application::SOURCE_YAML) {
             $importHandler->copyAcls($clonedApp, $application);
+        }
+        if ($root = $this->getRootUser()) {
+            $importHandler->addOwner($application, UserSecurityIdentity::fromAccount($root));
         }
 
         $output->writeln("Application cloned to new slug {$clonedApp->getSlug()}, id {$clonedApp->getId()}");

--- a/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
@@ -34,9 +34,6 @@ class ApplicationCloneCommand extends AbstractApplicationTransportCommand
 
         $importHandler = $this->getApplicationImporter();
         $clonedApp = $importHandler->duplicateApplication($application);
-        if ($application->getSource() !== Application::SOURCE_YAML) {
-            $importHandler->copyAcls($clonedApp, $application);
-        }
         if ($root = $this->getRootUser()) {
             $importHandler->addOwner($application, UserSecurityIdentity::fromAccount($root));
         }

--- a/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ApplicationCloneCommand.php
@@ -33,6 +33,10 @@ class ApplicationCloneCommand extends AbstractApplicationTransportCommand
 
         $importHandler = $this->getApplicationImporter();
         $clonedApp = $importHandler->duplicateApplication($application);
+        if ($application->getSource() !== Application::SOURCE_YAML) {
+            $importHandler->copyAcls($clonedApp, $application);
+        }
+
         $output->writeln("Application cloned to new slug {$clonedApp->getSlug()}, id {$clonedApp->getId()}");
     }
 }

--- a/src/Mapbender/CoreBundle/Command/ApplicationImportCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ApplicationImportCommand.php
@@ -7,6 +7,7 @@ namespace Mapbender\CoreBundle\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
 class ApplicationImportCommand extends AbstractApplicationTransportCommand
 {
@@ -33,8 +34,9 @@ class ApplicationImportCommand extends AbstractApplicationTransportCommand
         try {
             $applications = $importHandler->importApplicationData($importArray);
             if ($root) {
+                $rootSid = UserSecurityIdentity::fromAccount($root);
                 foreach ($applications as $application) {
-                    $importHandler->setDefaultAcls($application, $root);
+                    $importHandler->addOwner($application, $rootSid);
                 }
             } else {
                 $output->writeln("WARNING: root user not found, no owner will be assigned to imported applications", OutputInterface::VERBOSITY_QUIET);

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -175,6 +175,7 @@
             <argument type="service" id="mapbender.uploads_manager.service" />
             <argument type="service" id="security.acl.provider" />
             <argument type="service" id="fom.acl.manager" />
+            <argument type="service" id="security.token_storage" />
         </service>
         <service id="mapbender.application_exporter.service" class="%mapbender.application_exporter.service.class%">
             <argument type="service" id="doctrine.orm.default_entity_manager" />

--- a/src/Mapbender/ManagerBundle/Component/ImportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ImportHandler.php
@@ -18,14 +18,9 @@ use Mapbender\ManagerBundle\Component\Exchange\EntityHelper;
 use Mapbender\ManagerBundle\Component\Exchange\EntityPool;
 use Mapbender\ManagerBundle\Component\Exchange\ImportState;
 use Mapbender\ManagerBundle\Component\Exchange\ObjectHelper;
-use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
-use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
-use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
-use Symfony\Component\Security\Acl\Exception\Exception;
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
-use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
 use Symfony\Component\Security\Acl\Model\EntryInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
@@ -322,7 +317,7 @@ class ImportHandler extends ExchangeHandler
      * @param Application $target
      * @param Application $source
      * @throws InvalidDomainObjectException
-     * @throws Exception
+     * @throws \Symfony\Component\Security\Acl\Exception\Exception
      */
     public function copyAcls(Application $target, Application $source)
     {

--- a/src/Mapbender/ManagerBundle/Component/ImportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ImportHandler.php
@@ -132,6 +132,10 @@ class ImportHandler extends ExchangeHandler
             $this->uploadsManager->copySubdirectory($originalSlug, $clonedApp->getSlug());
             $this->em->flush();
 
+            if ($app->getSource() !== Application::SOURCE_YAML) {
+                $this->copyAcls($clonedApp, $app);
+            }
+
             return $clonedApp;
         } catch (ORMException $e) {
             throw new ImportException("Database error {$e->getMessage()}", 0, $e);
@@ -298,7 +302,7 @@ class ImportHandler extends ExchangeHandler
      * @throws InvalidDomainObjectException
      * @throws \Symfony\Component\Security\Acl\Exception\Exception
      */
-    public function copyAcls(Application $target, Application $source)
+    protected function copyAcls(Application $target, Application $source)
     {
         $sourceAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($source));
         $targetOid = ObjectIdentity::fromDomainObject($target);

--- a/src/Mapbender/ManagerBundle/Component/ImportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ImportHandler.php
@@ -18,19 +18,19 @@ use Mapbender\ManagerBundle\Component\Exchange\EntityHelper;
 use Mapbender\ManagerBundle\Component\Exchange\EntityPool;
 use Mapbender\ManagerBundle\Component\Exchange\ImportState;
 use Mapbender\ManagerBundle\Component\Exchange\ObjectHelper;
-    use Symfony\Component\Security\Acl\Domain\Acl;
+use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
-    use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
+use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
-    use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
-    use Symfony\Component\Security\Acl\Exception\Exception;
+use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Exception\Exception;
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
-    use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
+use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
 use Symfony\Component\Security\Acl\Model\EntryInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
 use Symfony\Component\Security\Acl\Permission\MaskBuilder;
-    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -48,8 +48,8 @@ class ImportHandler extends ExchangeHandler
     protected $aclProvider;
     /** @var AclManager */
     protected $aclManager;
-        /** @var TokenStorage */
-        protected $tokenStorage;
+    /** @var TokenStorage */
+    protected $tokenStorage;
 
     /**
      * @inheritdoc
@@ -59,7 +59,7 @@ class ImportHandler extends ExchangeHandler
                                 ExportHandler $exportHandler,
                                 UploadsManager $uploadsManager,
                                 MutableAclProviderInterface $aclProvider,
-                                    AclManager $aclManager, TokenStorage $tokenStorage)
+                                AclManager $aclManager, TokenStorage $tokenStorage)
     {
         parent::__construct($entityManager);
         $this->elementFactory = $elementFactory;
@@ -67,7 +67,7 @@ class ImportHandler extends ExchangeHandler
         $this->uploadsManager = $uploadsManager;
         $this->aclProvider = $aclProvider;
         $this->aclManager = $aclManager;
-            $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -137,14 +137,12 @@ class ImportHandler extends ExchangeHandler
             $this->uploadsManager->copySubdirectory($originalSlug, $clonedApp->getSlug());
             $this->em->flush();
 
-                $acl = $this->createAclForApplication($clonedApp);
-                $this->setApplicationOwnershipToCurrentUser($acl);
+            $acl = $this->createAclForApplication($clonedApp);
+            $this->setApplicationOwnershipToCurrentUser($acl);
             if ($app->getSource() !== Application::SOURCE_YAML) {
                 $this->copyAcls($clonedApp, $app);
             }
-            
-                
-                
+
             return $clonedApp;
         } catch (ORMException $e) {
             throw new ImportException("Database error {$e->getMessage()}", 0, $e);
@@ -314,7 +312,7 @@ class ImportHandler extends ExchangeHandler
         $aces = array(
             array(
                 'sid' => UserSecurityIdentity::fromAccount($currentUser),
-                    'mask' => MaskBuilder::MASK_OWNER,
+                'mask' => MaskBuilder::MASK_OWNER,
             ),
         );
         $this->aclManager->setObjectACL($application, $aces, 'object');
@@ -324,20 +322,19 @@ class ImportHandler extends ExchangeHandler
      * @param Application $target
      * @param Application $source
      * @throws InvalidDomainObjectException
-         * @throws Exception
+     * @throws Exception
      */
-        public function copyAcls(Application $target, Application $source )
+    public function copyAcls(Application $target, Application $source)
     {
-            /** @var MutableAclInterface $sourceAcl */
+        /** @var MutableAclInterface $sourceAcl */
         $sourceAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($source));
         /** @var MutableAclInterface $targetAcl */
-            $targetAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($target));
+        $targetAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($target));
 
         foreach ($sourceAcl->getObjectAces() as $sourceEntry) {
             /** @var EntryInterface $sourceEntry */
             $entryIdentity = $sourceEntry->getSecurityIdentity();
-                $targetAcl->insertObjectAce($entryIdentity, $sourceEntry->getMask());
-                
+            $targetAcl->insertObjectAce($entryIdentity, $sourceEntry->getMask());
         }
         $this->aclProvider->updateAcl($targetAcl);
     }
@@ -526,27 +523,25 @@ class ImportHandler extends ExchangeHandler
         }
         return $object;
     }
-        
-        /**
-         * @param Application $app
-         * @return MutableAclInterface
-         */
-        protected function createAclForApplication($app){
-    
-            $objectIdentityClonedApp =  ObjectIdentity::fromDomainObject($app);
-            $acl = $this->aclProvider->createAcl($objectIdentityClonedApp);
-            return $acl;
-        }
-    
-        /**
-         * @param MutableAclInterface $acl
-         */
-        protected function setApplicationOwnershipToCurrentUser($acl) {
 
-            $token = $this->tokenStorage->getToken();
-            $acl->insertObjectAce(UserSecurityIdentity::fromToken($token),MaskBuilder::MASK_OWNER );
-            $this->aclProvider->updateAcl($acl);
-            
-        }
-        
+    /**
+     * @param Application $app
+     * @return MutableAclInterface
+     */
+    protected function createAclForApplication($app)
+    {
+        $objectIdentityClonedApp = ObjectIdentity::fromDomainObject($app);
+        $acl = $this->aclProvider->createAcl($objectIdentityClonedApp);
+        return $acl;
+    }
+
+    /**
+     * @param MutableAclInterface $acl
+     */
+    protected function setApplicationOwnershipToCurrentUser($acl)
+    {
+        $token = $this->tokenStorage->getToken();
+        $acl->insertObjectAce(UserSecurityIdentity::fromToken($token), MaskBuilder::MASK_OWNER);
+        $this->aclProvider->updateAcl($acl);
+    }
 }

--- a/src/Mapbender/ManagerBundle/Component/ImportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ImportHandler.php
@@ -1,4 +1,5 @@
 <?php
+    
 namespace Mapbender\ManagerBundle\Component;
 
 use Doctrine\Common\Collections\Criteria;
@@ -17,13 +18,19 @@ use Mapbender\ManagerBundle\Component\Exchange\EntityHelper;
 use Mapbender\ManagerBundle\Component\Exchange\EntityPool;
 use Mapbender\ManagerBundle\Component\Exchange\ImportState;
 use Mapbender\ManagerBundle\Component\Exchange\ObjectHelper;
+    use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+    use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+    use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+    use Symfony\Component\Security\Acl\Exception\Exception;
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
+    use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
 use Symfony\Component\Security\Acl\Model\EntryInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
 use Symfony\Component\Security\Acl\Permission\MaskBuilder;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -41,6 +48,8 @@ class ImportHandler extends ExchangeHandler
     protected $aclProvider;
     /** @var AclManager */
     protected $aclManager;
+        /** @var TokenStorage */
+        protected $tokenStorage;
 
     /**
      * @inheritdoc
@@ -50,7 +59,7 @@ class ImportHandler extends ExchangeHandler
                                 ExportHandler $exportHandler,
                                 UploadsManager $uploadsManager,
                                 MutableAclProviderInterface $aclProvider,
-                                AclManager $aclManager)
+                                    AclManager $aclManager, TokenStorage $tokenStorage)
     {
         parent::__construct($entityManager);
         $this->elementFactory = $elementFactory;
@@ -58,6 +67,7 @@ class ImportHandler extends ExchangeHandler
         $this->uploadsManager = $uploadsManager;
         $this->aclProvider = $aclProvider;
         $this->aclManager = $aclManager;
+            $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -127,6 +137,14 @@ class ImportHandler extends ExchangeHandler
             $this->uploadsManager->copySubdirectory($originalSlug, $clonedApp->getSlug());
             $this->em->flush();
 
+                $acl = $this->createAclForApplication($clonedApp);
+                $this->setApplicationOwnershipToCurrentUser($acl);
+            if ($app->getSource() !== Application::SOURCE_YAML) {
+                $this->copyAcls($clonedApp, $app);
+            }
+            
+                
+                
             return $clonedApp;
         } catch (ORMException $e) {
             throw new ImportException("Database error {$e->getMessage()}", 0, $e);
@@ -296,7 +314,7 @@ class ImportHandler extends ExchangeHandler
         $aces = array(
             array(
                 'sid' => UserSecurityIdentity::fromAccount($currentUser),
-                'mask' => MaskBuilder::MASK_OWNER
+                    'mask' => MaskBuilder::MASK_OWNER,
             ),
         );
         $this->aclManager->setObjectACL($application, $aces, 'object');
@@ -305,29 +323,21 @@ class ImportHandler extends ExchangeHandler
     /**
      * @param Application $target
      * @param Application $source
-     * @param $currentUser
      * @throws InvalidDomainObjectException
-     * @throws \Symfony\Component\Security\Acl\Exception\Exception
+         * @throws Exception
      */
-    public function copyAcls(Application $target, Application $source, $currentUser)
+        public function copyAcls(Application $target, Application $source )
     {
-        $this->setDefaultAcls($target, $currentUser);
+            /** @var MutableAclInterface $sourceAcl */
         $sourceAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($source));
         /** @var MutableAclInterface $targetAcl */
-        $targetAcl = $this->aclManager->getACL($target);
-        $currentUserIdentity = UserSecurityIdentity::fromAccount($currentUser);
+            $targetAcl = $this->aclProvider->findAcl(ObjectIdentity::fromDomainObject($target));
 
-        // Quirky old behavior: current user has just been given MASK_OWNER, so access for that user
-        // is as complete as it can get. We only copy aces for other user identities. Any other
-        // entries for the current user are ignored and not copied over.
-        // We also only copy the identity + mask portions of the Aces, nothing else.
-        // @todo: Figure out if this really is the desired behaviour going forward.
         foreach ($sourceAcl->getObjectAces() as $sourceEntry) {
             /** @var EntryInterface $sourceEntry */
             $entryIdentity = $sourceEntry->getSecurityIdentity();
-            if (!$currentUserIdentity->equals($entryIdentity)) {
                 $targetAcl->insertObjectAce($entryIdentity, $sourceEntry->getMask());
-            }
+                
         }
         $this->aclProvider->updateAcl($targetAcl);
     }
@@ -516,4 +526,27 @@ class ImportHandler extends ExchangeHandler
         }
         return $object;
     }
+        
+        /**
+         * @param Application $app
+         * @return MutableAclInterface
+         */
+        protected function createAclForApplication($app){
+    
+            $objectIdentityClonedApp =  ObjectIdentity::fromDomainObject($app);
+            $acl = $this->aclProvider->createAcl($objectIdentityClonedApp);
+            return $acl;
+        }
+    
+        /**
+         * @param MutableAclInterface $acl
+         */
+        protected function setApplicationOwnershipToCurrentUser($acl) {
+
+            $token = $this->tokenStorage->getToken();
+            $acl->insertObjectAce(UserSecurityIdentity::fromToken($token),MaskBuilder::MASK_OWNER );
+            $this->aclProvider->updateAcl($acl);
+            
+        }
+        
 }

--- a/src/Mapbender/ManagerBundle/Component/ImportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ImportHandler.php
@@ -134,9 +134,6 @@ class ImportHandler extends ExchangeHandler
 
             $acl = $this->createAclForApplication($clonedApp);
             $this->setApplicationOwnershipToCurrentUser($acl);
-            if ($app->getSource() !== Application::SOURCE_YAML) {
-                $this->copyAcls($clonedApp, $app);
-            }
 
             return $clonedApp;
         } catch (ORMException $e) {

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -223,9 +223,6 @@ class ApplicationController extends WelcomeController
         $em->beginTransaction();
         try {
             $clonedApp = $impHandler->duplicateApplication($sourceApplication);
-            if ($sourceApplication->getSource() !== Application::SOURCE_YAML) {
-                $impHandler->copyAcls($clonedApp, $sourceApplication);
-            }
             $impHandler->addOwner($clonedApp, UserSecurityIdentity::fromToken($this->getUserToken()));
 
             $em->commit();

--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -219,6 +219,10 @@ class ApplicationController extends WelcomeController
         $em->beginTransaction();
         try {
             $clonedApp = $impHandler->duplicateApplication($sourceApplication);
+            if ($sourceApplication->getSource() !== Application::SOURCE_YAML) {
+                $impHandler->copyAcls($clonedApp, $sourceApplication);
+            }
+
             $em->commit();
             if ($this->isGranted('EDIT', $clonedApp)) {
                 // Redirect to edit view of imported application


### PR DESCRIPTION
With the current release copied application do not have an ACL at all. If you open the Security Tab only the default table will be loaded and it only seems that there are ACEs set. This result in a behavior that global ACEs will not have any impact on these applications access and you could copy and existing application and does not have access to the newly created one.