### PR TITLE
Support direct key (+wildcards) translation requirements

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/TranslationCompiler.php
+++ b/src/Mapbender/CoreBundle/Asset/TranslationCompiler.php
@@ -5,6 +5,8 @@ namespace Mapbender\CoreBundle\Asset;
 
 
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Compiles application translations for frontend consumption.
@@ -14,14 +16,21 @@ use Symfony\Component\Templating\EngineInterface;
  */
 class TranslationCompiler
 {
+    /** @var TranslatorInterface|TranslatorBagInterface */
+    protected $translator;
     /** @var EngineInterface */
     protected $templateEngine;
 
     /**
+     * @param TranslatorInterface $translator
      * @param EngineInterface $templateEngine
      */
-    public function __construct(EngineInterface $templateEngine)
+    public function __construct(TranslatorInterface $translator, EngineInterface $templateEngine)
     {
+        if (!($translator instanceof TranslatorBagInterface)) {
+            throw new \InvalidArgumentException("Given translator does not implement required TranslatorBagInterface");
+        }
+        $this->translator = $translator;
         $this->templateEngine = $templateEngine;
     }
 
@@ -32,9 +41,13 @@ class TranslationCompiler
     public function compile($inputs)
     {
         $translations = array();
-        foreach ($inputs as $transAsset) {
-            $renderedTranslations = json_decode($this->templateEngine->render($transAsset), true);
-            $translations = array_merge($translations, $renderedTranslations);
+        foreach ($inputs as $input) {
+            if (preg_match('/\.json\.twig$/', $input)) {
+                $values = $this->extractFromTemplate($input);
+            } else {
+                $values = $this->translatePattern($input);
+            }
+            $translations += $values;
         }
         $translationsJson = json_encode($translations, JSON_FORCE_OBJECT);
         $jsLogic = $this->templateEngine->render($this->getTemplate());
@@ -47,5 +60,45 @@ class TranslationCompiler
     protected function getTemplate()
     {
         return '@MapbenderCoreBundle/Resources/public/mapbender.trans.js';
+    }
+
+    /**
+     * @param string $template
+     * @return string[]
+     */
+    protected function extractFromTemplate($template)
+    {
+        return json_decode($this->templateEngine->render($template), true);
+    }
+
+    /**
+     * @param string $input translation key or prefix pattern ending in '.*'
+     * @return string[]
+     */
+    protected function translatePattern($input)
+    {
+        $values = array();
+        $allMessages = null;
+        if (preg_match('/\*$/', $input)) {
+            $wildcardPrefix = rtrim($input, '*');
+            if (!$wildcardPrefix || false !== strpos($wildcardPrefix, '*')) {
+                throw new \RuntimeException("Invalid translation key input " . print_r($input, true));
+            }
+            if (!$allMessages) {
+                $allMessages = $this->translator->getCatalogue()->all('messages');
+            }
+            foreach ($allMessages as $translationKey => $message) {
+                if (0 === strpos($translationKey, $wildcardPrefix)) {
+                    $values[$translationKey] = $message;
+                }
+            }
+        } else {
+            $translated = $this->translator->trans($input);
+            if ($translated === $input) {
+                throw new \LogicException("Untranslatable value " . print_r($input, true));
+            }
+            $values[$input] = $this->translator->trans($input);
+        }
+        return $values;
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -201,6 +201,7 @@
             <argument>%kernel.bundles%</argument>
         </service>
         <service id="mapbender.asset_compiler.translations" class="%mapbender.asset_compiler.translations.class%">
+            <argument type="service" id="translator" />
             <argument type="service" id="templating" />
         </service>
         <service id="mapbender.application_asset.service" class="%mapbender.application_asset.service.class%">


### PR DESCRIPTION
Requirements for JavaScript-available translations previously only support `.json.twig` inputs, which require maintenance and can be error prone (translation key mapping mismatches).

This pull adds optional support for Element::getAssets and Template::getAssets to include in their return value list for `trans` assets:
1) direct translation keys, e.g. `mb.core.featureinfo.error.nolayer`
2) translation key prefixes ending in a `*` wildcard, e.g. `mb.core.featureinfo.*` or even `mb.core.f*`

Wildcard prefixes expand to a list of every available translation where the key starts with that prefix. This allows extending available messages for Elements simply by adding more messages with the appropriate prefix to a catalog file (messages.en.yml et al in any activated bundle).

Note: direct key translation will throw if the translation result is equal to the input. This forces detection of untranslatable messages.