### PR TITLE
Fix selection frame resets on input rotation change

### DIFF
--- a/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
@@ -40,9 +40,18 @@
             $('select[name="scale_select"]', this.$form)
                 .on('change', $.proxy(this._updateGeometry, this));
             $('input[name="rotation"]', this.$form)
-                .on('keyup', $.proxy(this._updateGeometry, this));
+                .on("keyup", function () {
+                    this._updateGeometry(false);
+                }.bind(this));
             $('select[name="template"]', this.$form)
                 .on('change', $.proxy(this._onTemplateChange, this));
+
+            $("input", this.$form).keypress(function (e) {
+                if (e.which === 13) {
+                   e.preventDefault();
+                   this._print();
+                }
+            }.bind(this));
 
             this.$selectionFrameToggle = $('.-fn-toggle-frame', this.element);
             if (this.options.type === 'element') {
@@ -61,7 +70,7 @@
                         self._deactivateSelection();
                     }
                 });
-                $('.printSubmit', this.$form).on('click', $.proxy(this._print, this));
+                $('.printSubmit', this.$form).on('click', this._print.bind(this));
             } else {
                 // popup comes with its own buttons
                 $('.printSubmit', this.$form).remove();
@@ -511,6 +520,7 @@
         _onSubmit: function(evt) {
             // switch to queue display tab on successful submit
             $('.tab-container', this.element).tabs({active: 1});
+
         },
         _onTemplateChange: function() {
             var self = this;

--- a/src/Mapbender/PrintBundle/Resources/views/Element/printclient-settings.html.twig
+++ b/src/Mapbender/PrintBundle/Resources/views/Element/printclient-settings.html.twig
@@ -53,7 +53,7 @@
 
     {% if configuration.rotatable is defined and configuration.rotatable == 1 %}
         <label class="labelInput" for="rotation">{{ 'mb.core.printclient.label.rotation' | trans }}</label>
-        <input class="input" type="text" name="rotation" value="0"/>
+        <input class="input" type="number" name="rotation" value="0"/>
  {% else %}
 <input class="input" type="text" name="rotation" value="0" style="display: none"/>
     {% endif %}


### PR DESCRIPTION
Fix erroneous form submit on enter.

Every keyup in the rotation input reset the selection frame to the center of the screen because the event argument of the event listener callback function was wrongly passed to the _updatedGeometry function
and misinterpreted as the truthy reset parameter. Now the function is wrapped and called with the correct false value for reset.
Pressing enter in one of the input fields of the print form submitted the form without the necessary logic which is bound to the print-button. Now we catch all keypress-events and check for enter(Code 13) to prevent this and call t
he correct logic.