### PR TITLE
Enh/sass compiler update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
         "wheregroup/codemirror": "5.x",
         "components/underscore": "1.x",
         "wheregroup/open-sans": "1.x",
+        "wheregroup/assetic-filter-sassc": "^0.0.1",
+        "wheregroup/sassc-binaries": "^0.0.1",
 
         "mapbender/fom": "~3.1.2 || ^3.2.1",
         "mapbender/owsproxy": "^3.0.6.2@dev",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
 
         "setasign/fpdi-fpdf": "1.6.*",
 
-        "eslider/sasscb":  "3.1.x",
         "wheregroup/compass-mixins": "0.x",
         "mapbender/mapbender-icons": "1.x",
 

--- a/src/Mapbender/CoreBundle/DependencyInjection/Compiler/AutodetectSasscBinaryPass.php
+++ b/src/Mapbender/CoreBundle/DependencyInjection/Compiler/AutodetectSasscBinaryPass.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Wheregroup\SasscBinaries\Binary;
+
+class AutodetectSasscBinaryPass implements CompilerPassInterface
+{
+    /** @var string */
+    protected $parameterName;
+
+    /**
+     * @param string $parameterName
+     */
+    public function __construct($parameterName)
+    {
+        $this->parameterName = $parameterName;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $paramValue = $container->getParameter($this->parameterName);
+        if (empty($paramValue)) {
+            $replacement = Binary::pick();
+        } elseif (!is_executable($paramValue)) {
+            // NOTE: E_USER_DEPRECATED is the only error type that is guaranteed to go to the logs
+            $message = "WARNING: configured sassc binary " . print_r($paramValue, true) . " not found or not executable.";
+            @trigger_error($message, E_USER_DEPRECATED);
+            if (\php_sapi_name() === 'cli') {
+                fwrite(STDERR, $message . "\n");
+            }
+            $replacement = Binary::pick();
+        } else {
+            $replacement = null;
+        }
+        if ($replacement) {
+            if (!is_executable($replacement)) {
+                throw new \LogicException("No execution privileges on sassc binary " . print_r($replacement, true));
+            }
+            $container->setParameter($this->parameterName, $replacement);
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -2,6 +2,7 @@
 namespace Mapbender\CoreBundle;
 
 use Mapbender\CoreBundle\Component\MapbenderBundle;
+use Mapbender\CoreBundle\DependencyInjection\Compiler\AutodetectSasscBinaryPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\ContainerUpdateTimestampPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\MapbenderYamlCompilerPass;
 use Mapbender\CoreBundle\DependencyInjection\Compiler\ProvideBrandingPass;
@@ -38,6 +39,7 @@ class MapbenderCoreBundle extends MapbenderBundle
         }
         $container->addCompilerPass(new ContainerUpdateTimestampPass());
         $container->addCompilerPass(new ProvideBrandingPass());
+        $container->addCompilerPass(new AutodetectSasscBinaryPass('mapbender.asset.sassc_binary_path'));
 
         // @todo: remove legacy form theme bridging
         //        TBD: either rely on correct starter config (and do nothing here)

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -36,6 +36,9 @@
         <parameter key="mapbender.element_inventory.service.class">Mapbender\CoreBundle\Component\ElementInventoryService</parameter>
         <parameter key="mapbender.cookieconsent">false</parameter>
         <parameter key="mapbender.uploads_dir">uploads</parameter>
+        <!-- will be determined automatically if empty; see AtodetectSasscBinaryPass
+             try setting /usr/bin/sassc -->
+        <parameter key="mapbender.asset.sassc_binary_path">null</parameter>
     </parameters>
 
     <services>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -5,7 +5,7 @@
     <parameters>
         <parameter key="applications" type="collection" />
         <parameter key="signer.class">Mapbender\CoreBundle\Component\Signer</parameter>
-        <parameter key="assetic.filter.scss.class">Eslider\Filter\ScssFilter</parameter>
+        <parameter key="assetic.filter.scss.class">Wheregroup\AsseticFilterSassc\SasscFilter</parameter>
         <parameter key="mapbender.http_transport.service.class">Mapbender\Component\Transport\OwsProxyTransport</parameter>
         <parameter key="mapbender.source.instancetunnel.service.class">Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService</parameter>
         <parameter key="mapbender.form_type.element.layertree.menu.class">Mapbender\CoreBundle\Element\Type\LayerTreeMenuType</parameter>
@@ -85,7 +85,7 @@
         <service id="mapbender.assetic.filter.sass" class="%assetic.filter.scss.class%">
             <tag name="assetic.filter" alias="sass" />
 
-            <argument>null</argument>
+            <argument>%mapbender.asset.sassc_binary_path%</argument>
             <call method="setTimeout">
                 <argument>%assetic.filter.sass.timeout%</argument>
             </call>


### PR DESCRIPTION
Replaces sassc compiler dependency with [wheregroup/assetic-filter-sassc](https://packagist.org/packages/wheregroup/assetic-filter-sassc) plus [wheregroup/sassc-binaries](https://packagist.org/packages/wheregroup/sassc-binaries).

Allows using native sassc, e.g. available on Debian / Ubuntu via apt get. Set the path to your desired binary via parameter `mapbender.asset.sassc_binary_path`, usually to `/usr/bin/sassc`. This disables autopicking of the binary from one of the bundled ones.

The compiler change fixes the long broken minified CSS output in `prod` environment, aka `app.php`.

On Linux, outside of prod, results are identical (as per md5sum).  
This change needs verification on Windows and MacOS.  
The compiler is also used to validate the Application CSS form field in the backend. This should be reverified with / without deliberate errors in the CSS input.  