### PR TITLE
adjust ORM annotation of WMS InstanceLayer join to guarantee the Laye…

### DIFF
--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -28,7 +28,7 @@ class WmsInstance extends SourceInstance
      * @var WmsInstanceLayer[]|ArrayCollection
      * @ORM\OneToMany(targetEntity="WmsInstanceLayer", mappedBy="sourceInstance", cascade={"persist", "remove", "refresh"})
      * @ORM\JoinColumn(name="layers", referencedColumnName="id")
-     * @ORM\OrderBy({"priority" = "asc"})
+     * @ORM\OrderBy({"priority" = "asc", "id" = "asc"})
      */
     protected $layers;
 


### PR DESCRIPTION
…rs to be ordered by id

Within the WMS instance config, the application expects the WMS-Layers of a WMS Source to be ordered according to their ids when saved. The created form relies on this and the blank form's instance table is ordered like that. Internally, the inputs of the form are annotated with a counter:, the first row's inputs with 0, the second with 1, the third with 2 and so on. 

However, after creating an instance source, the configuration menu's instance table's inputs counters are messed up. They do not ascent starting with 0, but rather descend starting with the highest number. Saving this leads to distorted configuration, with the first row having the values of what was the last row before and so on.  Responsible for this is the incomplete ordering of the wmsinstances layers - the query orders them after priority only, not by id, as the application expects it.

see https://github.com/mapbender/mapbender/issues/1236