### PR TITLE
in _onMapClick, event.x and event.y return undefined when on mobile d…

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -253,9 +253,11 @@ window.Mapbender.Model = $.extend(Mapbender && Mapbender.Model || {}, {
     },
     _onMapClick: function(event) {
         var clickLonLat = this.olMap.getLonLatFromViewPortPx(event);
+        var x = event.x || event.xy.x; // on mobile devices, coordinates are returned as properties of the `xy`-Object only
+        var y = event.y || event.xy.y;
         $(this.mbMap.element).trigger('mbmapclick', {
             mbMap: this.mbMap,
-            pixel: [event.x, event.y],
+            pixel: [x, y],
             coordinate: [clickLonLat.lon, clickLonLat.lat]
         });
     },


### PR DESCRIPTION
…evice, but they can easily be replaced by event.xy.x and event.xy.y