### PR TITLE
Change alpha value to 127 instead of 0

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -468,7 +468,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
 
         if ($rotation != 0) {
             $image = imagecreatefrompng($northarrow);
-            $transColor = imagecolorallocatealpha($image, 255, 255, 255, 0);
+            $transColor = imagecolorallocatealpha($image, 255, 255, 255, 127);
             $rotatedImage = imagerotate($image, $rotation, $transColor);
             $srcSize = array(imagesx($image), imagesy($image));
 


### PR DESCRIPTION
The newly generated pixel from rotating the image(corners) will be white instead of transparent if alpha is zero. So north arrow overlapping the map has white corners.