### PR TITLE
Fix/simple search config mismatch vs documentation

### DIFF
--- a/src/Mapbender/CoreBundle/Element/SimpleSearch.php
+++ b/src/Mapbender/CoreBundle/Element/SimpleSearch.php
@@ -51,9 +51,7 @@ class SimpleSearch extends Element
             'geom_format'     => 'WKT',
             'delay'           => 300,
             'query_ws_replace' => null,
-            'result' => array(
-                'buffer' => 300,
-            )
+            'result_buffer' => 300,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/SimpleSearch.php
+++ b/src/Mapbender/CoreBundle/Element/SimpleSearch.php
@@ -152,6 +152,16 @@ class SimpleSearch extends Element implements ConfigMigrationInterface
             }
         }
         unset($config['result']);
+
+        if (!empty($config['token_regex']) && \is_array($config['token_regex'])) {
+            // Legacy example config quirk: documentation has historically suggested using an
+            // invalid array type for token_regex. This works incidentally because JavaScript
+            // RegExp constructor promotes everything to string.
+            // @see https://docs.mapbender.org/3.0.8/en/functions/search/simplesearch.html#yaml-definition
+            // Array values do however break the backend form, causing exceptions when editing
+            // a Yaml application cloned into the database.
+            $config['token_regex'] = implode(',', $config['token_regex']);
+        }
         $entity->setConfiguration($config);
     }
 

--- a/src/Mapbender/CoreBundle/Element/SimpleSearch.php
+++ b/src/Mapbender/CoreBundle/Element/SimpleSearch.php
@@ -3,13 +3,15 @@ namespace Mapbender\CoreBundle\Element;
 
 use Mapbender\Component\Transport\HttpTransportInterface;
 use Mapbender\CoreBundle\Component\Element;
+use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
+use Mapbender\CoreBundle\Entity;
 
 /**
  * Simple Search - Just type, select and show result
  *
  * @author Christian Wygoda
  */
-class SimpleSearch extends Element
+class SimpleSearch extends Element implements ConfigMigrationInterface
 {
     public static function getClassTitle()
     {
@@ -128,4 +130,29 @@ class SimpleSearch extends Element
 
         return $response;
     }
+
+    public static function updateEntityConfig(Entity\Element $entity)
+    {
+        $config = $entity->getConfiguration();
+        if (!empty($config['result']) && \is_array($config['result'])) {
+            if (isset($config['result']['icon_url'])) {
+                $config['result_icon_url'] = $config['result']['icon_url'];
+            }
+            if (isset($config['result']['icon_offset'])) {
+                $config['result_icon_offset'] = $config['result']['icon_offset'];
+            }
+            if (isset($config['result']['buffer'])) {
+                $config['result_buffer'] = $config['result']['buffer'];
+            }
+            if (isset($config['result']['minscale'])) {
+                $config['result_minscale'] = $config['result']['minscale'];
+            }
+            if (isset($config['result']['maxscale'])) {
+                $config['result_maxscale'] = $config['result']['maxscale'];
+            }
+        }
+        unset($config['result']);
+        $entity->setConfiguration($config);
+    }
+
 }

--- a/src/Mapbender/CoreBundle/Element/Type/SimpleSearchAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/SimpleSearchAdminType.php
@@ -70,19 +70,14 @@ class SimpleSearchAdminType extends AbstractType
                 'required' => true,
             ))
             ->add('result_buffer', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-                'property_path' => '[result][buffer]',
             ))
             ->add('result_minscale', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-                'property_path' => '[result][minscale]',
             ))
             ->add('result_maxscale', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-                'property_path' => '[result][maxscale]',
             ))
             ->add('result_icon_url', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-                'property_path' => '[result][icon_url]',
             ))
             ->add('result_icon_offset', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-                'property_path' => '[result][icon_offset]',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -10,13 +10,11 @@ $.widget('mapbender.mbSimpleSearch', {
         label_attribute: null,
         geom_attribute: null,
         geom_format: null,
-        result: {
-            buffer: null,
-            minscale: null,
-            maxscale: null,
-            icon_url: null,
-            icon_offset: null
-        },
+        result_buffer: null,
+        result_minscale: null,
+        result_maxscale: null,
+        result_icon_url: null,
+        result_icon_offset: null,
         delay: 0
     },
 
@@ -70,10 +68,10 @@ $.widget('mapbender.mbSimpleSearch', {
         var feature = format.read(evtData.data[this.options.geom_attribute]);
         var mbMap = this._getMbMap();
 
-        var zoomToFeatureOptions = this.options.result && {
-            maxScale: parseInt(this.options.result.maxscale) || null,
-            minScale: parseInt(this.options.result.minscale) || null,
-            buffer: parseInt(this.options.result.buffer) || null
+        var zoomToFeatureOptions = {
+            maxScale: parseInt(this.options.result_maxscale) || null,
+            minScale: parseInt(this.options.result_minscale) || null,
+            buffer: parseInt(this.options.result_buffer) || null
         };
         mbMap.getModel().zoomToFeature(feature, zoomToFeatureOptions);
         this._hideMobile();
@@ -86,10 +84,10 @@ $.widget('mapbender.mbSimpleSearch', {
         var bounds = feature.geometry.getBounds();
 
         // Add marker
-        if(self.options.result.icon_url) {
+        if (self.options.result_icon_url) {
             if(!self.marker) {
                 var addMarker = function() {
-                    var offset = (self.options.result.icon_offset || '').split(new RegExp('[, ;]'));
+                    var offset = (self.options.result_icon_offset || '').split(new RegExp('[, ;]'));
                     var x = parseInt(offset[0]);
 
                     var size = {
@@ -112,7 +110,7 @@ $.widget('mapbender.mbSimpleSearch', {
                 };
 
                 var image = new Image();
-                image.src = self.options.result.icon_url;
+                image.src = self.options.result_icon_url;
                 image.onload = addMarker;
                 image.onerror = addMarker;
             } else {


### PR DESCRIPTION
[Example configuration for SimpleSearch](https://doc.mapbender.org/de/functions/search/simplesearch.html#yaml-definition) has historically suggested using values that a) SimpleSearch does not actually process, b) cause exceptions when editing a SimpleSearch Element in the backend (after export + import / duplicating the application into the database).

Relevant parts of example SimpleSearch config from documentation:
```
<...>
token_regex: [^a-zA-Z0-9äöüÄÖÜß]
<...>
result_buffer: 50
result_minscale: 1000
result_maxscale: 5000
result_icon_url: http://demo.mapbender.org/bundles/mapbendercore/image/pin_red.png
result_icon_offset: -6,-38
```

SimpleSearch never actually looked at `result_*` values. It expected a `result` array with sub-entries `buffer`, `minscale` etc. This made the example config `result_*` values completely ineffective, producing just a fallback point geometry for results.
Actually, having individual top-level values is better, because it allows providing defaults for individual values, which is harder / not worth doing for a sub-array.

SimpleSearch `token_regex` is expected to be a scalar string by the backend form. The example configuration sets an array. This causes errors in the form. The JavaScript frontend can consume an array without errors, because the RegExp constructor implicitly casts to string. For JavaScript Array types, this implicit cast is equivalent to saying `[<something>].join(',')`.

This pull
1) makes SimpleSearch support the `result_*` configuration settings as suggested by the user documentation; working array-style `result` settings in existing applications are unpacked transparently
2) joins existing array-style values for `token_regex` into a scalar, removing the errors when editing the affected SimpleSearch element