### PR TITLE
Fix/reusable element grants checks

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
@@ -8,8 +8,6 @@ use Mapbender\CoreBundle\Component\UploadsManager;
 use Mapbender\CoreBundle\Component\Exception\ElementErrorException;
 use Mapbender\CoreBundle\Entity;
 use Mapbender\CoreBundle\Component;
-use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
-use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -119,32 +117,9 @@ class ApplicationService
      * @param Entity\Element $element
      * @param string $permission
      * @return bool
-     * @todo: this needs to be a voter
      */
     protected function isElementGranted(Entity\Element $element, $permission = 'VIEW')
     {
-        if ($element->getApplication()->isYamlBased()) {
-            $roles = $element->getYamlRoles();
-            if (!$roles) {
-                // Empty list of roles => allow all
-                return true;
-            }
-            foreach ($roles as $role) {
-                if ($this->authorizationChecker->isGranted($role)) {
-                    return true;
-                }
-            }
-        }
-        $oid = ObjectIdentity::fromDomainObject($element);
-        try {
-            $acl = $this->aclProvider->findAcl($oid);
-            if ($acl->getObjectAces()) {
-                return $this->authorizationChecker->isGranted($permission, $element);
-            } else {
-                return true;
-            }
-        } catch (AclNotFoundException $e) {
-            return true;
-        }
+        return $this->authorizationChecker->isGranted($permission, $element);
     }
 }

--- a/src/Mapbender/CoreBundle/Component/Security/FomRoleAdapterTrait.php
+++ b/src/Mapbender/CoreBundle/Component/Security/FomRoleAdapterTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Security;
+
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+trait FomRoleAdapterTrait
+{
+    /**
+     * Get role names from given token INCLUDING local database roles (FOM Group entities).
+     * @todo (in FOM): FOM-managed roles should already be on the token
+     *
+     * @param TokenInterface $token
+     * @return string[]
+     */
+    protected function getRoleNamesFromToken(TokenInterface $token)
+    {
+        $names = array();
+        foreach ($token->getRoles() as $tokenRole) {
+            $names[] = $tokenRole->getRole();
+        }
+        $user = $token->getUser();
+        if ($user && \is_object($user) && ($user instanceof \FOM\UserBundle\Entity\User)) {
+            // custom FOM Group entity assignment roles are NOT visible via token->getRoles
+            // @todo: fix this in FOM
+            $names = array_values(array_unique(array_merge($names, $user->getRoles())));
+        }
+        return $names;
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Security/Voter/BaseApplicationVoter.php
+++ b/src/Mapbender/CoreBundle/Component/Security/Voter/BaseApplicationVoter.php
@@ -3,6 +3,7 @@
 
 namespace Mapbender\CoreBundle\Component\Security\Voter;
 
+use Mapbender\CoreBundle\Component\Security\FomRoleAdapterTrait;
 use Mapbender\CoreBundle\Entity\Application;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -12,6 +13,8 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 
 abstract class BaseApplicationVoter extends Voter
 {
+    use FomRoleAdapterTrait;
+
     /** @var AccessDecisionManagerInterface */
     protected $accessDecisionManager;
     /** @var bool[] to speed up repeated oid grants checks */
@@ -75,27 +78,5 @@ abstract class BaseApplicationVoter extends Voter
         }
 
         return $this->oidGrantBuffer[$bufferKey];
-    }
-
-    /**
-     * Get role names from given token INCLUDING roles assigned by special snowflake FOM.
-     * @todo (in FOM): FOM-managed roles should already be on the token
-     *
-     * @param TokenInterface $token
-     * @return string[]
-     */
-    protected function getRoleNamesFromToken(TokenInterface $token)
-    {
-        $names = array();
-        foreach ($token->getRoles() as $tokenRole) {
-            $names[] = $tokenRole->getRole();
-        }
-        $user = $token->getUser();
-        if ($user && \is_object($user) && ($user instanceof \FOM\UserBundle\Entity\User)) {
-            // custom FOM Group entity assignment roles are NOT visible via token->getRoles
-            // @todo: fix this in FOM
-            $names = array_values(array_unique(array_merge($names, $user->getRoles())));
-        }
-        return $names;
     }
 }

--- a/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationElementVoter.php
+++ b/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationElementVoter.php
@@ -4,13 +4,17 @@
 namespace Mapbender\CoreBundle\Component\Security\Voter;
 
 
+use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Element;
+use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
+use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
 use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
+use Symfony\Component\Security\Acl\Util\ClassUtils;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -22,6 +26,8 @@ class DbApplicationElementVoter extends Voter
     protected $sidRetrievalStrategy;
     /** @var PermissionMapInterface */
     protected $permissionMap;
+    /** @var Acl[][] */
+    protected $applicationAclBuffer = array();
 
     public function __construct(AclProviderInterface $aclProvider,
                                 SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy,
@@ -49,15 +55,14 @@ class DbApplicationElementVoter extends Voter
         // NOTE: we cannot delegate to AuthorizationChecker via isGranted because we would cycle back here infinitely.
 
         /** @var Element $subject */
-        $oid = ObjectIdentity::fromDomainObject($subject);
-        try {
-            $acl = $this->aclProvider->findAcl($oid);
-            // If ACL exists but is empty, grant to all (this is unlike AclVoter which would deny)
-            if (!$acl->getObjectAces()) {
-                return true;
-            }
-        } catch (AclNotFoundException $e) {
-            // If ACL doesn't exist, grant to all (this is unlike AclVoter which would deny)
+        $aclMap = $this->getApplicationElementAcls($subject->getApplication());
+        if (empty($aclMap[$subject->getId()])) {
+            // If ACL on concrete Element doesn't exist, grant to all (this is unlike AclVoter which would deny)
+            return true;
+        }
+        $acl = $aclMap[$subject->getId()];
+        // If ACL exists but is empty, grant to all (this is unlike AclVoter which would deny)
+        if (!$acl->getObjectAces()) {
             return true;
         }
         $masks = $this->permissionMap->getMasks($attribute, $subject);
@@ -67,5 +72,44 @@ class DbApplicationElementVoter extends Voter
         } catch (NoAceFoundException $e) {
             return false;
         }
+    }
+
+    /**
+     * Bulk-(pre)fetch ACLs for all Elements inside the given $application.
+     * This is ~10x faster than individual single-OID lookups for typical applications.
+     *
+     * @param Application $application
+     * @return Acl[]
+     */
+    protected function getApplicationElementAcls(Application $application)
+    {
+        $key = \spl_object_hash($application);
+        if (!array_key_exists($key, $this->applicationAclBuffer)) {
+            $prefetchOids = array();
+            $idClass = null;
+            foreach ($application->getElements() as $element) {
+                $idClass = $idClass ?: ClassUtils::getRealClass($element);
+                $prefetchOids[] = new ObjectIdentity((string)$element->getId(), $idClass);
+            }
+            try {
+                $oidAclMap = $this->aclProvider->findAcls($prefetchOids);
+            } catch (NotAllAclsFoundException $e) {
+                $oidAclMap = $e->getPartialResult();
+            } catch (AclNotFoundException $e) {
+                $oidAclMap = false;
+            }
+            $aclMap = array();
+            if ($oidAclMap) {
+                // Unravel returned SplObjectStorage into a mapping of element id => Acl
+                foreach ($oidAclMap as $oid) {
+                    /** @var ObjectIdentity $oid */
+                    /** @var Acl $acl */
+                    $acl = $oidAclMap[$oid];
+                    $aclMap[$oid->getIdentifier()] = $acl;
+                }
+            }
+            $this->applicationAclBuffer[$key] = $aclMap;
+        }
+        return $this->applicationAclBuffer[$key];
     }
 }

--- a/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationElementVoter.php
+++ b/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationElementVoter.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Security\Voter;
+
+
+use Mapbender\CoreBundle\Entity\Element;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
+use Symfony\Component\Security\Acl\Model\AclProviderInterface;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
+use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class DbApplicationElementVoter extends Voter
+{
+    /** @var AclProviderInterface */
+    protected $aclProvider;
+    /** @var SecurityIdentityRetrievalStrategyInterface */
+    protected $sidRetrievalStrategy;
+    /** @var PermissionMapInterface */
+    protected $permissionMap;
+
+    public function __construct(AclProviderInterface $aclProvider,
+                                SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy,
+                                PermissionMapInterface $permissionMap)
+    {
+        $this->aclProvider = $aclProvider;
+        $this->sidRetrievalStrategy = $sidRetrievalStrategy;
+        $this->permissionMap = $permissionMap;
+    }
+
+    protected function supports($attribute, $subject)
+    {
+        // Only vote on VIEW on an Element in a non-Yaml-defined Application
+        return
+            ($attribute === 'VIEW')
+            && is_object($subject) && ($subject instanceof Element)
+            && ($subject->getApplication()) && (!$subject->getApplication()->isYamlBased())
+        ;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        // Minimal reimplementation of AclVoter, minus FieldVote supprt, minus logging, minus ObjectIdentity renormalization
+        /** @see \Symfony\Component\Security\Acl\Voter\AclVoter::vote */
+        // NOTE: we cannot delegate to AuthorizationChecker via isGranted because we would cycle back here infinitely.
+
+        /** @var Element $subject */
+        $oid = ObjectIdentity::fromDomainObject($subject);
+        try {
+            $acl = $this->aclProvider->findAcl($oid);
+            // If ACL exists but is empty, grant to all (this is unlike AclVoter which would deny)
+            if (!$acl->getObjectAces()) {
+                return true;
+            }
+        } catch (AclNotFoundException $e) {
+            // If ACL doesn't exist, grant to all (this is unlike AclVoter which would deny)
+            return true;
+        }
+        $masks = $this->permissionMap->getMasks($attribute, $subject);
+        $sids = $this->sidRetrievalStrategy->getSecurityIdentities($token);
+        try {
+            return $acl->isGranted($masks, $sids);
+        } catch (NoAceFoundException $e) {
+            return false;
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Component/Security/Voter/YamlApplicationElementVoter.php
+++ b/src/Mapbender/CoreBundle/Component/Security/Voter/YamlApplicationElementVoter.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Component\Security\Voter;
+
+
+use Mapbender\CoreBundle\Entity\Element;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class YamlApplicationElementVoter extends Voter
+{
+    /** @var AccessDecisionManagerInterface */
+    protected $accessDecisionManager;
+
+    public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+    }
+
+    protected function supports($attribute, $subject)
+    {
+        // Only vote on VIEW on an Element in a Yaml-defined Application
+        return
+            ($attribute === 'VIEW')
+            && is_object($subject) && ($subject instanceof Element)
+            && ($subject->getApplication()) && ($subject->getApplication()->isYamlBased())
+        ;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        /** @var Element $subject */
+        $roleNames = $subject->getYamlRoles();
+        if (!$roleNames) {
+            // Empty list of roles => allow all
+            return true;
+        }
+        foreach ($roleNames as $roleName) {
+            if ($this->accessDecisionManager->decide($token, array($roleName), null)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/security.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/security.xml
@@ -5,6 +5,8 @@
     <parameters>
         <parameter key="mb_core.security.voter.yaml_application.class">Mapbender\CoreBundle\Component\Security\Voter\YamlApplicationVoter</parameter>
         <parameter key="mb_core.security.voter.db_application.class">Mapbender\CoreBundle\Component\Security\Voter\DbApplicationVoter</parameter>
+        <parameter key="mb_core.security.voter.yaml_application_element.class">Mapbender\CoreBundle\Component\Security\Voter\YamlApplicationElementVoter</parameter>
+        <parameter key="mb_core.security.voter.db_application_element.class">Mapbender\CoreBundle\Component\Security\Voter\DbApplicationElementVoter</parameter>
     </parameters>
     <services>
         <service id="mb_core.security.voter.yaml_application" class="%mb_core.security.voter.yaml_application.class%">
@@ -14,6 +16,16 @@
         <service id="mb_core.security.voter.unpublished_application" class="%mb_core.security.voter.db_application.class%">
             <tag name="security.voter" priority="255" />
             <argument type="service" id="security.access.decision_manager" />
+        </service>
+        <service id="mb_core.security.voter.yaml_application_element" class="%mb_core.security.voter.yaml_application_element.class%">
+            <tag name="security.voter" />
+            <argument type="service" id="security.access.decision_manager" />
+        </service>
+        <service id="mb_core.security.voter.db_application_element" class="%mb_core.security.voter.db_application_element.class%">
+            <tag name="security.voter" />
+            <argument type="service" id="security.acl.provider" />
+            <argument type="service" id="security.acl.security_identity_retrieval_strategy" />
+            <argument type="service" id="security.acl.permission.map" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Extracts view access control checks for Elements into two new [voter](https://symfony.com/doc/3.4/security/voters.html#the-voter-interface) services `mb_core.security.voter.db_application_element` and `mb_core.security.voter.yaml_application_element`, thus making grants checks globally reusable and customizable via DI.

Grants checks produce the same outcomes as before, but are significantly faster due to the separation between Yaml-defined and database Applications. Grants checks in database Applications now use bulk-prefetching of the Element ACLs, which has been observed to improve total Element VIEW grants checking time for a typical application by up to 10x.
Yaml-defined Applications will completely skip attempting to look up (unassignable) Object ACLs, saving some performance as well.