### PR TITLE
Feature/view reset button

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ResetView.php
+++ b/src/Mapbender/CoreBundle/Element/ResetView.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element;
+
+
+class ResetView extends BaseButton
+{
+    // Disable being targetted by a Button
+    public static $ext_api = false;
+
+    public static function getClassTitle()
+    {
+        return 'mb.core.resetView.class.title';
+    }
+
+    public static function getClassDescription()
+    {
+        return 'mb.core.resetView.class.description';
+    }
+
+    public function getWidgetName()
+    {
+        return 'mapbender.resetView';
+    }
+
+    public static function getType()
+    {
+        return 'Mapbender\CoreBundle\Element\Type\ResetViewAdminType';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets()
+    {
+        return array(
+            'js' => array(
+                '@MapbenderCoreBundle/Resources/public/mapbender.element.button.js',
+                '@MapbenderCoreBundle/Resources/public/element/resetView.js',
+            ),
+            'css' => array(
+                '@MapbenderCoreBundle/Resources/public/sass/element/button.scss',
+            ),
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDefaultConfiguration()
+    {
+        $defaults = parent::getDefaultConfiguration();
+        // icon is hard-coded to iconReset (see twig template)
+        unset($defaults['icon']);
+        return $defaults;
+    }
+
+    public function getFrontendTemplatePath($suffix = '.html.twig')
+    {
+        return "MapbenderCoreBundle:Element:ResetView.html.twig";
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/ResetView.php
+++ b/src/Mapbender/CoreBundle/Element/ResetView.php
@@ -50,7 +50,9 @@ class ResetView extends BaseButton
      */
     public static function getDefaultConfiguration()
     {
-        $defaults = parent::getDefaultConfiguration();
+        $defaults = array_replace(parent::getDefaultConfiguration(), array(
+            'resetDynamicSources' => true,
+        ));
         // icon is hard-coded to iconReset (see twig template)
         unset($defaults['icon']);
         return $defaults;

--- a/src/Mapbender/CoreBundle/Element/Type/ResetViewAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ResetViewAdminType.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element\Type;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ResetViewAdminType extends AbstractType
+{
+    public function getParent()
+    {
+        return 'Mapbender\CoreBundle\Element\Type\BaseButtonAdminType';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // Icon is hard-coded, remove upstream icon field.
+        if ($builder->has('icon')) {
+            $builder->remove('icon');
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/Type/ResetViewAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ResetViewAdminType.php
@@ -20,5 +20,11 @@ class ResetViewAdminType extends AbstractType
         if ($builder->has('icon')) {
             $builder->remove('icon');
         }
+        $builder
+            ->add('resetDynamicSources', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'label' => 'mb.core.resetView.admin.resetDynamicSources',
+                'required' => false,
+            ))
+        ;
     }
 }

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -81,6 +81,7 @@ class MapbenderCoreBundle extends MapbenderBundle
             'Mapbender\CoreBundle\Element\Map',
             'Mapbender\CoreBundle\Element\Overview',
             'Mapbender\CoreBundle\Element\POI',
+            'Mapbender\CoreBundle\Element\ResetView',
             'Mapbender\CoreBundle\Element\Ruler',
             'Mapbender\CoreBundle\Element\ScaleBar',
             'Mapbender\CoreBundle\Element\ScaleDisplay',

--- a/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
@@ -2,6 +2,7 @@
     'use strict';
     $.widget('mapbender.resetView', $.mapbender.mbBaseButton, {
         options: {
+            resetDynamicSources: true
         },
         mbMap: null,
         initial: null,
@@ -22,7 +23,18 @@
         },
 
         run: function() {
+            if (this.options.resetDynamicSources) {
+                this.resetDynamicSources();
+            }
             this.mbMap.getModel().applySettings(this.initial);
+        },
+        resetDynamicSources: function() {
+            var model = this.mbMap.getModel();
+            model.sourceTree.forEach(function(source) {
+                if (source.wmsloader) {
+                    model.removeSource(source);
+                }
+            });
         }
     });
 }(jQuery));

--- a/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
@@ -1,0 +1,28 @@
+(function ($) {
+    'use strict';
+    $.widget('mapbender.resetView', $.mapbender.mbBaseButton, {
+        options: {
+        },
+        mbMap: null,
+        initial: null,
+
+        _create: function() {
+            var self = this;
+            Mapbender.elementRegistry.waitReady('.mb-element-map').then(function(mbMap) {
+                self.setup(mbMap);
+            });
+        },
+        setup: function(mbMap) {
+            var self = this;
+            this.mbMap = mbMap;
+            this.initial = mbMap.getModel().getInitialSettings();
+            this.element.on('click', function() {
+                self.run();
+            });
+        },
+
+        run: function() {
+            this.mbMap.getModel().applySettings(this.initial);
+        }
+    });
+}(jQuery));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -80,6 +80,7 @@ window.Mapbender.Source = (function() {
         }
         this.type = definition.type;
         this.configuration = definition.configuration;
+        this.wmsloader = definition.wmsloader;
         var sourceArg = this;
         this.configuration.children = (this.configuration.children || []).map(function(childDef) {
             return Mapbender.SourceLayer.factory(childDef, sourceArg, null)

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -364,6 +364,10 @@ mb:
     redlining:
       class:
         title: Skizzen
+    resetView:
+      class:
+        title: Ansicht zurücksetzen
+        description: Stellt den ursprünglichen Kartenausschnitt und Diensteeinstellungen wieder her
 
 # Login exceptions
 "Bad credentials.": Authentifizierung fehlgeschlagen.

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -368,6 +368,8 @@ mb:
       class:
         title: Ansicht zurücksetzen
         description: Stellt den ursprünglichen Kartenausschnitt und Diensteeinstellungen wieder her
+      admin:
+        resetDynamicSources: Hinzugeladene Quellen entfernen
 
 # Login exceptions
 "Bad credentials.": Authentifizierung fehlgeschlagen.

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -367,3 +367,5 @@ mb:
       class:
         title: Reset view
         description: Restores initial map view and source settings
+      admin:
+        resetDynamicSources: Remove dynamically loaded sources

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -363,3 +363,7 @@ mb:
     redlining:
       class:
         title: Sketches
+    resetView:
+      class:
+        title: Reset view
+        description: Restores initial map view and source settings

--- a/src/Mapbender/CoreBundle/Resources/views/Element/ResetView.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/ResetView.html.twig
@@ -1,0 +1,3 @@
+{# Generate same markup as control button, but predefine some (not configurable) expected variables #}
+{% set _config = configuration | merge({icon: 'iconReset', group: null}) %}
+{% include 'MapbenderCoreBundle:Element:control_button.html.twig' with {configuration: _config } %}

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -195,6 +195,7 @@
                 sourceDef.id = sourceId;
                 // Need to pre-generate layer ids now because layertree visual updates need layer ids
                 Mapbender.Util.SourceTree.generateLayerIds(sourceDef);
+                sourceDef.wmsloader = true;
                 this.activateLayersByName(sourceDef, options.layers || [], keepStates);
 
                 this.mbMap.model.addSourceFromConfig(sourceDef);


### PR DESCRIPTION
Adds a new ResetView Element that will bring the application back into its inital state without requiring a page reload.

This is useful for mangling with the recently added URL-based history and sharing functions, as it offers a friendlier reset interface than "cut the fragment off the URL". It is also a useful tool for ongoing developments in application state persistence, be it db / cookie / local storage based.

The ResetView interaction will restore to their initial states
* view parameters (center, scale, rotation, CRS)
* source layer selections
* source opacity values

Dynamically added sources (via WmsLoader) can also be removed in the reset interaction. This behavior optional, but on by default.

The ResetView Element can be added to a toolbar. It looks like a control button, but has a, for now, hardcoded icon. No other region integrations were considerd.

Example definition for yaml applications:
```yaml
  toolbar:
    resetView:
      class: Mapbender\CoreBundle\Element\ResetView
      resetDynamicSources: false   # boolean; optional; defaults to true
      # basic button options (inherited)
      label: true                  # boolean; default true; false: icon only; true: render element title
      tooltip: We need to go back  # string; defaults to same as title; text shown on mouse hover
```
