### PR TITLE
Feature/ls persistent map view

### DIFF
--- a/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
+++ b/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
@@ -116,6 +116,9 @@ class ApplicationYAMLMapper
         if (isset($definition['mapEngineCode'])) {
             $application->setMapEngineCode($definition['mapEngineCode']);
         }
+        if (isset($definition['persistentView'])) {
+            $application->setPersistentView($definition['persistentView']);
+        }
  
         if (array_key_exists('extra_assets', $definition)) {
             $application->setExtraAssets($definition['extra_assets']);

--- a/src/Mapbender/CoreBundle/Component/Presenter/Application/ConfigService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/Application/ConfigService.php
@@ -80,6 +80,7 @@ class ConfigService
             'slug'          => $entity->getSlug(),
             'debug'         => ($this->container->get('kernel')->getEnvironment() !== 'prod'),
             'mapEngineCode' => $entity->getMapEngineCode(),
+            'persistentView' => $entity->getPersistentView(),
         );
     }
 

--- a/src/Mapbender/CoreBundle/Entity/Application.php
+++ b/src/Mapbender/CoreBundle/Entity/Application.php
@@ -83,6 +83,12 @@ class Application
     protected $map_engine_code = self::MAP_ENGINE_CURRENT;
 
     /**
+     * @ORM\Column(type="boolean", name="persistent_view", options={"default": false})
+     * @var bool
+     */
+    protected $persistentView = false;
+
+    /**
      * @var RegionProperties[]|ArrayCollection
      * @ORM\OneToMany(targetEntity="RegionProperties", mappedBy="application", cascade={"remove", "persist"})
      * @ORM\OrderBy({"id" = "asc"})
@@ -644,6 +650,22 @@ class Application
     public function getMapEngineCode()
     {
         return $this->map_engine_code;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPersistentView()
+    {
+        return $this->persistentView;
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function setPersistentView($value)
+    {
+        $this->persistentView = $value;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -56,6 +56,16 @@ window.Mapbender.MapModelBase = (function() {
         this.configuredSettings_ = Object.assign({}, this.getCurrentSourceSettings(), {
             viewParams: this._getConfiguredViewParams(mapOptions)
         });
+        if (Mapbender.configuration.application.persistentView) {
+            try {
+                var settings = this.getLocalStorageSettings();
+                if (settings) {
+                    this.applySourceSettings(settings);
+                }
+            } catch (e) {
+                console.error("Restoration of local storage source selection settings failed, ignoring");
+            }
+        }
     }
 
     MapModelBase.prototype = {
@@ -1008,8 +1018,7 @@ window.Mapbender.MapModelBase = (function() {
         /**
          * @param {mmMapSettings} settings
          */
-        applySettings: function(settings) {
-            // @todo: restore layersets selected states
+        applySourceSettings: function(settings) {
             // @todo: defensive checks if source was actually changed to reduce reloads...?
             var sources = [], i;
             for (i = 0; i < settings.layersets.length; ++i) {
@@ -1032,10 +1041,17 @@ window.Mapbender.MapModelBase = (function() {
                     }
                 }
             }
+            return sources;
+        },
+        /**
+         * @param {mmMapSettings} settings
+         */
+        applySettings: function(settings) {
+            var sources = this.applySourceSettings(settings);
             this.applyViewParams(settings.viewParams);
             // Perform map view updates for (updated) sources; we deliberately defer this until after the view param
             // update because out of bounds / scale / CRS applicability checks heavily depend on view params.
-            for (i = 0; i < sources.length; ++i) {
+            for (var i = 0; i < sources.length; ++i) {
                 this._checkSource(sources[i], true);
             }
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -924,7 +924,13 @@ window.Mapbender.MapModelBase = (function() {
                 // fall through
             }
 
-            var params = this._getConfiguredViewParams(mapOptions);
+            var params;
+            var lsPersisted = Mapbender.configuration.application.persistentView && this.getLocalStorageSettings();
+            if (lsPersisted && lsPersisted.viewParams) {
+                params = lsPersisted.viewParams;
+            } else {
+                params = this._getConfiguredViewParams(mapOptions);
+            }
             var urlParams = (new Mapbender.Util.Url(window.location.href)).parameters || {};
             var srsOverride = this._filterSrsOverride(mapOptions, urlParams.srs);
             if (srsOverride) {
@@ -1113,6 +1119,9 @@ window.Mapbender.MapModelBase = (function() {
             }
         },
         _startShare: function() {
+            if (Mapbender.configuration.application.persistentView) {
+                this.startLocalStorageSettingsPersistence();
+            }
             var self = this;
             var currentHash = (window.location.hash || '').replace(/^#/, '');
             if (currentHash) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -110,11 +110,7 @@
             $(document).bind('mbmapsourcelayerremoved', $.proxy(this._onSourceLayerRemoved, this));
             $(document).on('mb.sourcenodeselectionchanged', function(e, data) {
                 if (data.node instanceof (Mapbender.Layerset)) {
-                    var themeNodeSelector = '[data-type="theme"][data-layersetid="' + data.node.getId() + '"]';
-                    var checkboxSelector = [themeNodeSelector, ' > .leaveContainer input[name="sourceVisibility"][type="checkbox"]'].join('');
-                    var $checkbox = $(checkboxSelector, self.element);
-                    $checkbox.prop('checked', data.selected);
-                    $checkbox.mbCheckbox();
+                    self._updateThemeNode(data.node);
                 }
             });
             if (this._mobilePane) {
@@ -192,7 +188,15 @@
             $li.toggleClass('showLeaves', options.opened);
             $('.-fn-toggle-children', $li).toggleClass('iconFolderActive', options.opened);
             $('span.layer-title:first', $li).text(layerset.getTitle() || '');
+            this._updateThemeNode(layerset, $li);
             return $li;
+        },
+        _updateThemeNode: function(layerset, $node) {
+            var $node_ = $node || this._findThemeNode(layerset);
+            var $checkbox = $('> .leaveContainer input[name="sourceVisibility"][type="checkbox"]', $node_);
+            console.warn("Checkbox found?", layerset, $node_.get(), $checkbox.get());
+            $checkbox.prop('checked', layerset.getSelected());
+            $checkbox.mbCheckbox();
         },
         _getThemeOptions: function(layerset) {
             var matches =  (this.options.themes || []).filter(function(item) {

--- a/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
@@ -96,6 +96,9 @@ class ApplicationType extends AbstractType
                 'required' => true,
                 'empty_data' => Application::MAP_ENGINE_OL2,
             ))
+            ->add('persistentView', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'required' => false,
+            ))
             ->add('custom_css', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
                 'required' => false,
             ))

--- a/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
@@ -98,6 +98,7 @@ class ApplicationType extends AbstractType
             ))
             ->add('persistentView', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
+                'label' => 'mb.manager.application.persistentView',
             ))
             ->add('custom_css', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
                 'required' => false,

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages.de.yml
@@ -53,6 +53,8 @@ mb:
       reusable_assigned_to_application: Die freie Instanz wurde der Anwendung hinzugefügt
       create_reusable: Freie Instanz erzeugen
       created_reusable: Neue freie Instanz erzeugt
+    application:
+      persistentView: Kartenzustand merken
     admin:
       sources: Datenquellen
       source:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages.en.yml
@@ -53,6 +53,8 @@ mb:
       reusable_added_to_application: The shared instance has been added to the application
       create_reusable: Create shared instance
       created_reusable: A new shared instance has been created
+    application:
+      persistentView: Persistent map state
     admin:
       sources: Sources
       source:

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-basic.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-basic.html.twig
@@ -30,4 +30,5 @@
 <div class="form-group">
     {{ form_row(form.description) }}
 </div>
+{{ form_row(form.persistentView) }}
 {{ form_widget(form.removeScreenShot) }}


### PR DESCRIPTION
Adds an opt-in behaviour to make view parameters and certain source settings "persistent", i.e. the map should initialize at the same place, with the same selected sources as in your previous session if you open the same application again in the same browser.

Persisted and restored settings encompass
* view parameters center, scale, rotation, SRS
* per-layerset selected or deselected state
* per-source and source layer selected or deselected state
* per-source opacity

Currently _not_ persisted and _not_ restored (known limitations) are
* Dimension parameter values
* Source additions (via WmsLoader)
* Layer / entire source removals (via Layertree context menu)
* Source / layer reordering operations via Layertree drag+drop
* States of per-layer featureinfo checkboxes

Persistence is based purely on browser local storage, which means it is private to a user's local browser. On properly multi-user systems it should also be private to the client systems login account. There is no interaction whatsoever with the Mapbender login.

Behaviour is enabled on a per-Application basis with a new checkbox in the backend "Base data" tab.

Behaviour can also be set in a Yaml application definition, with a new boolean-type `persistentView` entry on the top level. Omitting the entry is the same as setting it to false. E.g.:
```yaml
parameters:
    applications:
        mapbender_user:
            title: Mapbender Demo Map
            screenshot: screenshot.png
            published: true
            persistentView: true      # <== this is new
            template:  Mapbender\CoreBundle\Template\Fullscreen
```

This change introduces a new column in the mb_core_application table and as such will require a run of `app/console doctrine:schema:update --force`. Otherwise exceptions will occur on all Application access, including almost every backend page.

NOTE: with `persistentView` enabled, Applications will continually restore their states from previous sessions, in large part replacing preconfigured values. If you enable `persistentView` on an Application you may also want to give users a complementary [ResetView Element](https://github.com/mapbender/mapbender/pull/1300) as an explicit access path back to the preconfigured Application state.
