### PR TITLE
Add Map configuration option to disable fractional zoom

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -52,6 +52,7 @@ class Map extends Element implements ConfigMigrationInterface
                 'max' => array(0, 40, 20, 60),
                 'start' => array(5, 45, 15, 55)),
             "scales" => array(25000000, 10000000, 5000000, 1000000, 500000),
+            'fixedZoomSteps' => false,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -54,6 +54,10 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
                 'label' => 'mb.manager.admin.map.start_extent',
                 'property_path' => '[extents][start]',
             ))
+            ->add('fixedZoomSteps', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'label' => 'mb.core.map.admin.fixedZoomSteps',
+                'required' => false,
+            ))
             ->add('scales', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                 'label' => 'Scales (csv)',
                 'required' => true,

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -250,6 +250,8 @@ mb:
         mapquery: MapQuery
         openlayers: OpenLayers
       srsnotfound: 'SRS Eigenschaften für %srslist% wurden nicht gefunden.'
+      admin:
+        fixedZoomSteps: Feste Maßstabsstufen
     scalebar:
       class:
         title: Maßstabsleiste

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -249,6 +249,8 @@ mb:
         mapquery: MapQuery
         openlayers: OpenLayers
       srsnotfound: 'SRS properties for %srslist% are not found'
+      admin:
+        fixedZoomSteps: Fixed zoom steps
     scalebar:
       class:
         title: 'Scale bar'


### PR DESCRIPTION
Makes stepless zoom behaviour configurable. This is useful to increase visual quality of services that are cached on very particular resolution steps only.

We introduce a new configuration option `fixedZoomSteps` on the Map Element. This is a boolean and defaults to false (=previous behaviour, allowing any intermediate map resolution). When true, scale denominator snaps to one of the values given in the `scales` option (also in Map Element).
