### PR TITLE
Fix/button title no default

### DIFF
--- a/src/Mapbender/CoreBundle/Component/ElementFactory.php
+++ b/src/Mapbender/CoreBundle/Component/ElementFactory.php
@@ -80,9 +80,16 @@ class ElementFactory extends BaseElementFactory
             ->setClass($componentClass)
             ->setRegion($region)
             ->setWeight(0)
-            ->setTitle($this->translator->trans($component->getClassTitle()))
             ->setConfiguration($configuration)
         ;
+        if (!$componentClass || !\is_a($componentClass, 'Mapbender\CoreBundle\Element\ControlButton')) {
+            // Leave title empty. Will be resolved to target title when rendering
+            // @todo: make title column nullable (will require schema update)
+            $entity->setTitle('');
+        } else {
+            // @todo: reevaluate translation; translation should be done on presentation, not persisted
+            $entity->setTitle($this->translator->trans($component->getClassTitle()));
+        }
         if ($application) {
             $entity->setApplication($application);
         }

--- a/src/Mapbender/CoreBundle/Element/ControlButton.php
+++ b/src/Mapbender/CoreBundle/Element/ControlButton.php
@@ -4,6 +4,8 @@
 namespace Mapbender\CoreBundle\Element;
 
 
+use Mapbender\CoreBundle\Component\ElementBase\MinimalInterface;
+
 class ControlButton extends BaseButton
 {
     // Disable being targetted by any other Button
@@ -60,4 +62,26 @@ class ControlButton extends BaseButton
         return 'MapbenderCoreBundle:Element:control_button.html.twig';
     }
 
+    public function getFrontendTemplateVars()
+    {
+        $title = $this->entity->getTitle();
+        if (!$title) {
+            $target = $this->entity->getTargetElement('target');
+            if ($target) {
+                $title = $target->getTitle();
+                if ($target && $target->getClass()) {
+                    /** @var MinimalInterface|string $targetClass */
+                    $targetClass = $target->getClass();
+                    $title = $targetClass::getClassTitle();
+                }
+            }
+        }
+        if (!$title) {
+            $title = $this->getClassTitle();
+        }
+        return array(
+            'configuration' => $this->entity->getConfiguration(),
+            'title' => $title,
+        );
+    }
 }

--- a/src/Mapbender/CoreBundle/Element/ControlButton.php
+++ b/src/Mapbender/CoreBundle/Element/ControlButton.php
@@ -37,6 +37,11 @@ class ControlButton extends BaseButton
         return 'Mapbender\CoreBundle\Element\Type\ControlButtonAdminType';
     }
 
+    public static function getFormTemplate()
+    {
+        return 'MapbenderManagerBundle:Element:control_button.html.twig';
+    }
+
     public static function getDefaultConfiguration()
     {
         return array_replace(parent::getDefaultConfiguration(), array(

--- a/src/Mapbender/CoreBundle/Extension/ElementExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/ElementExtension.php
@@ -40,6 +40,8 @@ class ElementExtension extends AbstractExtension
     {
         return array(
             'element_class_title' => new TwigFunction('element_class_title', array($this, 'element_class_title')),
+            'element_default_title' => new TwigFunction('element_default_title', array($this, 'element_default_title')),
+            'element_title' => new TwigFunction('element_title', array($this, 'element_title')),
         );
     }
 
@@ -59,5 +61,32 @@ class ElementExtension extends AbstractExtension
             return null;
         }
     }
-}
 
+    /**
+     * @param Element $element
+     * @return string|null
+     */
+    public function element_title($element)
+    {
+        if ($title = $element->getTitle()) {
+            return $title;
+        } else {
+            return $this->element_default_title($element);
+        }
+    }
+
+    /**
+     * @param Element $element
+     * @return string|null
+     */
+    public function element_default_title($element)
+    {
+        if ($element->getClass() && \is_a($element->getClass(), 'Mapbender\CoreBundle\Element\ControlButton', true)) {
+            $target = $element->getTargetElement();
+            if ($target && $target !== $element) {
+                return $this->element_title($target);
+            }
+        }
+        return $this->element_class_title($element);
+    }
+}

--- a/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
+++ b/src/Mapbender/ManagerBundle/Component/ElementFormFactory.php
@@ -76,9 +76,13 @@ class ElementFormFactory extends BaseElementFactory
         $titleConstraints = array(
             new NotBlank(),
         );
+        // @todo: support empty titles for all elements (big frontend templating impact, e.g. sidepane headers)
+        $allowEmptyTitle = \is_a($element->getClass(), 'Mapbender\CoreBundle\Element\ControlButton', true);
         $formType
             ->add('title', 'Mapbender\ManagerBundle\Form\Type\ElementTitleType', array(
-                'constraints' => $titleConstraints,
+                'element_class' => $element->getClass(),
+                'required' => !$allowEmptyTitle,
+                'constraints' => $allowEmptyTitle ? array() : $titleConstraints,
             ))
         ;
         $configurationType = $this->getConfigurationFormType($element);

--- a/src/Mapbender/ManagerBundle/Form/Type/ElementTitleType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/ElementTitleType.php
@@ -4,15 +4,25 @@
 namespace Mapbender\ManagerBundle\Form\Type;
 
 
+use Mapbender\CoreBundle\Component\ElementBase\MinimalInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ElementTitleType extends AbstractType implements DataTransformerInterface
 {
     public function getParent()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\TextType';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('element_class');
+        $resolver->setAllowedTypes('element_class', 'string');
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -31,5 +41,21 @@ class ElementTitleType extends AbstractType implements DataTransformerInterface
         // Prevent nulls from reaching Element::setTitle()
         // @todo: make element title column nullable (requires schema update)
         return $value ?: '';
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (!$form->getConfig()->getRequired()) {
+            /** @var MinimalInterface|string $elementClass */
+            $elementClass = $options['element_class'];
+            $attr = array(
+                // NOTE: placeholder runs through translation in default form theme
+                'placeholder' => $elementClass::getClassTitle(),
+            );
+            if (!empty($view->vars['attr'])) {
+                $attr = $attr + $view->vars['attr'];
+            }
+            $view->vars['attr'] = $attr;
+        }
     }
 }

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
@@ -46,7 +46,7 @@
               <tr class="element" {% if is_map_element(element) -%}
                   id="-ft-map-element"
                 {%- endif %} data-id="{{element.id}}" data-href="{{ path('mapbender_manager_element_weight', {'id': element.id})}}">
-                <td class="titleColumn description">{{ element.title | trans }}</td>
+                <td class="titleColumn description">{{ element_title(element) | trans }}</td>
                 <td class="typeColumn description">{{ element_class_title(element) | trans }}</td>
                 <td class="iconColumn">
                   <div class="checkWrapper hover-highlight-effect {{ element.enabled ? 'iconPublishActive' : 'iconPublish' }} -ft-toggle-active"

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/control_button.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/control_button.html.twig
@@ -1,0 +1,15 @@
+{% include 'MapbenderManagerBundle:Element:button.html.twig' %}
+
+<script type="text/javascript">
+    !(function($) {
+        var titleEl = document.getElementById({{ form.title.vars.id | json_encode | raw }});
+        var targetEl = document.getElementById({{ form.configuration.target.vars.id | json_encode | raw }});
+        var initialPlaceholder = titleEl.placeholder || '';
+        var update = function() {
+            var selected = $('option:selected', targetEl).get(0);
+            titleEl.placeholder = (selected && selected.value && $(selected).text()) || initialPlaceholder;
+        };
+        update();
+        $(targetEl).on('change', update);
+    }(jQuery));
+</script>


### PR DESCRIPTION
Gives ControlButton a dynamic default title depending on its target Element, which can be translated properly to current locale.

This removes the requirement of knowing internal translation catalog structure when authoring Yaml applications. ControlButton titles can be omitted completely and still produce appropriate results, depending on the targetted Element.
It also un-breaks translation of button titles when the locale is changed after importing a Yaml application into the DB.

ControlButton backend form will allow clearing the title / saving with an empty title. The resulting (dynamic) default is shown in the form field as a placeholder.