### PR TITLE
Enh/safe element removal

### DIFF
--- a/src/Mapbender/Component/BaseElementFactory.php
+++ b/src/Mapbender/Component/BaseElementFactory.php
@@ -77,16 +77,9 @@ class BaseElementFactory
      * @param Element $element
      * @return bool
      */
-    public function isElementTypeDisabled(Element $element)
+    public function isTypeOfElementDisabled(Element $element)
     {
-        $disabled = $this->isClassDisabled($element->getClass());
-        if (!$disabled && \is_a($element->getClass(), 'Mapbender\CoreBundle\Element\ControlButton', true)) {
-            $target = $element->getTargetElement();
-            if ($target) {
-                $disabled = $this->isClassDisabled($target->getClass());
-            }
-        }
-        return $disabled;
+        return $this->inventoryService->isTypeOfElementDisabled($element);
     }
 
     /**

--- a/src/Mapbender/Component/BaseElementFactory.php
+++ b/src/Mapbender/Component/BaseElementFactory.php
@@ -65,6 +65,15 @@ class BaseElementFactory
     }
 
     /**
+     * @param string $className
+     * @return bool
+     */
+    public function isClassDisabled($className)
+    {
+        return $this->inventoryService->isClassDisabled($className);
+    }
+
+    /**
      * @param Element $element
      * @return string|\Mapbender\CoreBundle\Component\Element
      */

--- a/src/Mapbender/Component/BaseElementFactory.php
+++ b/src/Mapbender/Component/BaseElementFactory.php
@@ -75,6 +75,22 @@ class BaseElementFactory
 
     /**
      * @param Element $element
+     * @return bool
+     */
+    public function isElementTypeDisabled(Element $element)
+    {
+        $disabled = $this->isClassDisabled($element->getClass());
+        if (!$disabled && \is_a($element->getClass(), 'Mapbender\CoreBundle\Element\ControlButton', true)) {
+            $target = $element->getTargetElement();
+            if ($target) {
+                $disabled = $this->isClassDisabled($target->getClass());
+            }
+        }
+        return $disabled;
+    }
+
+    /**
+     * @param Element $element
      * @return string|\Mapbender\CoreBundle\Component\Element
      */
     protected function getComponentClass(Element $element)

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -4,6 +4,8 @@
 namespace Mapbender\CoreBundle\Component;
 
 
+use Mapbender\CoreBundle\Entity;
+
 /**
  * Maintains inventory of Element Component classes
  *
@@ -129,5 +131,17 @@ class ElementInventoryService
     public function isClassDisabled($className)
     {
         return \in_array($className, $this->disabledClassesFromConfig);
+    }
+
+    public function isTypeOfElementDisabled(Entity\Element $element)
+    {
+        $disabled = $this->isClassDisabled($element->getClass());
+        if (!$disabled && \is_a($element->getClass(), 'Mapbender\CoreBundle\Element\ControlButton', true)) {
+            $target = $element->getTargetElement();
+            if ($target) {
+                $disabled = $this->isClassDisabled($target->getClass());
+            }
+        }
+        return $disabled;
     }
 }

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -25,6 +25,13 @@ class ElementInventoryService
     protected $fullInventory = array();
     /** @var string[] */
     protected $noCreationClassNames = array();
+    /** @var string[] */
+    protected $disabledClassesFromConfig = array();
+
+    public function __construct($disabledClasses)
+    {
+        $this->disabledClassesFromConfig = $disabledClasses ?: array();
+    }
 
     /**
      * @param string $classNameIn
@@ -112,5 +119,15 @@ class ElementInventoryService
     public function getRawInventory()
     {
         return array_values($this->fullInventory);
+    }
+
+    protected function getDisabledClasses()
+    {
+        return $this->disabledClassesFromConfig;
+    }
+
+    public function isClassDisabled($className)
+    {
+        return \in_array($className, $this->disabledClassesFromConfig);
     }
 }

--- a/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
+++ b/src/Mapbender/CoreBundle/Component/ElementInventoryService.php
@@ -108,7 +108,7 @@ class ElementInventoryService
         foreach ($moved as $original => $replacement) {
             $inventoryCopy[$original] = $replacement;
         }
-        return array_unique(array_diff(array_values($inventoryCopy), $this->noCreationClassNames));
+        return array_unique(array_diff(array_values($inventoryCopy), $this->noCreationClassNames, $this->getDisabledClasses()));
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
@@ -106,7 +106,7 @@ class ApplicationService
     {
         $entitiesOut = array();
         foreach ($entities as $entity) {
-            $enabled = !$this->elementFactory->isElementTypeDisabled($entity) && $entity->getEnabled();
+            $enabled = !$this->elementFactory->isTypeOfElementDisabled($entity) && $entity->getEnabled();
             if ($enabled && (!$requireGrant || $this->isElementGranted($entity))) {
                 $entitiesOut[] = $entity;
             }

--- a/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
@@ -106,7 +106,8 @@ class ApplicationService
     {
         $entitiesOut = array();
         foreach ($entities as $entity) {
-            if ($entity->getEnabled() && (!$requireGrant || $this->isElementGranted($entity))) {
+            $enabled = !$this->elementFactory->isClassDisabled($entity->getClass()) && $entity->getEnabled();
+            if ($enabled && (!$requireGrant || $this->isElementGranted($entity))) {
                 $entitiesOut[] = $entity;
             }
         }

--- a/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
+++ b/src/Mapbender/CoreBundle/Component/Presenter/ApplicationService.php
@@ -106,7 +106,7 @@ class ApplicationService
     {
         $entitiesOut = array();
         foreach ($entities as $entity) {
-            $enabled = !$this->elementFactory->isClassDisabled($entity->getClass()) && $entity->getEnabled();
+            $enabled = !$this->elementFactory->isElementTypeDisabled($entity) && $entity->getEnabled();
             if ($enabled && (!$requireGrant || $this->isElementGranted($entity))) {
                 $entitiesOut[] = $entity;
             }

--- a/src/Mapbender/CoreBundle/Extension/ElementExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/ElementExtension.php
@@ -42,6 +42,7 @@ class ElementExtension extends AbstractExtension
             'element_class_title' => new TwigFunction('element_class_title', array($this, 'element_class_title')),
             'element_default_title' => new TwigFunction('element_default_title', array($this, 'element_default_title')),
             'element_title' => new TwigFunction('element_title', array($this, 'element_title')),
+            'is_typeof_element_disabled' => new TwigFunction('is_typeof_element_disabled', array($this, 'is_typeof_element_disabled')),
         );
     }
 
@@ -88,5 +89,10 @@ class ElementExtension extends AbstractExtension
             }
         }
         return $this->element_class_title($element);
+    }
+
+    public function is_typeof_element_disabled(Element $element)
+    {
+        return $this->inventoryService->isTypeOfElementDisabled($element);
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -44,6 +44,7 @@
         <parameter key="mapbender.yaml_application_dirs" type="collection">
             <parameter>%kernel.root_dir%/config/applications</parameter>
         </parameter>
+        <parameter key="mapbender.disabled_elements" type="collection" />
         <parameter key="mapbender.uploads_dir">uploads</parameter>
         <!-- will be determined automatically if empty; see AtodetectSasscBinaryPass
              try setting /usr/bin/sassc -->
@@ -232,7 +233,8 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
         <service id="mapbender.element_inventory.service" class="%mapbender.element_inventory.service.class%">
-            <!-- no arguments; element class changes are added via compiler passes; this is not configurable -->
+            <!-- NOTE: base Element class availability is not an argument, but added via compiler passes; this is not configurable -->
+            <argument>%mapbender.disabled_elements%</argument>
         </service>
         <service id="mapbender.sqlite_connection_listener" class="%mapbender.sqlite_connection_listener.class%">
             <tag name="doctrine.event_listener" event="postConnect" />

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-elements.html.twig
@@ -42,7 +42,7 @@
           </tr>
         </thead>
         <tbody>
-        {% for element in application.getElementsByRegion(region) %}
+        {% for element in application.getElementsByRegion(region) if not is_typeof_element_disabled(element) %}
               <tr class="element" {% if is_map_element(element) -%}
                   id="-ft-map-element"
                 {%- endif %} data-id="{{element.id}}" data-href="{{ path('mapbender_manager_element_weight', {'id': element.id})}}">


### PR DESCRIPTION
Allows suppressing Element types from showing up in frontend and backend via configuration.

This mechanism can fix errors when rendering or editing an application that holds references to Elements that are outdated, unsafe, or completely gone from the code base. In turn, it allows the Mapbender team to safely remove types of Elements from the code entirely without causing hard errors.
This is also useful to prevent operators from adding Elements that are no longer safe to use, or that have been superseded by project-level solutions.

Adds a new configuration parameter `mapbender.disabled_elements` (list of strings, default empty). Contained element types are fully qualified class names of the element component.

Example usage (suppresses all Layertree Elements in all applications).
```yaml
parameters:
    mapbender.disabled_elements:
        - Mapbender\CoreBundle\Element\Layertree
```

This suppression via configuration has no permanent effects on the persisted structure of the application. I.e., if you later change your mind and remove the `Layertree` entry again, all previously suppressed Layertree Elements will pop back into existence.

Button / ControlButton Elements targetting a disabled type of Element will also be suppressed.