### PR TITLE
Enh/featureinfo highlight customizable colors

### DIFF
--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -75,6 +75,8 @@ class FeatureInfo extends Element
             "height" => 500,
             "maxCount" => 100,
             'highlighting' => false,
+            'featureColorDefault' => '#ffa500',
+            'featureColorHover' => '#ff0000',
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -56,7 +56,7 @@ class FeatureInfo extends Element
             $iframeScripts[] = $templating->render('@MapbenderCoreBundle/Resources/public/element/featureinfo-highlighting.js');
         }
         $config['iframeInjection'] = implode("\n\n", $iframeScripts);
-        return $config;
+        return $config + $defaults;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -66,6 +66,12 @@ class FeatureInfoAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.admin.featureinfo.label.highlighting',
             ))
+            ->add('featureColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'required' => false,
+            ))
+            ->add('featureColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'required' => false,
+            ))
         ;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -67,10 +67,12 @@ class FeatureInfoAdminType extends AbstractType
                 'label' => 'mb.core.admin.featureinfo.label.highlighting',
             ))
             ->add('featureColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-                'required' => false,
+                'required' => true,
+                'label' => 'mb.core.admin.featureinfo.label.featureColorDefault',
             ))
             ->add('featureColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-                'required' => false,
+                'required' => true,
+                'label' => 'mb.core.admin.featureinfo.label.featureColorHover',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -10,6 +10,8 @@
             onlyValid: false,
             iframeInjection: null,
             highlighting: false,
+            featureColorDefault: '#ffa500',
+            featureColorHover: 'ff0000',
             maxCount: 100,
             width: 700,
             height: 500
@@ -347,28 +349,27 @@
         },
 
         _createLayerStyle: function () {
+            var strokeStyle = new ol.style.Stroke({
+                color: '#ff00ff', //rgba(255, 255, 255, 1)',
+                lineCap: 'round',
+                width: 1
+            });
+            var defaultColorComponents = Mapbender.StyleUtil.parseCssColor(this.options.featureColorDefault).slice(0, 3).concat(0.4);
+            var hoverColorComponents = Mapbender.StyleUtil.parseCssColor(this.options.featureColorHover).slice(0, 3).concat(0.7);
             this.featureInfoStyle = function (feature) {
                 return new ol.style.Style({
-                    stroke: new ol.style.Stroke({
-                        color: 'rgba(255, 255, 255, 1)',
-                        lineCap: 'round',
-                        width: 1
-                    }),
+                    stroke: strokeStyle,
                     fill: new ol.style.Fill({
-                        color: 'rgba(255, 165, 0, 0.4)'
+                        color: defaultColorComponents
                     })
                 });
             };
 
             this.featureInfoStyle_hover = function (feature) {
                 return new ol.style.Style({
-                    stroke: new ol.style.Stroke({
-                        color: 'rgba(255, 255, 255, 1)',
-                        lineCap: 'round',
-                        width: 1
-                    }),
+                    stroke: strokeStyle,
                     fill: new ol.style.Fill({
-                        color: 'rgba(255, 0, 0, 0.7)'
+                        color: hoverColorComponents
                     }),
                     zIndex: 1000
                 });

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -297,7 +297,10 @@ mb:
           deactivateonclose: 'Beim Schließen deaktivieren'
           autoopen: 'Automatisches Öffnen'
           onlyvalid: 'Nur valide zeigen'
-          highlighting: 'Highlighting'
+          highlighting_group: 'Highlighting'
+          highlighting: Highlighting aktiv
+          featureColorDefault: Grundfarbe
+          featureColorHover: Hover-Farbe
       printclient:
         label:
           autoopen: 'Automatisches Öffnen'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -296,7 +296,10 @@ mb:
           autoopen: Auto-open
           deactivateonclose: 'Deactivate on close'
           onlyvalid: 'Only valid'
-          highlighting: 'Highlighting'
+          highlighting_group: 'Highlighting'
+          highlighting: 'Highlighting enabled'
+          featureColorDefault: Default color
+          featureColorHover: Hover color
       printclient:
         label:
           autoopen: Auto-open

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -19,3 +19,9 @@
     {{ form_row(form.configuration.height) }}
     {{ form_rest(form.configuration) }}
 </div>
+<script type="text/javascript">
+    !(function($) {
+        var $pickers = $('#{{ form.configuration.featureColorDefault.vars.id | raw }},#{{ form.configuration.featureColorHover.vars.id | raw}}');
+        $pickers.colorpicker();
+    }(jQuery));
+</script>

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -27,6 +27,6 @@
 <script type="text/javascript">
     !(function($) {
         var $pickers = $('#{{ form.configuration.featureColorDefault.vars.id | raw }},#{{ form.configuration.featureColorHover.vars.id | raw}}');
-        $pickers.colorpicker();
+        $pickers.colorpicker({format: 'hex'});
     }(jQuery));
 </script>

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -1,4 +1,4 @@
-<div class="elementForm">
+<div class="extraWideLabelForm">
     <div>
         <div class="left">
             {{ form_row(form.configuration.autoActivate) }}
@@ -9,6 +9,9 @@
         <div class="left">
             {{ form_row(form.configuration.printResult) }}
         </div>
+        <div class="left">
+            {{ form_row(form.configuration.onlyValid) }}
+        </div>
         <div class="clearContainer"></div>
     </div>
     {{ form_row(form.title) }}
@@ -17,6 +20,8 @@
     {{ form_row(form.configuration.maxCount) }}
     {{ form_row(form.configuration.width) }}
     {{ form_row(form.configuration.height) }}
+    <h3>{{ 'mb.core.admin.featureinfo.label.highlighting_group' | trans }}</h3>
+    {{ form_row(form.configuration.highlighting) }}
     {{ form_rest(form.configuration) }}
 </div>
 <script type="text/javascript">

--- a/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/manager.html.twig
@@ -2,12 +2,14 @@
 
 {% block css %}
   <link rel="stylesheet" href="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'css'}) }}"/>
+  <link rel="stylesheet" href="{{ asset('components/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css') }}" />
 {% endblock %}
 
 {% block js %}
   {{parent()}}
   <script type="text/javascript" src="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'js'}) }}"></script>
   <script type="text/javascript" src="{{ path('mapbender_core_application_assets', {'slug': 'manager','type': 'trans'}) }}"></script>
+  <script type="text/javascript" src="{{ asset('components/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js') }}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Adds configurability for colors of geometric features extracted from FeatureInfo HTML (see [PR#1270](https://github.com/mapbender/mapbender/pull/1270)).

Two colors can be configured: `featureColorDefault` is applied to features when not hovered, and `featureColorHover` is applied to features currently hovered with the mouse cursor.
Both are string types, and should use CSS color syntax of hash character plus hex digits.
The defaults are the same as the values that were hardcoded previously.
The backend form uses color pickers for ease of use.

In Yaml application definitions, the new fields may be configured like this:
```yaml
                    featureinfo:
                        class: Mapbender\CoreBundle\Element\FeatureInfo
                        highlighting: true
                        <...>
                        # new fields
                        featureColorDefault: '#ff8888'   # bright red
                        featureColorHover: '#ffaa44'     # bright orange
```
Please note the quotation marks are not optional here. Hash characters outside of quotes are comments and will not be interpreted at all by the Yaml parser.