### PR TITLE
Fix/automatic dpi

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -44,7 +44,6 @@ class Map extends Element implements ConfigMigrationInterface
         /* "standardized rendering pixel size" for WMTS 0.28 mm × 0.28 mm -> DPI for WMTS: 90.714285714 */
         return array(
             'layersets' => array(),
-            'dpi' => 25.4 / 0.28,
             'srs' => 'EPSG:4326',
             'otherSrs' => array("EPSG:31466", "EPSG:31467"),
             'tileSize' => 512,

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -36,9 +36,6 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
                     'class' => 'input inputWrapper choiceExpandedSortable',
                 ),
             ))
-            ->add('dpi', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
-                'label' => 'DPI',
-            ))
             ->add('tileSize', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
                 'required' => false,
                 'label' => 'Tile size',

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -18,11 +18,14 @@
         /**
          * Creates the map widget
          */
-        _create: function(){
-            var defaultDpi = 25.4 / 0.28; // ~90.7142857142857
-            if (!this.options.dpi || Math.abs(this.options.dpi - defaultDpi) <= 0.05) {
-                this.options.dpi = defaultDpi;
-            }
+        _create: function() {
+            // Auto-calculate dpi from device pixel ratio, to maintain reasonable canvas quality
+            // see https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
+            // Avoid calculating dpi >= 1.5*96dpi to avoid pushing (Mapproxy) caches into a resolution
+            // with too low label font size.
+            // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
+            var dpr = window.devicePixelRatio || 1;
+            this.options.dpi = 96. * Math.max(1, dpr / Math.round(dpr));
 
             var self = this;
             this.elementUrl = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/';

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -19,15 +19,13 @@
          * Creates the map widget
          */
         _create: function() {
-            // Auto-calculate dpi from device pixel ratio, to maintain reasonable canvas quality
-            // see https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-            // Avoid calculating dpi >= 1.5*96dpi to avoid pushing (Mapproxy) caches into a resolution
-            // with too low label font size.
-            // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
-            var dpr = window.devicePixelRatio || 1;
-            this.options.dpi = 96. * Math.max(1, dpr / Math.floor(dpr + 0.25));
-
+            delete this.options.dpi;
             var self = this;
+            Object.defineProperty(this.options, 'dpi', {
+                get: function() {
+                    return self.detectDpi_();
+                }
+            });
             this.elementUrl = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/';
             if (!this.options.extents.start && !this.options.extents.max) {
                 throw new Error("Incomplete map configuration: no start extent");
@@ -107,6 +105,15 @@
          */
         validateSrsOption: function(srsName) {
             return (typeof srsName === 'string') && /^EPSG:\d+$/.test(srsName);
+        },
+        detectDpi_: function() {
+            // Auto-calculate dpi from device pixel ratio, to maintain reasonable canvas quality
+            // see https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
+            // Avoid calculating dpi >= 1.5*96dpi to avoid pushing (Mapproxy) caches into a resolution
+            // with too low label font size.
+            // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
+            var dpr = window.devicePixelRatio || 1;
+            return 96. * Math.max(1, dpr / Math.floor(dpr + 0.25));
         },
         _comma_dangle_dummy: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -113,7 +113,7 @@
             // with too low label font size.
             // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
             var dpr = window.devicePixelRatio || 1;
-            return 96. * Math.max(1, dpr / Math.max(1, Math.floor(dpr + 0.25)));
+            return 96. * Math.max(1, dpr / (1 +  Math.floor(dpr - 0.75)));
         },
         _comma_dangle_dummy: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -113,7 +113,7 @@
             // with too low label font size.
             // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
             var dpr = window.devicePixelRatio || 1;
-            return 96. * Math.max(1, dpr / Math.floor(dpr + 0.25));
+            return 96. * Math.max(1, dpr / Math.max(1, Math.floor(dpr + 0.25)));
         },
         _comma_dangle_dummy: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -25,7 +25,7 @@
             // with too low label font size.
             // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
             var dpr = window.devicePixelRatio || 1;
-            this.options.dpi = 96. * Math.max(1, dpr / Math.round(dpr));
+            this.options.dpi = 96. * Math.max(1, dpr / Math.floor(dpr + 0.25));
 
             var self = this;
             this.elementUrl = Mapbender.configuration.application.urls.element + '/' + this.element.attr('id') + '/';

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
@@ -1,7 +1,6 @@
 <div class="elementFormMap elementForm wideLabelForm">
     {{ form_row(form.title) }}
     {{ form_row(form.configuration.layersets) }}
-    {{ form_row(form.configuration.dpi) }}
     {{ form_row(form.configuration.tileSize) }}
     {{ form_row(form.configuration.srs) }}
     <div>


### PR DESCRIPTION
Replaces centrally predefined `dpi` configuration option with client-side dpi detection, respecting concrete display pixel density.
DPI is necessary for two things:
* mapping ratio received WMS / WMTS pixels to screen pixels; anything deviating from 1:1 will introduce scaling, and as such reduce sharpness
* Any computation involving scale denominators

The newly added DPI detection logic aims to balance sharpness and label sizing (esp on WMSes cached via Mapproxy), with extra considerations for keeping prerendered labels large enough on "retina" type displays.

This fixes the observed low quality of WMS particularly on "slightly" high-dpi displays (120~144dpi) or with slight browser zooming.

NOTE that browser-side zooming (usually achieved by pressing Ctrl + / Ctrl -) also factors into the detected display pixel density. The effects of this may only fully apply after reloading the page again.

NOTE that when coming from the previous default of 90.7... dpi on a typical (96dpi) flat panel display, your map will now appear 6% smaller (zoomed out). 