### PR TITLE
Feature/share url element

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ShareUrl.php
+++ b/src/Mapbender/CoreBundle/Element/ShareUrl.php
@@ -11,14 +11,12 @@ class ShareUrl extends BaseButton
 
     public static function getClassTitle()
     {
-        // @todo: translate
-        return 'Share url';
+        return 'mb.core.ShareUrl.class.title';
     }
 
     public static function getClassDescription()
     {
-        // @todo: translate
-        return 'Share current map view via url';
+        return 'mb.core.ShareUrl.class.description';
     }
 
     public function getWidgetName()

--- a/src/Mapbender/CoreBundle/Element/ShareUrl.php
+++ b/src/Mapbender/CoreBundle/Element/ShareUrl.php
@@ -43,6 +43,9 @@ class ShareUrl extends BaseButton
                 '@MapbenderCoreBundle/Resources/public/sass/element/button.scss',
                 '@MapbenderCoreBundle/Resources/public/element/mbShareUrl.scss',
             ),
+            'trans' => array(
+                'mb.core.ShareUrl.*',
+            ),
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ShareUrl.php
+++ b/src/Mapbender/CoreBundle/Element/ShareUrl.php
@@ -26,6 +26,11 @@ class ShareUrl extends BaseButton
         return 'mapbender.mbShareUrl';
     }
 
+    public static function getType()
+    {
+        return 'Mapbender\CoreBundle\Element\Type\ShareUrlAdminType';
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Mapbender/CoreBundle/Element/ShareUrl.php
+++ b/src/Mapbender/CoreBundle/Element/ShareUrl.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element;
+
+
+class ShareUrl extends BaseButton
+{
+    // Disable being targetted by a Button
+    public static $ext_api = false;
+
+    public static function getClassTitle()
+    {
+        // @todo: translate
+        return 'Share url';
+    }
+
+    public static function getClassDescription()
+    {
+        // @todo: translate
+        return 'Share current map view via url';
+    }
+
+    public function getWidgetName()
+    {
+        return 'mapbender.mbShareUrl';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAssets()
+    {
+        return array(
+            'js' => array(
+                '@MapbenderCoreBundle/Resources/public/mapbender.element.button.js',
+                '@MapbenderCoreBundle/Resources/public/element/mbShareUrl.js',
+            ),
+            'css' => array(
+                '@MapbenderCoreBundle/Resources/public/sass/element/button.scss',
+                '@MapbenderCoreBundle/Resources/public/element/mbShareUrl.scss',
+            ),
+        );
+    }
+
+    public static function getDefaultConfiguration()
+    {
+        $defaults = parent::getDefaultConfiguration();
+        // icon is hard-coded (see twig template)
+        unset($defaults['icon']);
+        return $defaults;
+    }
+
+    public function getFrontendTemplatePath($suffix = '.html.twig')
+    {
+        return "MapbenderCoreBundle:Element:ShareUrl.html.twig";
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/Type/ShareUrlAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ShareUrlAdminType.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element\Type;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ShareUrlAdminType extends AbstractType
+{
+    public function getParent()
+    {
+        return 'Mapbender\CoreBundle\Element\Type\BaseButtonAdminType';
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // Icon is hard-coded, remove upstream icon field.
+        if ($builder->has('icon')) {
+            $builder->remove('icon');
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -79,6 +79,7 @@ class MapbenderCoreBundle extends MapbenderBundle
             'Mapbender\CoreBundle\Element\ScaleDisplay',
             'Mapbender\CoreBundle\Element\ScaleSelector',
             'Mapbender\CoreBundle\Element\SearchRouter',
+            'Mapbender\CoreBundle\Element\ShareUrl',
             'Mapbender\CoreBundle\Element\SimpleSearch',
             'Mapbender\CoreBundle\Element\SrsSelector',
             'Mapbender\CoreBundle\Element\ZoomBar',

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.js
@@ -25,7 +25,7 @@
                 $(this).attr('href', url);
                 if (useClipboard) {
                     self._copyToClipboard(url);
-                    Mapbender.info('Copied to clipboard');
+                    Mapbender.info(Mapbender.trans('mb.core.ShareUrl.copied_to_clipboard'));
                     evt.preventDefault();
                     evt.stopPropagation();
                     return false;

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.js
@@ -1,0 +1,66 @@
+;!(function($) {
+    "use strict";
+    $.widget("mapbender.mbShareUrl", {
+        mbMap: null,
+        baseUrl: null,
+
+        _create: function() {
+            var self = this;
+            this.baseUrl = window.location.href.replace(/[?#].*$/, '');
+            Mapbender.elementRegistry.waitReady('.mb-element-map').then(function(mbMap) {
+                self._setup(mbMap);
+            });
+        },
+        _setup: function(mbMap) {
+            this.mbMap = mbMap;
+            this._initEvents();
+        },
+        _initEvents: function() {
+            var self = this;
+
+            this.element.on('click', 'a.-fn-share-link', function(evt) {
+                var useClipboard = evt.which === 1 && !evt.ctrlKey && !evt.shiftKey;
+                var url = self._getUrl();
+                // Update href to preempt standard browser actions "open in new tab" / "open in new window"
+                $(this).attr('href', url);
+                if (useClipboard) {
+                    self._copyToClipboard(url);
+                    Mapbender.info('Copied to clipboard');
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    return false;
+                } else {
+                    return true;
+                }
+            });
+            this.element.on('mousedown', 'a.-fn-share-link', function() {
+                // Update href to preempt standard browser actions "open in new tab" / "open in new window"
+                $(this).attr('href', self._getUrl());
+            });
+        },
+        _getUrl: function() {
+            var m = this.mbMap.getModel();
+            var settings = m.getCurrentSettings();
+            var diff = m.diffSettings(m.getConfiguredSettings(), m.getCurrentSettings());
+            var params = m.encodeSettingsDiff(diff);
+            var url = Mapbender.Util.addUrlParams(this.baseUrl, params).replace(/\/?\?$/, '');
+            url = [url, m.encodeViewParams(settings.viewParams)].join('#');
+            return url;
+        },
+        _copyToClipboard: function(text) {
+            // MUST use an input that is in the DOM and nominally visible.
+            // We prevent visible rendering flashes with style="opacity: 0;" (works in Chrome + FF)
+            // Remove input from DOM immediately after copy operation
+            var $input = $(document.createElement('textarea'));
+            $input.val(text);
+            $input.css({opacity: 0});
+            document.body.appendChild($input.get(0));
+            $input.focus();
+            $input.select();
+            document.execCommand('copy');
+            document.body.removeChild($input.get(0));
+        },
+        __dummy__: null
+    });
+})(jQuery);
+

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbShareUrl.scss
@@ -1,0 +1,2 @@
+.mb-element-shareurl {
+}

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -284,6 +284,7 @@ mb:
       class:
         title: URL teilen
         description: Teilt die aktuelle Kartenansicht über eine URL
+      copied_to_clipboard: URL in Zischenablage kopiert
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -280,6 +280,10 @@ mb:
       tag:
         srs: SRS
         selector: Auswahl
+    ShareUrl:
+      class:
+        title: URL teilen
+        description: Teilt die aktuelle Kartenansicht über eine URL
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -283,6 +283,7 @@ mb:
       class:
         title: Share URL
         description: Share current map view via url
+      copied_to_clipboard: URL copied to clipboard
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -279,6 +279,10 @@ mb:
       tag:
         srs: SRS
         selector: selector
+    ShareUrl:
+      class:
+        title: Share URL
+        description: Share current map view via url
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/views/Element/ShareUrl.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/ShareUrl.html.twig
@@ -1,0 +1,11 @@
+{# Generate same markup as control button, but use fixed icon #}
+<div id="{{ id }}"
+      title="{{ configuration.tooltip|default(title)|trans }}"
+      class="mb-button mb-element-shareurl">
+        <a class="-fn-share-link" href="#">
+            <i class="fa fas fa-share-alt"></i>
+              {% if configuration.label %}
+              <span>{{ title|trans }}</span>
+              {% endif %}
+        </a>
+</div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/ShareUrl.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/ShareUrl.html.twig
@@ -5,7 +5,7 @@
         <a class="-fn-share-link" href="#">
             <i class="fa fas fa-share-alt"></i>
               {% if configuration.label %}
-              <span>{{ title|trans }}</span>
+              <span class="hidden-sm hidden-xs hidden-md-down">{{ title|trans }}</span>
               {% endif %}
         </a>
 </div>


### PR DESCRIPTION
Adds a new "Share URL" Element. This Element is button-like and works in toolbars (top + bottom) for now.

On regular left click, a URL is written to the clipboard that encapsulates the current map view. This URL can then be pasted into chat / email etc.

The Element also detects and transparently supports "open in new tab" / "open in new window" standard browser interactions. I.e. the Element behaves like a link if you right-click it, or use Ctrl+click / Shift+click shortcuts on it.

Visiting the generated URL restores
* basic view parameters (center, scale, rotation, CRS)
* layer and layerset settings changes (selected / deselected layersets, sources and layers; layer opacity settings)

The URL _does_ _not_ transfer
* dynamically added sources (via WmsLoader)
* dynamically removed layers or sources (via Layertree context menu)
* changes to source or layer order (via Layertree drag&drop)

### Configuration
|name|type|default|description|
|--|--|--|--|
|title|string or empty|--empty--|Optional custom title. Uses (translated) default title "Share URL" if omitted
|tooltip|string or empty|--empty--|Optional custom tooltip. Same as title if omitted
|label|boolean|true|Enable display of `title` (false: display icon only)

Basic definition for Yaml applications:
```yaml
    elements:
      toolbar:
        <...>
        shareUrl:
          class: Mapbender\CoreBundle\Element\ShareUrl
```

Full definition including optionals:
```yaml
    elements:
      toolbar:
        <...>
        shareUrl:
          class: Mapbender\CoreBundle\Element\ShareUrl
          title: Share this map view
          tooltip: I am displayed on hover
          label: true
```
