### PR TITLE
Fix config request content type

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/init/frontend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/init/frontend.js
@@ -26,7 +26,7 @@
 
     $.ajax({
         url: configUrl,
-        contentType: 'json'
+        contentType: 'application/json'
     }).done(function (data, textStatus, jqXHR) {
         Mapbender.configuration = data;
         $(Mapbender.setup);


### PR DESCRIPTION
'json' is not a valid content type. 
This causes problems whenever a firewall with a strict set of rules is involved.