### PR TITLE
Fix/published database application grants

### DIFF
--- a/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationVoter.php
+++ b/src/Mapbender/CoreBundle/Component/Security/Voter/DbApplicationVoter.php
@@ -13,10 +13,10 @@ class DbApplicationVoter extends BaseApplicationVoter
     {
         /** @var mixed|Application $subject */
         if (parent::supports($attribute, $subject) && $subject->getSource() !== Application::SOURCE_YAML) {
-            // VIEW: only vote on database / persistable Application instances
-            // Abstain on published Application (Symfony default ACL handles all of that by itself)
+            // VIEW: only vote on database / persistable Application instances that are published
+            // Abstain on unpublished Application (access determined by ACL; getting involved in voting would cause an infinite loop)
             if ($attribute === 'VIEW') {
-                return !$subject->isPublished();
+                return $subject->isPublished();
             } else {
                 // rely on parent support for 'CLONE'
                 return true;
@@ -28,10 +28,12 @@ class DbApplicationVoter extends BaseApplicationVoter
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
+        /** @var Application $subject */
         switch ($attribute) {
             case 'VIEW':
-                // no own logic for published Application (see supports)
-                return $this->voteViewUnpublished($subject, $token);
+                // Is published; see supports
+                assert(!!$subject->isPublished());
+                return true;
             default:
                 return parent::voteOnAttribute($attribute, $subject, $token);
         }
@@ -42,19 +44,6 @@ class DbApplicationVoter extends BaseApplicationVoter
         return array_unique(array_merge(parent::getSupportedAttributes($subject), array(
             'VIEW',
         )));
-    }
-
-    /**
-     * Decide on view grant.
-     *
-     * @param Application $subject guaranteed to be Db-based (see supports)
-     * @param TokenInterface $token
-     * @return bool true for grant, false for deny (cannot abstain here)
-     */
-    protected function voteViewUnpublished(Application $subject, TokenInterface $token)
-    {
-        // forward to ACL check on 'EDIT' attribute and explicitly DENY if not granted
-        return $this->accessDecisionManager->decide($token, array('EDIT'), $subject);
     }
 
     protected function voteOnClone(Application $application, TokenInterface $token)

--- a/src/Mapbender/CoreBundle/Entity/Application.php
+++ b/src/Mapbender/CoreBundle/Entity/Application.php
@@ -96,7 +96,7 @@ class Application
     /**
      * @ORM\Column(type="boolean")
      */
-    protected $published = false;
+    protected $published = true;
 
     /**
      * @ORM\Column(type="string", length=256, nullable=true)

--- a/src/Mapbender/CoreBundle/Mapbender.php
+++ b/src/Mapbender/CoreBundle/Mapbender.php
@@ -7,7 +7,6 @@ use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\CoreBundle\Component\MapbenderBundle;
 use Mapbender\CoreBundle\Component\Source\TypeDirectoryService;
 use Mapbender\CoreBundle\Component\UploadsManager;
-use Mapbender\CoreBundle\Component\YamlApplicationImporter;
 use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Layerset;
 use Mapbender\CoreBundle\Utils\EntityUtil;
@@ -213,11 +212,6 @@ class Mapbender
             $element->setConfiguration($config);
             $this->manager->persist($element);
         }
-
-
-        /** @var YamlApplicationImporter $importerService */
-        $importerService = $this->container->get('mapbender.yaml_application_importer.service');
-        $importerService->addViewPermissions($application);
 
         $this->manager->flush();
         $this->manager->commit();

--- a/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/ApplicationType.php
@@ -98,6 +98,7 @@ class ApplicationType extends AbstractType
                     'mapped' => false,
                     'data' => $options['data'],
                     'create_standard_permissions' => true,
+                    'standard_anon_access' => false,
                     'permissions' => 'standard::object',
                 ))
             ;


### PR DESCRIPTION
Updates access control logic for Application view grant.
If the Application is set as "published", allow access to all.
When creating a new Application, no longer add an ACL entry for anonymous users; instead, default the new Application to "published".

This fixes an old limitation where direct Application view grants for specific users or groups did not grant access unless the Application was also "published". Only "EDIT" grants would have allowed viewing those Applications. Now a direct view grant on the Application (or globally on the Application class) works as expected.

This also increases performance on larger installations. The very common view access check on any published Application can now completely skip ACL lookups from the database.

This fixes #1326 