### PR TITLE
Feature/zoombar zoom home layersettings restoration

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/ZoomBarAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ZoomBarAdminType.php
@@ -24,6 +24,11 @@ class ZoomBarAdminType extends AbstractType
     {
 
         $builder
+            ->add('target', 'Mapbender\CoreBundle\Element\Type\TargetElementType', array(
+                'element_class' => 'Mapbender\\CoreBundle\\Element\\Map',
+                'application' => $options['application'],
+                'required' => false,
+            ))
             ->add('components', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'required' => true,
                 'multiple' => true,
@@ -39,10 +44,9 @@ class ZoomBarAdminType extends AbstractType
                     'size' => 6,
                 ),
             ))
-            ->add('target', 'Mapbender\CoreBundle\Element\Type\TargetElementType', array(
-                'element_class' => 'Mapbender\\CoreBundle\\Element\\Map',
-                'application' => $options['application'],
+            ->add('zoomHomeRestoresLayers', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
+                'label' => 'mb.core.zoombar.zoomHomeRestoresLayers',
             ))
             ->add('anchor', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'required' => true,

--- a/src/Mapbender/CoreBundle/Element/ZoomBar.php
+++ b/src/Mapbender/CoreBundle/Element/ZoomBar.php
@@ -63,6 +63,7 @@ class ZoomBar extends Element
             ),
             'anchor' => 'left-top',
             'draggable' => true,
+            'zoomHomeRestoresLayers' => false,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.zoombar.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.zoombar.js
@@ -3,11 +3,13 @@
 $.widget("mapbender.mbZoomBar", {
     options: {
         target: null,
-        draggable: true
+        draggable: true,
+        zoomHomeRestoresLayers: false
     },
 
     zoomslider: null,
     mbMap: null,
+    configuredMapSettings: null,
 
     _create: function() {
         if(!Mapbender.checkTarget("mbZoomBar", this.options.target)){
@@ -22,6 +24,8 @@ $.widget("mapbender.mbZoomBar", {
 
     _setup: function() {
         var self = this;
+        this.configuredMapSettings = this.mbMap.getModel().getConfiguredSettings();
+
         this._setupSlider();
         this._setupZoomButtons();
         $(document).on('mbmapzoomchanged', function(e, data) {
@@ -94,7 +98,11 @@ $.widget("mapbender.mbZoomBar", {
         });
         this.element.on('click', '.-fn-zoom-home', function() {
             var m = self.mbMap.getModel();
-            m.applyViewParams(m.getConfiguredSettings().viewParams);
+            if (self.options.zoomHomeRestoresLayers) {
+                m.applySettings(self.configuredMapSettings);
+            } else {
+                m.applyViewParams(self.configuredMapSettings.viewParams);
+            }
         });
     },
     /**

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -192,6 +192,7 @@ mb:
       zoombybox: 'Ausschnitt aufziehen'
       zoombyworld: 'Zoom auf gesamte Ausdehnung'
       zoom_home: Zurück zum Anfang
+      zoomHomeRestoresLayers: '"Zurück zum Anfang" setzt Dienstezustände zurück'
       zoomin: Hineinzoomen
       zoomout: Herauszoomen
       class:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -191,6 +191,7 @@ mb:
       zoombybox: 'Zoom by box'
       zoombyworld: 'Zoom by world'
       zoom_home: Back to start
+      zoomHomeRestoresLayers: '"Back to start" also resets layer settings'
       zoomin: Zoom in
       zoomout: Zoom out
       class:

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/zoombar.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/zoombar.html.twig
@@ -2,4 +2,15 @@
     {{ form_row(form.configuration.draggable) }}
     {{ form_row(form.title) }}
     {{ form_rest(form.configuration) }}
+    <script type="text/javascript">
+        (function($) {
+            var componentsInput = document.getElementById({{ form.configuration.components.vars.id | json_encode | raw }});
+            var zoomHomeRestoresLayersInput = document.getElementById({{ form.configuration.zoomHomeRestoresLayers.vars.id | json_encode | raw }});
+            var updateCb = function() {
+                $(zoomHomeRestoresLayersInput).prop('disabled', -1 === $(this).val().indexOf('zoom_home'));
+            };
+            updateCb.call(componentsInput);
+            $(componentsInput).on('change', updateCb);
+        }(jQuery));
+    </script>
 </div>


### PR DESCRIPTION
Adds ability to also restore layer settings to their configured defaults when perusing the ZoomBar "zoom_home" component.

This is controlled with a new field in the ZoomBar configuration

Name|Type|default
-|-|-
`zoomHomeRestoresLayers`|boolean|false

