### PR TITLE
Feature/view manager

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -36,6 +36,10 @@ class ViewManagerAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.allowAnonymousSave',
             ))
+            ->add('allowNonAdminDelete', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'required' => false,
+                'label' => 'mb.core.viewManager.admin.allowNonAdminDelete',
+            ))
         ;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -18,7 +18,7 @@ class ViewManagerAdminType extends AbstractType
         }
         $accessChoices = array(
             // @todo: translate choice labels
-            'Do not show' => null,
+            'Do not show' => '',
             'Read only' => 'ro',
             'Allow saving' => 'rw',
         );

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -28,6 +28,10 @@ class ViewManagerAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.privateEntries',
             ))
+            ->add('showDate', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'required' => false,
+                'label' => 'mb.core.viewManager.admin.showDate',
+            ))
             ->add('allowAnonymousSave', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.allowAnonymousSave',

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -21,6 +21,7 @@ class ViewManagerAdminType extends AbstractType
             'mb.core.viewManager.admin.access.none' => '',
             'mb.core.viewManager.admin.access.ro' => ViewManager::ACCESS_READONLY,
             'mb.core.viewManager.admin.access.rw' => ViewManager::ACCESS_READWRITE,
+            'mb.core.viewManager.admin.access.rwd' => ViewManager::ACCESS_READWRITEDELETE,
         );
         $builder
            ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
@@ -35,10 +36,6 @@ class ViewManagerAdminType extends AbstractType
             ->add('allowAnonymousSave', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.allowAnonymousSave',
-            ))
-            ->add('allowNonAdminDelete', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-                'required' => false,
-                'label' => 'mb.core.viewManager.admin.allowNonAdminDelete',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -24,11 +24,6 @@ class ViewManagerAdminType extends AbstractType
             'mb.core.viewManager.admin.access.rwd' => ViewManager::ACCESS_READWRITEDELETE,
         );
         $builder
-           ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
-               'choices' => $accessChoices,
-               'required' => false,
-               'label' => 'mb.core.viewManager.admin.publicEntries',
-           ))
             ->add('privateEntries', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.privateEntries',
@@ -37,6 +32,11 @@ class ViewManagerAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.allowAnonymousSave',
             ))
+           ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
+               'choices' => $accessChoices,
+               'required' => false,
+               'label' => 'mb.core.viewManager.admin.publicEntries',
+           ))
         ;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -17,25 +17,24 @@ class ViewManagerAdminType extends AbstractType
             $choiceOptions['choices_as_values'] = true;
         }
         $accessChoices = array(
-            // @todo: translate choice labels
-            'Do not show' => '',
-            'Read only' => 'ro',
-            'Allow saving' => 'rw',
+            'mb.core.viewManager.admin.access.none' => '',
+            'mb.core.viewManager.admin.access.ro' => 'ro',
+            'mb.core.viewManager.admin.access.rw' => 'rw',
         );
         $builder
            ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
-               // @todo: supply translatable label
                'choices' => $accessChoices,
                'required' => false,
+               'label' => 'mb.core.viewManager.admin.publicEntries',
            ))
             ->add('privateEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
-                    // @todo: supply translatable label
                 'choices' => $accessChoices,
                 'required' => false,
+                'label' => 'mb.core.viewManager.admin.privateEntries',
             ))
             ->add('allowAnonymousSave', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-                // @todo: supply translatable label
                 'required' => false,
+                'label' => 'mb.core.viewManager.admin.allowAnonymousSave',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -4,6 +4,7 @@
 namespace Mapbender\CoreBundle\Element\Type;
 
 
+use Mapbender\CoreBundle\Element\ViewManager;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -18,8 +19,8 @@ class ViewManagerAdminType extends AbstractType
         }
         $accessChoices = array(
             'mb.core.viewManager.admin.access.none' => '',
-            'mb.core.viewManager.admin.access.ro' => 'ro',
-            'mb.core.viewManager.admin.access.rw' => 'rw',
+            'mb.core.viewManager.admin.access.ro' => ViewManager::ACCESS_READONLY,
+            'mb.core.viewManager.admin.access.rw' => ViewManager::ACCESS_READWRITE,
         );
         $builder
            ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element\Type;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class ViewManagerAdminType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $choiceOptions = array();
+        if (Kernel::MAJOR_VERSION < 3) {
+            $choiceOptions['choices_as_values'] = true;
+        }
+        $accessChoices = array(
+            // @todo: translate choice labels
+            'Do not show' => null,
+            'Read only' => 'ro',
+            'Allow saving' => 'rw',
+        );
+        $builder
+           ->add('publicEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
+               // @todo: supply translatable label
+               'choices' => $accessChoices,
+               'required' => false,
+           ))
+            ->add('privateEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
+                    // @todo: supply translatable label
+                'choices' => $accessChoices,
+                'required' => false,
+            ))
+            ->add('allowAnonymousSave', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                // @todo: supply translatable label
+                'required' => false,
+            ))
+        ;
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ViewManagerAdminType.php
@@ -28,8 +28,7 @@ class ViewManagerAdminType extends AbstractType
                'required' => false,
                'label' => 'mb.core.viewManager.admin.publicEntries',
            ))
-            ->add('privateEntries', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $choiceOptions + array(
-                'choices' => $accessChoices,
+            ->add('privateEntries', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                 'required' => false,
                 'label' => 'mb.core.viewManager.admin.privateEntries',
             ))

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -47,12 +47,18 @@ class ViewManager extends Element
         return 'Mapbender\CoreBundle\Element\Type\ViewManagerAdminType';
     }
 
+    public static function getFormTemplate()
+    {
+        return 'MapbenderCoreBundle:ElementAdmin:view_manager.html.twig';
+    }
+
     public static function getDefaultConfiguration()
     {
         return array(
             'publicEntries' => 'ro',
             'privateEntries' => 'rw',
             'allowAnonymousSave' => false,
+            'allowNonAdminDelete' => false,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -71,8 +71,7 @@ class ViewManager extends Element
         $grants = $this->getHttpHandler()->getGrantsVariables($config);
 
         return array(
-            'showSaving' => $grants['savePublic'] || $grants['savePrivate'],
-            'showListSelector' => $config['privateEntries'] && $config['publicEntries'] && $config['publicEntries'] !== self::ACCESS_READONLY,
+            'grants' => $grants,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element;
+
+use Mapbender\CoreBundle\Component\Element;
+use Symfony\Component\HttpFoundation\Request;
+
+
+class ViewManager extends Element
+{
+    public static function getClassTitle()
+    {
+        // @todo: translate me
+        return 'View manager';
+    }
+
+    public static function getClassDescription()
+    {
+        // @todo: translate me
+        return 'Stores and restores map state';
+    }
+
+    public function getWidgetName()
+    {
+        return 'mapbender.mbViewManager';
+    }
+
+    public function getFrontendTemplatePath()
+    {
+        return 'MapbenderCoreBundle:Element:view_manager.html.twig';
+    }
+
+    public function getAssets()
+    {
+        return array(
+            'js' => array(
+                '@MapbenderCoreBundle/Resources/public/element/mbViewManager.js',
+            ),
+            'css' => array(),
+            'trans' => array(),
+        );
+    }
+
+    public function handleHttpRequest(Request $request)
+    {
+        /** @var ViewManagerHttpHandler $handler */
+        $handler = $this->container->get('mb.element.view_manager.http_handler');
+        return $handler->handleHttpRequest($this->entity, $request);
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -11,14 +11,12 @@ class ViewManager extends Element
 {
     public static function getClassTitle()
     {
-        // @todo: translate me
-        return 'View manager';
+        return 'mb.core.viewManager.class.title';
     }
 
     public static function getClassDescription()
     {
-        // @todo: translate me
-        return 'Stores and restores map state';
+        return 'mb.core.viewManager.class.description';
     }
 
     public function getWidgetName()

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -62,6 +62,7 @@ class ViewManager extends Element
             'publicEntries' => self::ACCESS_READONLY,
             'privateEntries' => true,
             'allowAnonymousSave' => false,
+            'showDate' => true,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -56,6 +56,15 @@ class ViewManager extends Element
         );
     }
 
+    public function getFrontendTemplateVars()
+    {
+        $config = $this->entity->getConfiguration() + $this->getDefaultConfiguration();
+        return array(
+            'showSaving' => ($config['publicEntries'] === 'rw' || $config['privateEntries'] === 'rw'),
+            'showListSelector' => !empty($config['publicEntries']) && !empty($config['privateEntries']),
+        );
+    }
+
     public function handleHttpRequest(Request $request)
     {
         /** @var ViewManagerHttpHandler $handler */

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -69,6 +69,8 @@ class ViewManager extends Element
     {
         /** @var ViewManagerHttpHandler $handler */
         $handler = $this->container->get('mb.element.view_manager.http_handler');
+        // Extend with defaults
+        $this->entity->setConfiguration($this->entity->getConfiguration() + $this->getDefaultConfiguration());
         return $handler->handleHttpRequest($this->entity, $request);
     }
 }

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -9,6 +9,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ViewManager extends Element
 {
+    const ACCESS_READWRITE = 'rw';
+    const ACCESS_READONLY = 'ro';
+
     public static function getClassTitle()
     {
         return 'mb.core.viewManager.class.title';
@@ -55,8 +58,8 @@ class ViewManager extends Element
     public static function getDefaultConfiguration()
     {
         return array(
-            'publicEntries' => 'ro',
-            'privateEntries' => 'rw',
+            'publicEntries' => self::ACCESS_READONLY,
+            'privateEntries' => self::ACCESS_READWRITE,
             'allowAnonymousSave' => false,
             'allowNonAdminDelete' => false,
         );
@@ -66,7 +69,7 @@ class ViewManager extends Element
     {
         $config = $this->entity->getConfiguration() + $this->getDefaultConfiguration();
         return array(
-            'showSaving' => ($config['publicEntries'] === 'rw' || $config['privateEntries'] === 'rw'),
+            'showSaving' => ($config['publicEntries'] === self::ACCESS_READWRITE || $config['privateEntries'] === self::ACCESS_READWRITE),
             'showListSelector' => !empty($config['publicEntries']) && !empty($config['privateEntries']),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -59,7 +59,7 @@ class ViewManager extends Element
     {
         return array(
             'publicEntries' => self::ACCESS_READONLY,
-            'privateEntries' => self::ACCESS_READWRITE,
+            'privateEntries' => true,
             'allowAnonymousSave' => false,
             'allowNonAdminDelete' => false,
         );
@@ -69,8 +69,8 @@ class ViewManager extends Element
     {
         $config = $this->entity->getConfiguration() + $this->getDefaultConfiguration();
         return array(
-            'showSaving' => ($config['publicEntries'] === self::ACCESS_READWRITE || $config['privateEntries'] === self::ACCESS_READWRITE),
-            'showListSelector' => !empty($config['publicEntries']) && !empty($config['privateEntries']),
+            'showSaving' => ($config['publicEntries'] === self::ACCESS_READWRITE || $config['privateEntries']),
+            'showListSelector' => !empty($config['publicEntries']) && $config['privateEntries'],
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -72,7 +72,7 @@ class ViewManager extends Element
 
         return array(
             'showSaving' => $grants['savePublic'] || $grants['savePrivate'],
-            'showListSelector' => !empty($config['publicEntries']) && $config['publicEntries'] !== self::ACCESS_READONLY && $config['privateEntries'],
+            'showListSelector' => $config['privateEntries'] && $config['publicEntries'] && $config['publicEntries'] !== self::ACCESS_READONLY,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -42,6 +42,20 @@ class ViewManager extends Element
         );
     }
 
+    public static function getType()
+    {
+        return 'Mapbender\CoreBundle\Element\Type\ViewManagerAdminType';
+    }
+
+    public static function getDefaultConfiguration()
+    {
+        return array(
+            'publicEntries' => 'ro',
+            'privateEntries' => 'rw',
+            'allowAnonymousSave' => false,
+        );
+    }
+
     public function handleHttpRequest(Request $request)
     {
         /** @var ViewManagerHttpHandler $handler */

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -68,18 +68,28 @@ class ViewManager extends Element
     public function getFrontendTemplateVars()
     {
         $config = $this->entity->getConfiguration() + $this->getDefaultConfiguration();
+        $grants = $this->getHttpHandler()->getGrantsVariables($config);
+
         return array(
-            'showSaving' => ($config['publicEntries'] === self::ACCESS_READWRITE || $config['privateEntries']),
+            'showSaving' => $grants['savePublic'] || $grants['savePrivate'],
             'showListSelector' => !empty($config['publicEntries']) && $config['privateEntries'],
         );
     }
 
     public function handleHttpRequest(Request $request)
     {
-        /** @var ViewManagerHttpHandler $handler */
-        $handler = $this->container->get('mb.element.view_manager.http_handler');
         // Extend with defaults
         $this->entity->setConfiguration($this->entity->getConfiguration() + $this->getDefaultConfiguration());
-        return $handler->handleHttpRequest($this->entity, $request);
+        return $this->getHttpHandler()->handleHttpRequest($this->entity, $request);
+    }
+
+    /**
+     * @return ViewManagerHttpHandler
+     */
+    public function getHttpHandler()
+    {
+        /** @var ViewManagerHttpHandler $handler */
+        $handler = $this->container->get('mb.element.view_manager.http_handler');
+        return $handler;
     }
 }

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -72,7 +72,7 @@ class ViewManager extends Element
 
         return array(
             'showSaving' => $grants['savePublic'] || $grants['savePrivate'],
-            'showListSelector' => !empty($config['publicEntries']) && $config['privateEntries'],
+            'showListSelector' => !empty($config['publicEntries']) && $config['publicEntries'] !== self::ACCESS_READONLY && $config['privateEntries'],
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -37,7 +37,9 @@ class ViewManager extends Element
             'js' => array(
                 '@MapbenderCoreBundle/Resources/public/element/mbViewManager.js',
             ),
-            'css' => array(),
+            'css' => array(
+                '@MapbenderCoreBundle/Resources/public/element/mbViewManager.scss',
+            ),
             'trans' => array(),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManager.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManager.php
@@ -9,8 +9,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ViewManager extends Element
 {
-    const ACCESS_READWRITE = 'rw';
     const ACCESS_READONLY = 'ro';
+    const ACCESS_READWRITE = 'rw';
+    const ACCESS_READWRITEDELETE = 'rwd';
 
     public static function getClassTitle()
     {
@@ -61,7 +62,6 @@ class ViewManager extends Element
             'publicEntries' => self::ACCESS_READONLY,
             'privateEntries' => true,
             'allowAnonymousSave' => false,
-            'allowNonAdminDelete' => false,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -113,6 +113,7 @@ class ViewManagerHttpHandler
     protected function getSaveResponse(Entity\Element $element, Request $request)
     {
         if ($id = $request->query->get('id')) {
+            /** @var ViewManagerState|null $record */
             $record = $this->getRepository()->find($id);
             if (!$record) {
                 throw new NotFoundHttpException();
@@ -120,6 +121,7 @@ class ViewManagerHttpHandler
             if ($newTitle = $request->request->get('title')) {
                 $record->setTitle($newTitle);
             }
+            $record->setMtime(new \DateTime());
         } else {
             $record = new ViewManagerState();
             $record->setApplicationSlug($element->getApplication()->getSlug());

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -88,7 +88,7 @@ class ViewManagerHttpHandler
         $record = new MapViewDiff();
         $record->setApplicationSlug($element->getApplication()->getSlug());
         $record->setTitle($request->request->get('title'));
-        $record->setUserId($request->request->get('savePublic') ? $this->getUserId() : null);
+        $record->setUserId($request->request->get('savePublic') ? null : $this->getUserId());
         // NOTE: Empty arrays do not survive jQuery Ajax post, will be stripped completely from incoming data
         $record->setViewParams($request->request->get('viewParams'));
         $record->setLayersetDiffs($request->request->get('layersetsDiff', array()));

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -101,6 +101,10 @@ class ViewManagerHttpHandler
             }
         }
 
+        $criteria->orderBy(array(
+            'applicationSlug' => Criteria::ASC,
+            'userId' => Criteria::ASC,
+        ));
         $records = $this->getRepository()->matching($criteria);
 
         $vars = $this->getGrantsVariables($config) + array(

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Element;
+
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Mapbender\CoreBundle\Entity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Templating\EngineInterface;
+
+class ViewManagerHttpHandler
+{
+    /** @var EngineInterface */
+    protected $templating;
+    /** @var EntityManagerInterface */
+    protected $em;
+
+    public function __construct(EngineInterface $templating, EntityManagerInterface $em)
+    {
+        $this->templating = $templating;
+        $this->em = $em;
+    }
+
+    /**
+     * @param Entity\Element $element
+     * @param Request $request
+     * @return Response
+     * @throws HttpException
+     */
+    public function handleHttpRequest(Entity\Element $element, Request $request)
+    {
+        switch ($request->attributes->get('action')) {
+            default:
+                throw new NotFoundHttpException();
+            case 'listing':
+                return $this->getListingResponse($element, $request);
+            case 'save':
+                return $this->getSaveResponse($element, $request);
+        }
+    }
+
+    /**
+     * @param Entity\Element $element
+     * @param Request $request
+     * @return Response
+     */
+    protected function getListingResponse(Entity\Element $element, Request $request)
+    {
+        $records = $this->getRepository()->findBy(array(
+            'applicationSlug' => $element->getApplication()->getSlug(),
+        ));
+        $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing.html.twig', array(
+            'records' => $records,
+            'dateFormat' => $this->getDateFormat($request),
+        ));
+        return new Response($content);
+    }
+
+    protected function getSaveResponse(Entity\Element $element, Request $request)
+    {
+        $record = new Entity\MapViewDiff();
+        // @todo: store user
+        $record->setApplicationSlug($element->getApplication()->getSlug());
+        $record->setTitle($request->request->get('title'));
+        // NOTE: Empty arrays do not survive jQuery Ajax post, will be stripped completely from incoming data
+        $record->setViewParams($request->request->get('viewParams'));
+        $record->setLayersetDiffs($request->request->get('layersetsDiff', array()));
+        $record->setSourceDiffs($request->request->get('sourcesDiff', array()));
+
+        $this->em->persist($record);
+        $this->em->flush();
+        $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing-row.html.twig', array(
+            'record' => $record,
+            'dateFormat' => $this->getDateFormat($request),
+        ));
+        return new Response($content);
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    protected function getDateFormat(Request $request)
+    {
+        // @todo: locale-dependent format
+        return 'Y-m-d H:m:i';
+    }
+
+    /**
+     * @return \Doctrine\Persistence\ObjectRepository
+     */
+    protected function getRepository()
+    {
+        /** @var EntityRepository */
+        $repository = $this->em->getRepository('Mapbender\CoreBundle\Entity\MapViewDiff');
+        return $repository;
+    }
+}

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -65,9 +65,10 @@ class ViewManagerHttpHandler
     protected function getListingResponse(Entity\Element $element, Request $request)
     {
         $config = $element->getConfiguration();
-        $vars = $this->getGrantsVariables($config) + array(
+        $vars = array(
             'records' => $this->loadListing($element->getApplication(), $config),
             'dateFormat' => $this->getDateFormat($request),
+            'grants' => $this->getGrantsVariables($config),
         );
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing.html.twig', $vars);
         return new Response($content);
@@ -129,9 +130,10 @@ class ViewManagerHttpHandler
         $this->em->persist($record);
         $this->em->flush();
 
-        $vars = $this->getGrantsVariables($element->getConfiguration()) + array(
+        $vars = array(
             'record' => $record,
             'dateFormat' => $this->getDateFormat($request),
+            'grants' => $this->getGrantsVariables($element->getConfiguration()),
         );
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing-row.html.twig', $vars);
         return new Response($content);
@@ -230,7 +232,7 @@ class ViewManagerHttpHandler
                 ViewManager::ACCESS_READWRITEDELETE,
             ))),
             'savePrivate' => $isAdmin || ($saveDefault && $config['privateEntries']),
-            'allowPublicDelete' => $isAdmin || $config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE,
+            'deletePublic' => $isAdmin || $config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE,
         );
     }
 
@@ -241,7 +243,7 @@ class ViewManagerHttpHandler
             default:
                 false;
             case 'delete':
-                return $grantsVariables['allowPublicDelete'];
+                return $grantsVariables['deletePublic'];
             case 'savePublic':
                 return $grantsVariables['savePublic'];
             case 'savePrivate':

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -86,9 +86,9 @@ class ViewManagerHttpHandler
     protected function getSaveResponse(Entity\Element $element, Request $request)
     {
         $record = new MapViewDiff();
-        // @todo: store user
         $record->setApplicationSlug($element->getApplication()->getSlug());
         $record->setTitle($request->request->get('title'));
+        $record->setUserId($request->request->get('savePublic') ? $this->getUserId() : null);
         // NOTE: Empty arrays do not survive jQuery Ajax post, will be stripped completely from incoming data
         $record->setViewParams($request->request->get('viewParams'));
         $record->setLayersetDiffs($request->request->get('layersetsDiff', array()));
@@ -96,9 +96,13 @@ class ViewManagerHttpHandler
 
         $this->em->persist($record);
         $this->em->flush();
+
+        $config = $element->getConfiguration();
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing-row.html.twig', array(
             'record' => $record,
             'dateFormat' => $this->getDateFormat($request),
+            'savePrivate' => $config['publicEntries'] === 'rw',
+            'savePublic' => $config['privateEntries'] === 'rw',
         ));
         return new Response($content);
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -128,7 +128,7 @@ class ViewManagerHttpHandler
     protected function getDateFormat(Request $request)
     {
         // @todo: locale-dependent format
-        return 'Y-m-d H:m:i';
+        return 'Y-m-d'; // . ' H:m:i';
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -77,6 +77,8 @@ class ViewManagerHttpHandler
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing.html.twig', array(
             'records' => $records,
             'dateFormat' => $this->getDateFormat($request),
+            'savePrivate' => $config['publicEntries'] === 'rw',
+            'savePublic' => $config['privateEntries'] === 'rw',
         ));
         return new Response($content);
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -189,8 +189,8 @@ class ViewManagerHttpHandler
     protected function getGrantsVariables($config)
     {
         return array(
-            'savePublic' => $config['publicEntries'] === 'rw',
-            'savePrivate' => $config['privateEntries'] === 'rw',
+            'savePublic' => $config['publicEntries'] === ViewManager::ACCESS_READWRITE,
+            'savePrivate' => $config['privateEntries'] === ViewManager::ACCESS_READWRITE,
             'allowDelete' => $config['allowNonAdminDelete'] || $this->isAdmin(),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -190,7 +190,7 @@ class ViewManagerHttpHandler
     {
         return array(
             'savePublic' => $config['publicEntries'] === ViewManager::ACCESS_READWRITE,
-            'savePrivate' => $config['privateEntries'] === ViewManager::ACCESS_READWRITE,
+            'savePrivate' => !!$config['privateEntries'],
             'allowDelete' => $config['allowNonAdminDelete'] || $this->isAdmin(),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -72,13 +72,14 @@ class ViewManagerHttpHandler
         } elseif ($showPrivate && !$showPublic) {
             $criteria['userId'] = $this->getUserId();
         }
+
         $records = $this->getRepository()->findBy($criteria);
 
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing.html.twig', array(
             'records' => $records,
             'dateFormat' => $this->getDateFormat($request),
-            'savePrivate' => $config['publicEntries'] === 'rw',
-            'savePublic' => $config['privateEntries'] === 'rw',
+            'savePrivate' => $config['privateEntries'] === 'rw',
+            'savePublic' => $config['publicEntries'] === 'rw',
         ));
         return new Response($content);
     }
@@ -101,8 +102,8 @@ class ViewManagerHttpHandler
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing-row.html.twig', array(
             'record' => $record,
             'dateFormat' => $this->getDateFormat($request),
-            'savePrivate' => $config['publicEntries'] === 'rw',
-            'savePublic' => $config['privateEntries'] === 'rw',
+            'savePrivate' => $config['privateEntries'] === 'rw',
+            'savePublic' => $config['publicEntries'] === 'rw',
         ));
         return new Response($content);
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -233,7 +233,7 @@ class ViewManagerHttpHandler
                 ViewManager::ACCESS_READWRITEDELETE,
             )))),
             'savePrivate' => !$isAnon && $config['privateEntries'],
-            'deletePublic' => $isAdmin || ($config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE),
+            'deletePublic' => $isAdmin || !$isAnon && ($config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE),
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -211,11 +211,12 @@ class ViewManagerHttpHandler
 
     public function getGrantsVariables($config)
     {
-        $saveDefault = $this->isCurrentUserAnonymous() ? $config['allowAnonymousSave'] : true;
+        $isAdmin = $this->isAdmin();
+        $saveDefault = $isAdmin || $this->isCurrentUserAnonymous() ? $config['allowAnonymousSave'] : true;
         return array(
-            'savePublic' => $saveDefault && $config['publicEntries'] === ViewManager::ACCESS_READWRITE,
-            'savePrivate' => $saveDefault && $config['privateEntries'],
-            'allowDelete' => $config['allowNonAdminDelete'] || $this->isAdmin(),
+            'savePublic' => $isAdmin || ($saveDefault && $config['publicEntries'] === ViewManager::ACCESS_READWRITE),
+            'savePrivate' => $isAdmin || ($saveDefault && $config['privateEntries']),
+            'allowDelete' => $isAdmin || $config['allowNonAdminDelete'],
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -73,6 +73,8 @@ class ViewManagerHttpHandler
             $criteria['userId'] = null;
         } elseif ($showPrivate && !$showPublic) {
             $criteria['userId'] = $this->getUserId();
+        } else {
+            $criteria['userId'] = array($this->getUserId(), null);
         }
 
         $records = $this->getRepository()->findBy($criteria);

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityRepository;
 use Mapbender\CoreBundle\Entity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Templating\EngineInterface;
@@ -41,6 +42,8 @@ class ViewManagerHttpHandler
                 return $this->getListingResponse($element, $request);
             case 'save':
                 return $this->getSaveResponse($element, $request);
+            case 'delete':
+                return $this->getDeleteResponse($element, $request);
         }
     }
 
@@ -79,6 +82,20 @@ class ViewManagerHttpHandler
             'dateFormat' => $this->getDateFormat($request),
         ));
         return new Response($content);
+    }
+
+    protected function getDeleteResponse(Entity\Element $element, Request $request)
+    {
+        $id = $request->query->get('id');
+        if (!$id) {
+            throw new BadRequestHttpException("Missing id");
+        }
+        $record = $records = $this->getRepository()->find($id);
+        if ($record) {
+            $this->em->remove($record);
+            $this->em->flush();
+        }
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -209,11 +209,12 @@ class ViewManagerHttpHandler
         return false;
     }
 
-    protected function getGrantsVariables($config)
+    public function getGrantsVariables($config)
     {
+        $saveDefault = $this->isCurrentUserAnonymous() ? $config['allowAnonymousSave'] : true;
         return array(
-            'savePublic' => $config['publicEntries'] === ViewManager::ACCESS_READWRITE,
-            'savePrivate' => !!$config['privateEntries'],
+            'savePublic' => $saveDefault && $config['publicEntries'] === ViewManager::ACCESS_READWRITE,
+            'savePrivate' => $saveDefault && $config['privateEntries'],
             'allowDelete' => $config['allowNonAdminDelete'] || $this->isAdmin(),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -138,7 +138,8 @@ class ViewManagerHttpHandler
         /** @var MapViewDiff|null $record */
         $record = $records = $this->getRepository()->find($id);
         if ($record) {
-            if (!$record->getUserId()) {
+            $isPrivate = $record->getUserId() || $record->getIsAnon() && $this->isCurrentUserAnonymous();
+            if (!$isPrivate) {
                 if (!$this->isAdmin()) {
                     if (($record->getUserId() !== $this->getUserId() || !$this->checkGrant($element, 'delete'))) {
                         throw new AccessDeniedHttpException();

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -169,7 +169,13 @@ class ViewManagerHttpHandler
 
     protected function updateRecord(MapviewDiff $record, Request $request)
     {
-        $record->setUserId($request->request->get('savePublic') ? null : $this->getUserId());
+        if ($request->request->get('savePublic')) {
+            $record->setUserId(null);
+            $record->setIsPublic(true);
+        } else {
+            $record->setUserId($this->getUserId());
+            $record->setIsPublic(false);
+        }
         $record->setIsAnon($this->isCurrentUserAnonymous());
         // NOTE: Empty arrays do not survive jQuery Ajax post, will be stripped completely from incoming data
         $record->setViewParams($request->request->get('viewParams'));

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -228,11 +228,11 @@ class ViewManagerHttpHandler
         $isAnon = !$isAdmin && $this->isCurrentUserAnonymous();
         $saveDefault = $isAnon ? $config['allowAnonymousSave'] : true;
         return array(
-            'savePublic' => $isAdmin || ($saveDefault && \in_array($config['publicEntries'], array(
+            'savePublic' => $config['publicEntries'] && ($isAdmin || ($saveDefault && \in_array($config['publicEntries'], array(
                 ViewManager::ACCESS_READWRITE,
                 ViewManager::ACCESS_READWRITEDELETE,
-            ))),
-            'savePrivate' => $isAdmin || (!$isAnon && $config['privateEntries']),
+            )))),
+            'savePrivate' => !$isAnon && $config['privateEntries'],
             'deletePublic' => $isAdmin || ($config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE),
         );
     }

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -67,7 +67,8 @@ class ViewManagerHttpHandler
         $config = $element->getConfiguration();
         $vars = array(
             'records' => $this->loadListing($element->getApplication(), $config),
-            'dateFormat' => $this->getDateFormat($request),
+            'showDate' => $config['showDate'],
+            'dateFormat' => $config['showDate'] ? $this->getDateFormat($request) : false,
             'grants' => $this->getGrantsVariables($config),
         );
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing.html.twig', $vars);
@@ -129,9 +130,10 @@ class ViewManagerHttpHandler
         $this->em->persist($record);
         $this->em->flush();
 
+        $config = $element->getConfiguration();
         $vars = array(
             'record' => $record,
-            'dateFormat' => $this->getDateFormat($request),
+            'dateFormat' => $config['showDate'] ? $this->getDateFormat($request) : false,
             'grants' => $this->getGrantsVariables($element->getConfiguration()),
         );
         $content = $this->templating->render('MapbenderCoreBundle:Element:view_manager-listing-row.html.twig', $vars);

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use FOM\UserBundle\Entity\User;
 use Mapbender\CoreBundle\Entity;
-use Mapbender\CoreBundle\Entity\MapViewDiff;
+use Mapbender\CoreBundle\Entity\ViewManagerState;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -126,7 +126,7 @@ class ViewManagerHttpHandler
                 $record->setTitle($newTitle);
             }
         } else {
-            $record = new MapViewDiff();
+            $record = new ViewManagerState();
             $record->setApplicationSlug($element->getApplication()->getSlug());
             $record->setTitle($request->request->get('title'));
         }
@@ -149,7 +149,7 @@ class ViewManagerHttpHandler
         if (!$id) {
             throw new BadRequestHttpException("Missing id");
         }
-        /** @var MapViewDiff|null $record */
+        /** @var ViewManagerState|null $record */
         $record = $records = $this->getRepository()->find($id);
         if ($record) {
             $isPrivate = $record->getUserId() || $record->getIsAnon() && $this->isCurrentUserAnonymous();
@@ -167,7 +167,7 @@ class ViewManagerHttpHandler
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    protected function updateRecord(MapviewDiff $record, Request $request)
+    protected function updateRecord(ViewManagerState $record, Request $request)
     {
         if ($request->request->get('savePublic')) {
             $record->setUserId(null);
@@ -199,7 +199,7 @@ class ViewManagerHttpHandler
     protected function getRepository()
     {
         /** @var EntityRepository */
-        $repository = $this->em->getRepository('Mapbender\CoreBundle\Entity\MapViewDiff');
+        $repository = $this->em->getRepository('Mapbender\CoreBundle\Entity\ViewManagerState');
         return $repository;
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -232,7 +232,7 @@ class ViewManagerHttpHandler
                 ViewManager::ACCESS_READWRITEDELETE,
             ))),
             'savePrivate' => $isAdmin || ($saveDefault && $config['privateEntries']),
-            'deletePublic' => $isAdmin || $config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE,
+            'deletePublic' => $isAdmin || ($config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE),
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -223,11 +223,14 @@ class ViewManagerHttpHandler
     public function getGrantsVariables($config)
     {
         $isAdmin = $this->isAdmin();
-        $saveDefault = $isAdmin || $this->isCurrentUserAnonymous() ? $config['allowAnonymousSave'] : true;
+        $saveDefault = $this->isCurrentUserAnonymous() ? $config['allowAnonymousSave'] : true;
         return array(
-            'savePublic' => $isAdmin || ($saveDefault && $config['publicEntries'] === ViewManager::ACCESS_READWRITE),
+            'savePublic' => $isAdmin || ($saveDefault && \in_array($config['publicEntries'], array(
+                ViewManager::ACCESS_READWRITE,
+                ViewManager::ACCESS_READWRITEDELETE,
+            ))),
             'savePrivate' => $isAdmin || ($saveDefault && $config['privateEntries']),
-            'allowDelete' => $isAdmin || $config['allowNonAdminDelete'],
+            'allowPublicDelete' => $isAdmin || $config['publicEntries'] === ViewManager::ACCESS_READWRITEDELETE,
         );
     }
 
@@ -238,7 +241,7 @@ class ViewManagerHttpHandler
             default:
                 false;
             case 'delete':
-                return $grantsVariables['allowDelete'];
+                return $grantsVariables['allowPublicDelete'];
             case 'savePublic':
                 return $grantsVariables['savePublic'];
             case 'savePrivate':

--- a/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
+++ b/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
@@ -43,6 +43,12 @@ class MapViewDiff
     protected $isAnon = 0;
 
     /**
+     * @var bool
+     * @ORM\Column(type="integer", name="is_public", nullable=false, options={"default"="0"})
+     */
+    protected $isPublic = 0;
+
+    /**
      * Date and time of last modification
      *
      * @var \DateTime|null
@@ -138,6 +144,22 @@ class MapViewDiff
     public function getIsAnon()
     {
         return !!$this->isAnon;
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function setIsPublic($value)
+    {
+        $this->isPublic = $value ? 1 : 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsPublic()
+    {
+        return !!$this->isPublic;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
+++ b/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
@@ -37,6 +37,12 @@ class MapViewDiff
     protected $userId;
 
     /**
+     * @var bool
+     * @ORM\Column(type="integer", name="is_anon", nullable=false, options={"default"="0"})
+     */
+    protected $isAnon = 0;
+
+    /**
      * Date and time of last modification
      *
      * @var \DateTime|null
@@ -116,6 +122,22 @@ class MapViewDiff
     public function getUserId()
     {
         return $this->userId;
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function setIsAnon($value)
+    {
+        $this->isAnon = $value ? 1 : 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsAnon()
+    {
+        return !!$this->isAnon;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
+++ b/src/Mapbender/CoreBundle/Entity/MapViewDiff.php
@@ -1,0 +1,212 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Entity;
+
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="mb_core_map_view_diff", indexes={@ORM\Index(columns={"slug", "user_id"})})
+ */
+class MapViewDiff
+{
+    /**
+     * @var integer
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    protected $id;
+
+    /**
+     * @see Application::$slug
+     * @var string
+     * @ORM\Column(type="string", length=255, name="slug")
+     * NOTE: cannot use id (Yaml applications have no ids)
+     * NOTE: cannot use relation (Yaml applications not visible to Doctrine)
+     */
+    protected $applicationSlug;
+
+    /**
+     * @var string|null
+     * @ORM\Column(type="string", length=255, name="user_id", nullable=true)
+     * NOTE: cannot use a relation; cannot guarantee database record for any user with LDAP / other custom user providers
+     */
+    protected $userId;
+
+    /**
+     * Date and time of last modification
+     *
+     * @var \DateTime|null
+     * @ORM\Column(type="datetime")
+     */
+    protected $mtime;
+
+    /**
+     * @var string
+     * @ORM\Column(type="string", length=63)
+     */
+    protected $title;
+
+    /**
+     * Scalar encoded view parameters (center + scale + srs + rotation)
+     * Same as url fragment in frontend
+     *
+     * @var string
+     * @ORM\Column(type="string", length=47, name="view_params")
+     */
+    protected $viewParams;
+
+    /**
+     * @var mixed[]
+     * @ORM\Column(type="array", name="layerset_diffs")
+     */
+    protected $layersetDiffs;
+
+    /**
+     * @var mixed[]
+     * @ORM\Column(type="array", name="source_diffs")
+     */
+    protected $sourceDiffs;
+
+    public function __construct()
+    {
+        $this->layersetDiffs = array();
+        $this->sourceDiffs = array();
+        $this->mtime = new \DateTime();
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicationSlug()
+    {
+        return $this->applicationSlug;
+    }
+
+    /**
+     * @param string $applicationSlug
+     */
+    public function setApplicationSlug($applicationSlug)
+    {
+        $this->applicationSlug = $applicationSlug;
+    }
+
+    /**
+     * @param string|null $userId
+     */
+    public function setUserId($userId)
+    {
+        $this->userId = $userId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getMtime()
+    {
+        return $this->mtime;
+    }
+
+    /**
+     * @param \DateTime $mtime
+     */
+    public function setMtime(\DateTime $mtime)
+    {
+        $this->mtime = $mtime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getViewParams()
+    {
+        return $this->viewParams;
+    }
+
+    /**
+     * @param string $viewParams
+     */
+    public function setViewParams(string $viewParams)
+    {
+        $this->viewParams = $viewParams;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getSourceDiffs()
+    {
+        return $this->sourceDiffs;
+    }
+
+    /**
+     * @param mixed[] $sourceDiffs
+     */
+    public function setSourceDiffs(array $sourceDiffs)
+    {
+        $this->sourceDiffs = $sourceDiffs;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getLayersetDiffs()
+    {
+        return $this->layersetDiffs;
+    }
+
+    /**
+     * @param mixed[] $layersetDiffs
+     */
+    public function setLayersetDiffs(array $layersetDiffs)
+    {
+        $this->layersetDiffs = $layersetDiffs;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function encode()
+    {
+        return array(
+            'viewParams' => $this->getViewParams(),
+            'layersets' => $this->getLayersetDiffs(),
+            'sources' => $this->getSourceDiffs(),
+        );
+    }
+}

--- a/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
+++ b/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
@@ -38,12 +38,6 @@ class ViewManagerState
 
     /**
      * @var bool
-     * @ORM\Column(type="integer", name="is_anon", nullable=false, options={"default"="0"})
-     */
-    protected $isAnon = 0;
-
-    /**
-     * @var bool
      * @ORM\Column(type="integer", name="is_public", nullable=false, options={"default"="0"})
      */
     protected $isPublic = 0;
@@ -128,22 +122,6 @@ class ViewManagerState
     public function getUserId()
     {
         return $this->userId;
-    }
-
-    /**
-     * @param bool $value
-     */
-    public function setIsAnon($value)
-    {
-        $this->isAnon = $value ? 1 : 0;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getIsAnon()
-    {
-        return !!$this->isAnon;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
+++ b/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
@@ -37,12 +37,6 @@ class ViewManagerState
     protected $userId;
 
     /**
-     * @var bool
-     * @ORM\Column(type="integer", name="is_public", nullable=false, options={"default"="0"})
-     */
-    protected $isPublic = 0;
-
-    /**
      * Date and time of last modification
      *
      * @var \DateTime|null
@@ -122,22 +116,6 @@ class ViewManagerState
     public function getUserId()
     {
         return $this->userId;
-    }
-
-    /**
-     * @param bool $value
-     */
-    public function setIsPublic($value)
-    {
-        $this->isPublic = $value ? 1 : 0;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getIsPublic()
-    {
-        return !!$this->isPublic;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
+++ b/src/Mapbender/CoreBundle/Entity/ViewManagerState.php
@@ -8,9 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="mb_core_map_view_diff", indexes={@ORM\Index(columns={"slug", "user_id"})})
+ * @ORM\Table(name="mb_core_viewmanager_state", indexes={@ORM\Index(columns={"slug", "user_id"})})
  */
-class MapViewDiff
+class ViewManagerState
 {
     /**
      * @var integer

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -70,6 +70,7 @@ class MapbenderCoreBundle extends MapbenderBundle
             'Mapbender\CoreBundle\Element\Layertree',
             'Mapbender\CoreBundle\Element\Legend',
             'Mapbender\CoreBundle\Element\LinkButton',
+            'Mapbender\CoreBundle\Element\ViewManager',
             'Mapbender\CoreBundle\Element\Map',
             'Mapbender\CoreBundle\Element\Overview',
             'Mapbender\CoreBundle\Element\POI',

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -278,9 +278,5 @@
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="mapbender.application.yaml_entity_repository" />
         </service>
-        <service id="mb.element.view_manager.http_handler" class="%mb.element.view_manager.http_handler.class%">
-            <argument type="service" id="templating" />
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
-        </service>
     </services>
 </container>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -268,6 +268,11 @@
         </service>
 
         <!-- Element related -->
+        <service id="mb.element.view_manager.http_handler" class="%mb.element.view_manager.http_handler.class%">
+            <argument type="service" id="templating" />
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="security.token_storage" />
+        </service>
         <service id="mb.element.application_switcher.http_handler" class="%mb.element.application_switcher.http_handler.class%">
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -55,6 +55,7 @@
         <parameter key="assetic.filter.sass.timeout">null</parameter>
         <!-- Element related -->
         <parameter key="mb.element.application_switcher.http_handler.class">Mapbender\CoreBundle\Element\ApplicationSwitcherHttpHandler</parameter>
+        <parameter key="mb.element.view_manager.http_handler.class">Mapbender\CoreBundle\Element\ViewManagerHttpHandler</parameter>
     </parameters>
 
     <services>
@@ -271,6 +272,10 @@
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="mapbender.application.yaml_entity_repository" />
+        </service>
+        <service id="mb.element.view_manager.http_handler" class="%mb.element.view_manager.http_handler.class%">
+            <argument type="service" id="templating" />
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
         </service>
     </services>
 </container>

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -129,9 +129,7 @@
             return diff;
         },
         _apply: function(diff) {
-            console.log("Trying to apply diff", diff);
             var settings = this.mbMap.getModel().mergeSettings(this.referenceSettings, diff);
-            console.log("Produced complete settings", settings);
 
             this.mbMap.getModel().applyViewParams(diff.viewParams);
             this.mbMap.getModel().applySettings(settings);

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -1,9 +1,15 @@
 ;!(function($) {
     "use strict";
     $.widget("mapbender.mbViewManager", {
+        options: {
+            publicEntries: null,
+            privateEntries: null,
+            allowAnonymousSave: false
+        },
         mbMap: null,
         elementUrl: null,
         referenceSettings: null,
+        defaultSavePublic: false,
 
         _create: function() {
             var self = this;
@@ -12,6 +18,7 @@
             Mapbender.elementRegistry.waitReady('.mb-element-map').then(function(mbMap) {
                 self._setup(mbMap);
             });
+            this.defaultSavePublic = (this.options.publicEntries === 'rw');
             this._load();   // Does not need map element to finish => can start asynchronously
         },
         _setup: function(mbMap) {
@@ -61,11 +68,19 @@
                 // @todo: error feedback
                 throw new Error("Cannot save with empty title");
             }
+            var $savePublicCb = $('input[name="save-as-public"]', this.element);
+            var savePublic;
+            if (!$savePublicCb.length) {
+                savePublic = this.defaultSavePublic;
+            } else {
+                savePublic = $savePublicCb.prop('checked');
+            }
 
             var currentSettings = this.mbMap.getModel().getCurrentSettings();
             var diff = this.mbMap.getModel().diffSettings(this.referenceSettings, currentSettings);
             var data = {
                 title: title,
+                savePublic: savePublic,
                 viewParams: this.mbMap.getModel().encodeViewParams(diff.viewParams || this.mbMap.getModel().getCurrentViewParams()),
                 layersetsDiff: diff.layersets,
                 sourcesDiff: diff.sources

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -71,10 +71,15 @@
             ;
         },
         _saveNew: function() {
-            var title = $('input[name="title"]', this.element).val();
+            var $titleInput = $('input[name="title"]', this.element);
+            var title = $titleInput.val();
             if (!title) {
-                // @todo: error feedback
-                throw new Error("Cannot save with empty title");
+                var $titleGroup = $titleInput.closest('.form-group');
+                $titleGroup.addClass('has-error');
+                $titleInput.one('keydown', function() {
+                    $titleGroup.removeClass('has-error');
+                });
+                return $.Deferred().reject().promise();
             }
             var $savePublicCb = $('input[name="save-as-public"]', this.element);
             var savePublic;
@@ -101,7 +106,7 @@
                 data: data
             }).then(function(response) {
                 $('table tbody', self.element).prepend(response);
-            })
+            });
         },
         _delete: function(id) {
             var params = {id: id};

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -32,6 +32,12 @@
             this.element.on('click', '.-fn-apply', function() {
                 self._apply(self._decodeDiff(this));
             });
+            this.element.on('click', '.-fn-delete[data-id]', function() {
+                var $row = $(this).closest('tr');
+                self._delete($(this).attr('data-id')).then(function() {
+                    $row.remove();
+                });
+            });
         },
         _load: function() {
             var $loadingPlaceholder = $('.-fn-loading-placeholder')
@@ -67,6 +73,12 @@
             }).then(function(response) {
                 $('table tbody', self.element).prepend(response);
             })
+        },
+        _delete: function(id) {
+            var params = {id: id};
+            return $.ajax([[this.elementUrl, 'delete'].join('/'), $.param(params)].join('?'), {
+                method: 'DELETE'
+            });
         },
         /**
          * @param {Element} node

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -80,6 +80,7 @@
             var title = $('input[name="title"]', this.element).val() || $row.attr('data-title');
             var data = Object.assign(this._getCommonSaveData(), {
                 title: title,
+                // @see https://stackoverflow.com/questions/14716730/send-a-boolean-value-in-jquery-ajax-data/14716803
                 savePublic: $row.attr('data-visibility-group') === 'public' && '1' || ''
             });
             var params = {id: id};
@@ -104,9 +105,6 @@
                 });
                 return $.Deferred().reject().promise();
             }
-            return this._saveCommon(title);
-        },
-        _saveCommon: function(title) {
             var data = Object.assign(this._getCommonSaveData(), {
                 title: title
             });

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -50,7 +50,7 @@
             });
         },
         _load: function() {
-            var $loadingPlaceholder = $('.-fn-loading-placeholder')
+            var $loadingPlaceholder = $('.-fn-loading-placeholder', this.element)
             var self = this;
             $.ajax([this.elementUrl, 'listing'].join('/'))
                 .then(function(response) {

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -1,0 +1,103 @@
+;!(function($) {
+    "use strict";
+    $.widget("mapbender.mbViewManager", {
+        mbMap: null,
+        elementUrl: null,
+        referenceSettings: null,
+
+        _create: function() {
+            var self = this;
+            this._toggleEnabled(false);
+            this.elementUrl = [Mapbender.configuration.application.urls.element, this.element.attr('id')].join('/');
+            Mapbender.elementRegistry.waitReady('.mb-element-map').then(function(mbMap) {
+                self._setup(mbMap);
+            });
+            this._load();   // Does not need map element to finish => can start asynchronously
+        },
+        _setup: function(mbMap) {
+            this.mbMap = mbMap;
+            this.referenceSettings = mbMap.getModel().getConfiguredSettings();
+            this._initEvents();
+            this._toggleEnabled(true);
+        },
+        _toggleEnabled: function(enabled) {
+            $('.-fn-save-new', this.element.prop('disabled', !enabled));
+            $('input[name="title"]', this.element).prop('disabled', !enabled);
+        },
+        _initEvents: function() {
+            var self = this;
+            this.element.on('click', '.-fn-save-new', function() {
+                self._saveNew();
+            });
+            this.element.on('click', '.-fn-apply', function() {
+                self._apply(self._decodeDiff(this));
+            });
+        },
+        _load: function() {
+            var $loadingPlaceholder = $('.-fn-loading-placeholder')
+            $.ajax([this.elementUrl, 'listing'].join('/'))
+                .then(function(response) {
+                    var $content = $(response);
+                    $loadingPlaceholder.replaceWith($content);
+                }, function() {
+                    $loadingPlaceholder.hide()
+                })
+            ;
+        },
+        _saveNew: function() {
+            var title = $('input[name="title"]', this.element).val();
+            if (!title) {
+                // @todo: error feedback
+                throw new Error("Cannot save with empty title");
+            }
+
+            var currentSettings = this.mbMap.getModel().getCurrentSettings();
+            var diff = this.mbMap.getModel().diffSettings(this.referenceSettings, currentSettings);
+            var data = {
+                title: title,
+                viewParams: this.mbMap.getModel().encodeViewParams(diff.viewParams || this.mbMap.getModel().getCurrentViewParams()),
+                layersetsDiff: diff.layersets,
+                sourcesDiff: diff.sources
+            };
+
+            var self = this;
+            $.ajax([this.elementUrl, 'save'].join('/'), {
+                method: 'POST',
+                data: data
+            }).then(function(response) {
+                $('table tbody', self.element).prepend(response);
+            })
+        },
+        /**
+         * @param {Element} node
+         * @return {mmMapSettingsDiff}
+         * @private
+         */
+        _decodeDiff: function(node) {
+            var raw = JSON.parse($(node).attr('data-diff'));
+            // unravel viewParams from scalar string => Object
+            var diff = {
+                viewParams: this.mbMap.getModel().decodeViewParams(raw.viewParams),
+                sources: raw.sources || [],
+                layersets: raw.layersets || []
+            };
+            // Fix stringified numbers
+            diff.sources = diff.sources.map(function(entry) {
+                if (typeof (entry.opacity) === 'string') {
+                    entry.opacity = parseFloat(entry.opacity);
+                }
+                return entry;
+            });
+            return diff;
+        },
+        _apply: function(diff) {
+            console.log("Trying to apply diff", diff);
+            var settings = this.mbMap.getModel().mergeSettings(this.referenceSettings, diff);
+            console.log("Produced complete settings", settings);
+
+            this.mbMap.getModel().applyViewParams(diff.viewParams);
+            this.mbMap.getModel().applySettings(settings);
+        },
+        __dummy__: null
+    });
+})(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -129,6 +129,7 @@
             });
 
             var self = this;
+            var $tbody = $('table tbody', this.element);
             return $.ajax([this.elementUrl, 'save'].join('/'), {
                 method: 'POST',
                 data: data
@@ -137,7 +138,12 @@
                 $('a.-fn-apply', $(newRow)).each(function() {
                     self._updateLinkUrl(this);
                 });
-                $('table tbody', self.element).prepend(newRow);
+                var insertAfter = !data.savePublic && $('tr[data-visibility-group="public"]', $tbody).get(-1);
+                if (insertAfter) {
+                    $(insertAfter).before(newRow);
+                } else {
+                    $tbody.prepend(newRow);
+                }
                 self._flash($(newRow), '#88ff88');
             });
         },

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -190,6 +190,16 @@
                 $popover.remove();
                 deferred.reject();
             });
+            $popover.data('deferred', deferred);
+            // Close / reject other pending popovers
+            $('table .popover', this.element).each(function() {
+                var $other = $(this);
+                var otherPromise = $other.data('deferred');
+                if (otherPromise) {
+                    otherPromise.reject();
+                }
+                $other.remove();
+            });
             $('.-js-confirmation-anchor-delete', $row).append($popover);
 
             return deferred.promise();

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -27,7 +27,9 @@
         _initEvents: function() {
             var self = this;
             this.element.on('click', '.-fn-save-new', function() {
-                self._saveNew();
+                self._saveNew().then(function() {
+                    self._updatePlaceholder();
+                });
             });
             this.element.on('click', '.-fn-apply', function() {
                 self._apply(self._decodeDiff(this));
@@ -36,15 +38,18 @@
                 var $row = $(this).closest('tr');
                 self._delete($(this).attr('data-id')).then(function() {
                     $row.remove();
+                    self._updatePlaceholder();
                 });
             });
         },
         _load: function() {
             var $loadingPlaceholder = $('.-fn-loading-placeholder')
+            var self = this;
             $.ajax([this.elementUrl, 'listing'].join('/'))
                 .then(function(response) {
                     var $content = $(response);
                     $loadingPlaceholder.replaceWith($content);
+                    self._updatePlaceholder();
                 }, function() {
                     $loadingPlaceholder.hide()
                 })
@@ -67,7 +72,7 @@
             };
 
             var self = this;
-            $.ajax([this.elementUrl, 'save'].join('/'), {
+            return $.ajax([this.elementUrl, 'save'].join('/'), {
                 method: 'POST',
                 data: data
             }).then(function(response) {
@@ -79,6 +84,12 @@
             return $.ajax([[this.elementUrl, 'delete'].join('/'), $.param(params)].join('?'), {
                 method: 'DELETE'
             });
+        },
+        _updatePlaceholder: function() {
+            var $rows = $('table tbody tr', this.element);
+            var $plch = $rows.filter('.placeholder-row');
+            var $dataRows = $rows.not($plch);
+            $plch.toggleClass('hidden', !!$dataRows.length);
         },
         /**
          * @param {Element} node

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -80,7 +80,8 @@
             var diff = this.mbMap.getModel().diffSettings(this.referenceSettings, currentSettings);
             var data = {
                 title: title,
-                savePublic: savePublic,
+                // @see https://stackoverflow.com/questions/14716730/send-a-boolean-value-in-jquery-ajax-data/14716803
+                savePublic: savePublic && '1' || '',
                 viewParams: this.mbMap.getModel().encodeViewParams(diff.viewParams || this.mbMap.getModel().getCurrentViewParams()),
                 layersetsDiff: diff.layersets,
                 sourcesDiff: diff.sources

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -140,7 +140,7 @@
                 });
                 var insertAfter = !data.savePublic && $('tr[data-visibility-group="public"]', $tbody).get(-1);
                 if (insertAfter) {
-                    $(insertAfter).before(newRow);
+                    $(insertAfter).after(newRow);
                 } else {
                     $tbody.prepend(newRow);
                 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -83,11 +83,14 @@
                 savePublic: $row.attr('data-visibility-group') === 'public' && '1' || ''
             });
             var params = {id: id};
+            var self = this;
             return $.ajax([[this.elementUrl, 'save'].join('/'), $.param(params)].join('?'), {
                 method: 'POST',
                 data: data
             }).then(function(response) {
-                $row.replaceWith(response);
+                var newRow = $.parseHTML(response);
+                $row.replaceWith(newRow);
+                self._flash($(newRow), '#88ff88');
             });
         },
         _saveNew: function() {
@@ -113,7 +116,9 @@
                 method: 'POST',
                 data: data
             }).then(function(response) {
-                $('table tbody', self.element).prepend(response);
+                var newRow = $.parseHTML(response);
+                $('table tbody', self.element).prepend(newRow);
+                self._flash($(newRow), '#88ff88');
             });
         },
         _delete: function(id) {
@@ -196,6 +201,20 @@
 
             this.mbMap.getModel().applyViewParams(diff.viewParams);
             this.mbMap.getModel().applySettings(settings);
+        },
+        _flash: function($el, color) {
+            $el.css({
+                'background-color': color
+            });
+            window.setTimeout(function() {
+                $el.css({
+                    'transition': 'background-color 1s',
+                    'background-color': ''
+                });
+                window.setTimeout(function() {
+                    $el.css('transition', '');
+                }, 1000);
+            });
         },
         __dummy__: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -24,7 +24,7 @@
                 self._setup(mbMap);
                 return mbMap;
             });
-            this.defaultSavePublic = (this.options.publicEntries === 'rw');
+            this.defaultSavePublic = (this.options.publicEntries === 'rw') || (this.options.publicEntries === 'rwd');
             this.deleteConfirmationContent = $('.-js-delete-confirmation-content', this.element)
                 .remove().removeClass('hidden').html()
             ;

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
@@ -1,0 +1,26 @@
+.mb-element-viewmanager {
+  p {
+    // Restore standard paragraph margins (10px = Bootstrap default)
+    // @todo: remove global Mapbender margin: 0 on p
+    margin-bottom: 10px;
+  }
+  .static-popover-wrap {
+    position: relative; // for anchoring of absolute-positioned .popover
+    .popover {
+      display: initial;
+      width: 12em;
+      padding: 0.5em;
+      left: initial;
+      right: -2.5ch;
+
+      .arrow {
+        right: 2ch;
+        left: initial;
+      }
+
+      &.bottom {
+        top: 2ex;
+      }
+    }
+  }
+}

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
@@ -8,8 +8,7 @@
     position: relative; // for anchoring of absolute-positioned .popover
     .popover {
       display: initial;
-      width: 12em;
-      padding: 0.5em;
+      padding: 1em;
       left: initial;
       right: -2.5ch;
 

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.scss
@@ -1,9 +1,4 @@
 .mb-element-viewmanager {
-  p {
-    // Restore standard paragraph margins (10px = Bootstrap default)
-    // @todo: remove global Mapbender margin: 0 on p
-    margin-bottom: 10px;
-  }
   .static-popover-wrap {
     position: relative; // for anchoring of absolute-positioned .popover
     .popover {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -1163,7 +1163,33 @@ window.Mapbender.MapModelBase = (function() {
             return diff;
         },
         /**
+         * @param {mmMapSettings} base
+         * @param {mmMapSettingsDiff} diff
+         * @return {mmMapSettings}
+         */
+        mergeSettings: function(base, diff) {
+            var settings = Object.assign({}, base, {
+                viewParams: diff.viewParams,
+                sources: base.sources.map(/** @param {SourceSettings} baseSettings */ function(baseSettings) {
+                    var diffMatches = diff.sources.filter(function(diffEntry) {
+                        return ('' + diffEntry.id) === ('' + baseSettings.id);
+                    });
+                    if (diffMatches.length) {
+                        return Mapbender.Source.prototype.mergeSettings.call(null, baseSettings, diffMatches[0]);
+                    } else {
+                        return baseSettings;
+                    }
+                }),
+                // @todo: merge layersets settings
+                layersets: base.layersets.slice()
+            });
+
+            return settings;
+        },
+        /**
          * @param {mmMapSettings} settings
+         * @return {Array<Mapbender.Source>}
+         * @todo: fold with applySourceSettingsDiff
          */
         applySourceSettings: function(settings) {
             // @todo: defensive checks if source was actually changed to reduce reloads...?

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -218,6 +218,22 @@ window.Mapbender.Source = (function() {
             // null if completely empty
             return Object.keys(diff).length && diff || null;
         },
+        /**
+         * @param {SourceSettings} base
+         * @param {SourceSettingsDiff} diff
+         * @return {SourceSettings}
+         */
+        mergeSettings: function(base, diff) {
+            var settings = Object.assign({}, base);
+            if (typeof (diff.opacity) !== 'undefined') {
+                settings.opacity = diff.opacity;
+            }
+            settings.selectedIds = settings.selectedIds.filter(function(id) {
+                return -1 === ((diff || {}).deactivate || []).indexOf(id);
+            });
+            settings.selectedIds = settings.selectedIds.concat((diff || {}).activate || []);
+            return settings;
+        },
         checkRecreateOnSrsSwitch: function(oldProj, newProj) {
             return this.recreateOnSrsSwitch;
         },

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -300,10 +300,10 @@ mb:
         access.none: Nicht anzeigen
         access.ro: Nur lesen
         access.rw: Speichern erlauben
+        access.rwd: Speichern und löschen erlauben
         publicEntries: Öffentliche Liste
         privateEntries: Private Liste anzeigen
         adminDeleteHint: "Hinweis: Administratoren dürfen immer löschen"
-        allowNonAdminDelete: Löschen öffentlicher Einträge erlauben
         allowAnonymousSave: Anonyme Besucher dürfen speichern
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -297,7 +297,7 @@ mb:
         access.ro: Nur lesen
         access.rw: Speichern erlauben
         publicEntries: Öffentliche Liste
-        privateEntries: Private Liste
+        privateEntries: Private Liste anzeigen
         adminDeleteHint: "Hinweis: Administratoren dürfen immer löschen"
         allowNonAdminDelete: Löschen öffentlicher Einträge erlauben
         allowAnonymousSave: Anonyme Besucher dürfen speichern

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -292,6 +292,10 @@ mb:
         description: Speichert Kartenzustände zum späteren Abruf
       saveAsPublic: Als öffentlichen Eintrag speichern
       confirmDelete: Eintrag wirklich löschen?
+      no_data: Keine Daten
+      title: Titel
+      date: Datum
+      enter_title: Titel eingeben
       admin:
         access.none: Nicht anzeigen
         access.ro: Nur lesen

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -296,6 +296,8 @@ mb:
       title: Titel
       date: Datum
       enter_title: Titel eingeben
+      apply: Abrufen
+      replace: Überschreiben
       admin:
         access.none: Nicht anzeigen
         access.ro: Nur lesen

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -307,6 +307,7 @@ mb:
         privateEntries: Private Liste anzeigen
         adminDeleteHint: "Hinweis: Administratoren dürfen öffentliche Einträge immer löschen"
         allowAnonymousSave: Anonyme Besucher dürfen speichern
+        showDate: Datum anzeigen
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -298,6 +298,8 @@ mb:
         access.rw: Speichern erlauben
         publicEntries: Öffentliche Liste
         privateEntries: Private Liste
+        adminDeleteHint: "Hinweis: Administratoren dürfen immer löschen"
+        allowNonAdminDelete: Löschen öffentlicher Einträge erlauben
         allowAnonymousSave: Anonyme Besucher dürfen speichern
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -286,6 +286,19 @@ mb:
         title: URL teilen
         description: Teilt die aktuelle Kartenansicht über eine URL
       copied_to_clipboard: URL in Zwischenablage kopiert
+    viewManager:
+      class:
+        title: Ansichtsverwaltung
+        description: Speichert Kartenzustände zum späteren Abruf
+      saveAsPublic: Als öffentlichen Eintrag speichern
+      confirmDelete: Eintrag wirklich löschen?
+      admin:
+        access.none: Nicht anzeigen
+        access.ro: Nur lesen
+        access.rw: Speichern erlauben
+        publicEntries: Öffentliche Liste
+        privateEntries: Private Liste
+        allowAnonymousSave: Anonyme Besucher dürfen speichern
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -303,7 +303,7 @@ mb:
         access.rwd: Speichern und löschen erlauben
         publicEntries: Öffentliche Liste
         privateEntries: Private Liste anzeigen
-        adminDeleteHint: "Hinweis: Administratoren dürfen immer löschen"
+        adminDeleteHint: "Hinweis: Administratoren dürfen öffentliche Einträge immer löschen"
         allowAnonymousSave: Anonyme Besucher dürfen speichern
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -295,6 +295,8 @@ mb:
       title: Title
       date: Date
       enter_title: Enter title
+      apply: Apply
+      replace: Replace
       admin:
         access.none: Do not show
         access.ro: Read only

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -302,7 +302,7 @@ mb:
         access.rwd: Allow saving and deletion
         publicEntries: Public list
         privateEntries: Show private list
-        adminDeleteHint: "Note: the administrator can always delete entries"
+        adminDeleteHint: "Note: the administrator can always delete public entries"
         allowAnonymousSave: Allow saving to anonymous users
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -299,10 +299,10 @@ mb:
         access.none: Do not show
         access.ro: Read only
         access.rw: Allow saving
+        access.rwd: Allow saving and deletion
         publicEntries: Public list
         privateEntries: Show private list
         adminDeleteHint: "Note: the administrator can always delete entries"
-        allowNonAdminDelete: Allow deletion of public entries
         allowAnonymousSave: Allow saving to anonymous users
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -306,6 +306,7 @@ mb:
         privateEntries: Show private list
         adminDeleteHint: "Note: the administrator can always delete public entries"
         allowAnonymousSave: Allow saving to anonymous users
+        showDate: Show date
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -296,7 +296,7 @@ mb:
         access.ro: Read only
         access.rw: Allow saving
         publicEntries: Public list
-        privateEntries: Private list
+        privateEntries: Show private list
         adminDeleteHint: "Note: the administrator can always delete entries"
         allowNonAdminDelete: Allow deletion of public entries
         allowAnonymousSave: Allow saving to anonymous users

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -285,6 +285,19 @@ mb:
         title: Share URL
         description: Share current map view via url
       copied_to_clipboard: URL copied to clipboard
+    viewManager:
+      class:
+        title: View manager
+        description: Saves map states for later restoration
+      saveAsPublic: Save as public
+      confirmDelete: Confirm deletion
+      admin:
+        access.none: Do not show
+        access.ro: Read only
+        access.rw: Allow saving
+        publicEntries: Public list
+        privateEntries: Private list
+        allowAnonymousSave: Allow saving to anonymous users
     admin:
       poi:
         label:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -297,6 +297,8 @@ mb:
         access.rw: Allow saving
         publicEntries: Public list
         privateEntries: Private list
+        adminDeleteHint: "Note: the administrator can always delete entries"
+        allowNonAdminDelete: Allow deletion of public entries
         allowAnonymousSave: Allow saving to anonymous users
     admin:
       poi:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -291,6 +291,10 @@ mb:
         description: Saves map states for later restoration
       saveAsPublic: Save as public
       confirmDelete: Confirm deletion
+      no_data: No data
+      title: Title
+      date: Date
+      enter_title: Enter title
       admin:
         access.none: Do not show
         access.ro: Read only

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -2,11 +2,11 @@
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>
-    <td class="text-nowrap">
-        <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
-        {%- if (savePrivate and _is_private) or (savePublic and not _is_private) %}
+    <td class="text-nowrap text-right">
+        {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
         <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
-        {%- endif -%}
+        {%- endif %}
+        <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
     </td>
 </tr>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -3,9 +3,9 @@
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>
     <td class="text-nowrap text-right">
-        {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
+        {%- if (grants.savePrivate and _is_private) or (grants.savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{{ 'mb.core.viewManager.replace' | trans }}" data-id="{{ record.id }}"></i>
-        {%- if _is_private or allowPublicDelete -%}
+        {%- if _is_private or grants.deletePublic -%}
         <span class="static-popover-wrap -js-confirmation-anchor-delete">
             <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{{ 'mb.actions.delete' | trans }}" data-id="{{ record.id }}"></i>
         </span>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -5,9 +5,11 @@
     <td class="text-nowrap text-right">
         {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
+        {%- if _is_private or allowDelete -%}
         <span class="static-popover-wrap -js-confirmation-anchor-delete">
             <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
         </span>
+        {%- endif -%}
         {%- endif %}
         <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
     </td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,9 +1,12 @@
-<tr>
+{%- set _is_private = record.userId is not empty -%}
+<tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>
     <td class="text-nowrap">
         <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
+        {%- if (savePrivate and _is_private) or (savePublic and not _is_private) %}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
         <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
+        {%- endif -%}
     </td>
 </tr>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,4 +1,4 @@
-{%- set _is_private = not record.isPublic -%}
+{%- set _is_private = record.userId is not empty-%}
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}" data-title="{{ record.title }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,7 +1,7 @@
 {%- set _is_private = record.userId is not empty-%}
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}" data-title="{{ record.title }}">
     <td>{{ record.title }}</td>
-    <td>{{ record.mtime | date(dateFormat) }}</td>
+    <td class="text-nowrap">{{ record.mtime | date(dateFormat) }}</td>
     <td class="text-nowrap text-right">
         {%- if (grants.savePrivate and _is_private) or (grants.savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{{ 'mb.core.viewManager.replace' | trans }}" data-id="{{ record.id }}"></i>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -11,6 +11,8 @@
         </span>
         {%- endif -%}
         {%- endif %}
-        <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
+        <a href="#" class="-fn-apply hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}">
+            <i class="fa fas fa-folder-open"></i>
+        </a>
     </td>
 </tr>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -5,7 +5,9 @@
     <td class="text-nowrap text-right">
         {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
-        <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
+        <span class="static-popover-wrap -js-confirmation-anchor-delete">
+            <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
+        </span>
         {%- endif %}
         <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
     </td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -5,12 +5,12 @@
     <td class="text-nowrap text-right">
         {%- if (grants.savePrivate and _is_private) or (grants.savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{{ 'mb.core.viewManager.replace' | trans }}" data-id="{{ record.id }}"></i>
+        {%- endif -%}
         {%- if _is_private or grants.deletePublic -%}
         <span class="static-popover-wrap -js-confirmation-anchor-delete">
             <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{{ 'mb.actions.delete' | trans }}" data-id="{{ record.id }}"></i>
         </span>
         {%- endif -%}
-        {%- endif %}
         <a href="#" class="-fn-apply hover-highlight-effect" title="{{ 'mb.core.viewManager.apply' | trans }}" data-diff="{{ record.encode() | json_encode }}">
             <i class="fa fas fa-folder-open"></i>
         </a>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,0 +1,9 @@
+<tr>
+    <td>{{ record.title }}</td>
+    <td>{{ record.mtime | date(dateFormat) }}</td>
+    <td class="text-nowrap">
+        <i class="-fn-apply fa fas fa-folder-open clickable hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}"></i>
+        <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
+        <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
+    </td>
+</tr>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,5 +1,5 @@
 {%- set _is_private = record.userId is not empty -%}
-<tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}">
+<tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}" data-title="{{ record.title }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>
     <td class="text-nowrap text-right">

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -4,14 +4,14 @@
     <td>{{ record.mtime | date(dateFormat) }}</td>
     <td class="text-nowrap text-right">
         {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
-        <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
+        <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{{ 'mb.core.viewManager.replace' | trans }}" data-id="{{ record.id }}"></i>
         {%- if _is_private or allowPublicDelete -%}
         <span class="static-popover-wrap -js-confirmation-anchor-delete">
-            <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
+            <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{{ 'mb.actions.delete' | trans }}" data-id="{{ record.id }}"></i>
         </span>
         {%- endif -%}
         {%- endif %}
-        <a href="#" class="-fn-apply hover-highlight-effect" title="{# @todo: translate #}Abrufen" data-diff="{{ record.encode() | json_encode }}">
+        <a href="#" class="-fn-apply hover-highlight-effect" title="{{ 'mb.core.viewManager.apply' | trans }}" data-diff="{{ record.encode() | json_encode }}">
             <i class="fa fas fa-folder-open"></i>
         </a>
     </td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,4 +1,4 @@
-{%- set _is_private = record.userId is not empty or (record.userId is empty and record.isAnon) -%}
+{%- set _is_private = not record.isPublic -%}
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}" data-title="{{ record.title }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -1,4 +1,4 @@
-{%- set _is_private = record.userId is not empty -%}
+{%- set _is_private = record.userId is not empty or (record.userId is empty and record.isAnon) -%}
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}" data-title="{{ record.title }}">
     <td>{{ record.title }}</td>
     <td>{{ record.mtime | date(dateFormat) }}</td>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -5,7 +5,7 @@
     <td class="text-nowrap text-right">
         {%- if (savePrivate and _is_private) or (savePublic and not _is_private) -%}
         <i class="-fn-update fa fas fa-save clickable hover-highlight-effect" title="{# @todo: translate #}Überschreiben" data-id="{{ record.id }}"></i>
-        {%- if _is_private or allowDelete -%}
+        {%- if _is_private or allowPublicDelete -%}
         <span class="static-popover-wrap -js-confirmation-anchor-delete">
             <i class="-fn-delete fa fas fa-times clickable hover-highlight-effect" title="{# @todo: translate #}Löschen" data-id="{{ record.id }}"></i>
         </span>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
@@ -2,7 +2,9 @@
     <thead>
         <tr>
             <th>{{ 'mb.core.viewManager.title' | trans }}</th>
+            {%- if showDate -%}
             <th>{{ 'mb.core.viewManager.date' | trans }}</th>
+            {%- endif -%}
             <th></th>
         </tr>
     </thead>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
@@ -1,8 +1,8 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th>{# @todo: translate #}Titel</th>
-            <th>{# @todo: translate #}Datum</th>
+            <th>{{ 'mb.core.viewManager.title' | trans }}</th>
+            <th>{{ 'mb.core.viewManager.date' | trans }}</th>
             <th></th>
         </tr>
     </thead>
@@ -11,9 +11,7 @@
             {% include 'MapbenderCoreBundle:Element:view_manager-listing-row.html.twig' with {'record': record} %}
         {%- endfor -%}
         <tr class="placeholder-row">
-            <td colspan="3" class="text-center">
-                {#@todo: translate #}&ndash; keine Daten &ndash;
-            </td>
+            <td colspan="3" class="text-center">&ndash; {{ 'mb.core.viewManager.no_data' | trans }} &ndash;</td>
         </tr>
     </tbody>
 </table>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing.html.twig
@@ -1,0 +1,19 @@
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>{# @todo: translate #}Titel</th>
+            <th>{# @todo: translate #}Datum</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {%- for record in records -%}
+            {% include 'MapbenderCoreBundle:Element:view_manager-listing-row.html.twig' with {'record': record} %}
+        {%- endfor -%}
+        <tr class="placeholder-row">
+            <td colspan="3" class="text-center">
+                {#@todo: translate #}&ndash; keine Daten &ndash;
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -1,0 +1,15 @@
+<div id="{{ id }}" class="mb-element mb-element-viewmanager">
+    <div>
+        <div class="form-group">
+            <div class="input-group">
+                <input type="text" name="title" class="form-control" required="required" placeholder="Titel eingeben..." value="">
+                <span class="input-group-addon btn -fn-save-new" title="{# @todo: translate #}Speichern">
+                    <i class="fa fas fa-save"></i>
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class="ui-helper-clearfix -fn-loading-placeholder">
+        <div class="pull-right"><i class="fa fas fa-spinner fa-spin"></i></div>
+    </div>
+</div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -19,4 +19,11 @@
     <div class="ui-helper-clearfix -fn-loading-placeholder">
         <div class="pull-right"><i class="fa fas fa-spinner fa-spin"></i></div>
     </div>
+    <div class="hidden -js-delete-confirmation-content">
+        <p>{# @todo: translate #}Eintrag löschen?</p>
+        <div>
+            <button type="button" class="btn btn-sm btn-danger -fn-confirm">{{ 'mb.actions.delete' | trans }}</button>
+            <button type="button" class="btn btn-sm btn-info -fn-cancel">{{ 'mb.actions.cancel' | trans }}</button>
+        </div>
+    </div>
 </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -11,7 +11,7 @@
         </div>
         {%- if showListSelector -%}
         <div class="form-group checkbox">
-            <label><input name="save-as-public" type="checkbox">{# @todo: translate #}Öffentlicher Eintrag</label>
+            <label><input name="save-as-public" type="checkbox">{{ 'mb.core.viewManager.saveAsPublic' | trans }}</label>
         </div>
         {%- endif -%}
     </div>
@@ -20,7 +20,7 @@
         <div class="pull-right"><i class="fa fas fa-spinner fa-spin"></i></div>
     </div>
     <div class="hidden -js-delete-confirmation-content">
-        <p>{# @todo: translate #}Eintrag löschen?</p>
+        <p>{{ 'mb.core.viewManager.confirmDelete' | trans }}</p>
         <div class="text-nowrap">
             <button type="button" class="btn btn-sm btn-danger -fn-confirm">{{ 'mb.actions.delete' | trans }}</button>
             <button type="button" class="btn btn-sm btn-info -fn-cancel">{{ 'mb.actions.cancel' | trans }}</button>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -21,7 +21,7 @@
     </div>
     <div class="hidden -js-delete-confirmation-content">
         <p>{# @todo: translate #}Eintrag löschen?</p>
-        <div>
+        <div class="text-nowrap">
             <button type="button" class="btn btn-sm btn-danger -fn-confirm">{{ 'mb.actions.delete' | trans }}</button>
             <button type="button" class="btn btn-sm btn-info -fn-cancel">{{ 'mb.actions.cancel' | trans }}</button>
         </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -3,8 +3,8 @@
     <div>
         <div class="form-group">
             <div class="input-group">
-                <input type="text" name="title" class="form-control" required="required" placeholder="Titel eingeben..." value="">
-                <span class="input-group-addon btn -fn-save-new" title="{# @todo: translate #}Speichern">
+                <input type="text" name="title" class="form-control" required="required" placeholder="{{ 'mb.core.viewManager.enter_title' | trans }}..." value="">
+                <span class="input-group-addon btn -fn-save-new" title="{{ 'mb.actions.save' | trans }}">
                     <i class="fa fas fa-save"></i>
                 </span>
             </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -1,4 +1,5 @@
 <div id="{{ id }}" class="mb-element mb-element-viewmanager">
+    {%- if showSaving -%}
     <div>
         <div class="form-group">
             <div class="input-group">
@@ -8,7 +9,13 @@
                 </span>
             </div>
         </div>
+        {%- if showListSelector -%}
+        <div class="form-group checkbox">
+            <label><input name="save-target" type="checkbox">{# @todo: translate #}Öffentlicher Eintrag</label>
+        </div>
+        {%- endif -%}
     </div>
+    {%- endif -%}
     <div class="ui-helper-clearfix -fn-loading-placeholder">
         <div class="pull-right"><i class="fa fas fa-spinner fa-spin"></i></div>
     </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -1,5 +1,5 @@
 <div id="{{ id }}" class="mb-element mb-element-viewmanager">
-    {%- if showSaving -%}
+    {%- if grants.savePublic or grants.savePrivate -%}
     <div>
         <div class="form-group">
             <div class="input-group">
@@ -9,7 +9,7 @@
                 </span>
             </div>
         </div>
-        {%- if showListSelector -%}
+        {%- if grants.savePublic and grants.savePrivate -%}
         <div class="form-group checkbox">
             <label><input name="save-as-public" type="checkbox">{{ 'mb.core.viewManager.saveAsPublic' | trans }}</label>
         </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager.html.twig
@@ -11,7 +11,7 @@
         </div>
         {%- if showListSelector -%}
         <div class="form-group checkbox">
-            <label><input name="save-target" type="checkbox">{# @todo: translate #}Öffentlicher Eintrag</label>
+            <label><input name="save-as-public" type="checkbox">{# @todo: translate #}Öffentlicher Eintrag</label>
         </div>
         {%- endif -%}
     </div>

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
@@ -1,5 +1,6 @@
 <div class="extraWideLabelForm">
+    {{ form_row(form.title) }}
+    {{ form_row(form.configuration.publicEntries) }}
+    <div class="alert alert-info">{{ 'mb.core.viewManager.admin.adminDeleteHint' | trans }}.</div>
     {{ form_rest(form) }}
-    <div class="alert alert-info">{{ 'mb.core.viewManager.admin.adminDeleteHint' | trans }}</div>
 </div>
-

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
@@ -1,0 +1,5 @@
+<div class="extraWideLabelForm">
+    {{ form_rest(form) }}
+    <div class="alert alert-info">{{ 'mb.core.viewManager.admin.adminDeleteHint' | trans }}</div>
+</div>
+

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/view_manager.html.twig
@@ -1,6 +1,16 @@
 <div class="extraWideLabelForm">
-    {{ form_row(form.title) }}
-    {{ form_row(form.configuration.publicEntries) }}
-    <div class="alert alert-info">{{ 'mb.core.viewManager.admin.adminDeleteHint' | trans }}.</div>
     {{ form_rest(form) }}
+    <div class="alert alert-info">{{ 'mb.core.viewManager.admin.adminDeleteHint' | trans }}.</div>
+    <script type="text/javascript">
+        (function($) {
+            var anonSaveCheckbox = document.getElementById({{ form.configuration.allowAnonymousSave.vars.id | json_encode | raw }});
+            var publicEntriesInput = document.getElementById({{ form.configuration.publicEntries.vars.id | json_encode | raw }});
+            var updateCb = function() {
+                var val = $(this).val();
+                $(anonSaveCheckbox).prop('disabled', !val || val === 'ro');
+            };
+            updateCb.call(publicEntriesInput);
+            $(publicEntriesInput).on('change', updateCb);
+        })(jQuery);
+    </script>
 </div>


### PR DESCRIPTION
Adds a new Element "ViewManager" that enables storing and reapplying map states (center / scale / srs / rotation, layer / source / layerset selection, source opacities).

This should address more, and hopefully most of the remaining use cases of the (removed) WmcEditor / WmcLoader elements that have not yet been covered by the recently added ShareUrl and AppplicationSwitcher elements.

Note that unlike WmcEditor / WmcLoader, saved states are always reapplied on top of the _current_ Application configuration. I.e. if the Application configuration has been modified to add, reorder or remove sources, or modify any layer defaults since a state has been saved, those administrative changes will remain in effect when reloading the state.

## Basic operation
Map states are separated by application, and further separated into public and user-private lists.

Public and private map states can be saved, reapplied and deleted, as allowed by configuration (see below). Each state must be given a title for reidentification. For saving the current map view as a new state, enter a title and click on the adjoined save button.

Saved states are listed in a table. Each table row shows the title, (optionally) the date of creation / last updated, and possible interactions.  

![Screenshot_2021-04-22_12-55-33](https://user-images.githubusercontent.com/24895932/115703290-3ff7d700-a36a-11eb-8b59-2a590217c30b.png)

## Interacting with saved states
The most basic interaction (always available) is re-applying the map state stored in the entry. Note that the interaction button for reapplying a saved state also supports common browser context menu actions (copy link url, open in new window etc).

Entries may offer a "Replace" interaction. This will overwrite the map state stored in the entry, and will also update the title, using the global title input field, unless that is currently empty.

Entries may offer a "Delete" interaction (with an extra confirmation step).

## Element configuration
Name|Type|Default|Notes
-|-|-|-
publicEntries|string or empty|`ro`|Falsy value disables public entries entirely; other allowed values are `ro` (read only), `rw` (allow read and write), `rwd` (allow read and write and deletion)
privateEntries|boolean|true|Turns user-private states on, with full usage (save, reapply, delete)
allowAnonymousSave|boolean|false|Extend right to save public entries also to anonymous users
showDate|boolean|true|Show date of creation or last update in entry listing

NOTE: access checks on public entries are suspended for the root user. The administrator can create, update and delete public entries at will.  
Anonymous users are excluded from working with private entries, and they can never delete public entries. Their ability to create and update public entries is gated through the `allowAnonymousSave` flag. If false, their access to public entries is downgraded to read-only.

If you want to completely exclude anonymous visitors, you should place a `ROLE_USER` access restriction on the entire element.

### Example yaml application definition
```yaml
<...>
   sidepane:
     vm:
       class: Mapbender\CoreBundle\Element\ViewManager
       publicEntries: false
```

## Known limitations
This element currently only works in a sidepane. No other modes of display, such as popup or toolbar dropdown, have been implemented at this point.

The saved states _do_ _not_ include
* any interactively added sources (via WmsLoader)
* any interactively removed layers (via Layertree context menu)
* any values for WMS dimensions
* any dynamically rendered geometries (Digitizer etc)

