### PR TITLE
Enh/component package bypass

### DIFF
--- a/src/Mapbender/Component/AutoMimeResponseFile.php
+++ b/src/Mapbender/Component/AutoMimeResponseFile.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Mapbender\Component;
+
+
+use Symfony\Component\HttpFoundation\File\File;
+
+/**
+ * Extension of Symfony File to provide some basic component asset mimetypes even in absence
+ * of PHP Fileinfo extension.
+ */
+class AutoMimeResponseFile extends File
+{
+    /** @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types */
+    protected static $extensionMimeMap = array(
+        // textual
+        'css' => 'text/css',
+        'js' => 'text/javascript',
+        // Font types
+        'otf' => 'font/otf',
+        'ttf' => 'font/ttf',
+        'woff' => 'font/woff',
+        'woff2' => 'font/woff2',
+        // Image types
+        'bmp' => 'image/bmp',
+        'gif' => 'image/gif',
+        'ico' => 'image/vnd.microsoft.ico',
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'svg' => 'image/svg+xml',
+    );
+
+    public function getMimeType()
+    {
+        if ($mime = $this->guessMimeTypeFromExtension($this->getExtension())) {
+            return $mime;
+        } else {
+            return parent::getMimeType();
+        }
+    }
+
+    public static function guessMimeTypeFromExtension($extension)
+    {
+        $extension = \strtolower($extension);
+        if ($extension && !empty(static::$extensionMimeMap[$extension])) {
+            $baseMime = static::$extensionMimeMap[$extension];
+            if (\preg_match('#^text/#', $baseMime)) {
+                return $baseMime . '; charset=UTF-8';
+            } else {
+                return $baseMime;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -4,6 +4,7 @@
 namespace Mapbender\CoreBundle\Controller;
 
 
+use Mapbender\Component\AutoMimeResponseFile;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,7 +46,7 @@ class ComponentsController extends Controller
             $fullPath = "{$packagePath}/{$filePath}";
 
             if (\is_readable($fullPath) && !\is_dir($fullPath)) {
-                return new \SplFileInfo($fullPath);
+                return new AutoMimeResponseFile($fullPath);
             }
         }
         return null;

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -30,8 +30,9 @@ class ComponentsController extends Controller
         if (!$fileInfo) {
             throw new NotFoundHttpException();
         }
-
-        return new BinaryFileResponse($fileInfo);
+        $response = new BinaryFileResponse($fileInfo);
+        $response->isNotModified($request);
+        return $response;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -12,6 +12,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * Controller to deliver assets from various vendor paths from /components/ urls.
+ * Only answers if file does not actually exist in web/components (see example rewrite configuration in .htaccess).
+ * Having this Controller allows installing and requesting /components/ packages even without having
+ * a "component installer" package, such as robloach/component-installer (abandoned) or
+ * mnsami/composer-custom-directory-installer on the system.
+ */
 class ComponentsController extends Controller
 {
     /**
@@ -53,6 +60,10 @@ class ComponentsController extends Controller
         return null;
     }
 
+    /**
+     * @param string $packageName
+     * @return string|null
+     */
     protected function getPackagePath($packageName)
     {
         switch ($packageName) {
@@ -76,11 +87,18 @@ class ComponentsController extends Controller
         }
     }
 
+    /**
+     * @return string
+     */
     protected function getVendorPath()
     {
         return realpath($this->getParameter('kernel.root_dir') . '/../vendor');
     }
 
+    /**
+     * @param string $path
+     * @return bool
+     */
     protected function matchHidden($path)
     {
         $patterns = array(

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -1,0 +1,91 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Controller;
+
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ComponentsController extends Controller
+{
+    /**
+     * @Route("/components/{packageName}/{path}", methods={"GET"}, requirements={"path"=".+"})
+     * @param Request $request
+     * @param string $packageName
+     * @param string $path
+     * @return Response
+     */
+    public function componentsAction(Request $request, $packageName, $path)
+    {
+        if ($this->matchHidden($path)) {
+            throw new NotFoundHttpException();
+        }
+        $fileInfo = $this->locateFile($packageName, $path);
+        if (!$fileInfo) {
+            throw new NotFoundHttpException();
+        }
+
+        return new BinaryFileResponse($fileInfo);
+    }
+
+    /**
+     * @param string $packageName
+     * @param string $filePath
+     * @return \SplFileInfo|null
+     */
+    protected function locateFile($packageName, $filePath)
+    {
+        $packagePath = $this->getPackagePath($packageName);
+        if ($packagePath) {
+            $fullPath = "{$packagePath}/{$filePath}";
+
+            if (\is_readable($fullPath) && !\is_dir($fullPath)) {
+                return new \SplFileInfo($fullPath);
+            }
+        }
+        return null;
+    }
+
+    protected function getPackagePath($packageName)
+    {
+        switch ($packageName) {
+            default:
+                $path = $this->getVendorPath() . "/components/{$packageName}";
+                break;
+            case 'bootstrap-colorpicker':
+                $path = $this->getVendorPath() . "/debugteam/{$packageName}";
+                break;
+        }
+        if (\is_dir($path) && \is_readable($path)) {
+            return $path;
+        } else {
+            return null;
+        }
+    }
+
+    protected function getVendorPath()
+    {
+        return realpath($this->getParameter('kernel.root_dir') . '/../vendor');
+    }
+
+    protected function matchHidden($path)
+    {
+        $patterns = array(
+            '#(^|/)\.#',
+            '#(^|/)(composer|component|package|bower).json$#',
+            '#(^|/)[^/]+\.(md|txt)$#',
+            '#(^|/)Makefile[^/]*$#',
+        );
+        foreach ($patterns as $pattern) {
+            if (\preg_match($pattern, $path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -61,6 +61,9 @@ class ComponentsController extends Controller
             case 'bootstrap-colorpicker':
                 $path = $this->getVendorPath() . "/debugteam/{$packageName}";
                 break;
+            case 'mapbender-icons':
+                $path = $this->getVendorPath() . "/mapbender/{$packageName}";
+                break;
         }
         if (\is_dir($path) && \is_readable($path)) {
             return $path;

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -64,6 +64,9 @@ class ComponentsController extends Controller
             case 'mapbender-icons':
                 $path = $this->getVendorPath() . "/mapbender/{$packageName}";
                 break;
+            case 'open-sans':
+                $path = $this->getVendorPath() . "/wheregroup/{$packageName}";
+                break;
         }
         if (\is_dir($path) && \is_readable($path)) {
             return $path;


### PR DESCRIPTION
Adds a Controller to serve `/components/` urls, to allow safe removal of e.g. (abandoned) [robloach/component-installer](https://packagist.org/packages/robloach/component-installer). Note that if a file actually exists inside `web/components`, the web server will handle the request internally. PHP will not be invoked, and this Controller will not be invoked.  
Only files not present in web/components will invoke this Controller. Contents will be served from an appropriate location inside `/vendor/`. Browser caching is supported.

Currently targets 5 packages of common interest for delivery:
* debugteam/bootstrap-colorpicker
* wheregroup/open-sans
* mapbender/mapbender-icons
* components/font-awesome
* components/bootstrap

Other packages with a "component" vendor may or may not work. This depends on if / how the file structure inside vendor is altered when a "component installer" copies files into `web/components`.

NOTE: though not strictily necessary, for optimal performance the firewall should be bypassed on the `/components/` url prefix. This requires an extra url exclusion configuration in Mapbender Starter. See [4c362e3](https://github.com/mapbender/mapbender-starter/commit/4c362e35520bb0774a16d31c7727052cd6de2655).
