### PR TITLE
wmts changed $fees to text as with postgresql string will create VARC…

### DIFF
--- a/src/Mapbender/WmtsBundle/Entity/WmtsSource.php
+++ b/src/Mapbender/WmtsBundle/Entity/WmtsSource.php
@@ -36,7 +36,7 @@ class WmtsSource extends Source implements ContainingKeyword, MutableUrlTarget
 
     /**
      * @var string
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     protected $fees = "";
 


### PR DESCRIPTION
…HAR(255) which is to short

* change the type to text (same as for wms source)
* see ticket: https://github.com/mapbender/mapbender/issues/1311
* this change wold help if you have long fees definitions already