### PR TITLE
Login backdrop image customizability

### DIFF
--- a/src/Mapbender/CoreBundle/Extension/BrandingExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/BrandingExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class BrandingExtension extends AbstractExtension
+{
+    /** @var string */
+    protected $loginBackdrop;
+    /** @var string|null */
+    protected $loginBackdropHq;
+
+    /**
+     * @param string|null $loginBackdrop
+     */
+    public function __construct($loginBackdrop)
+    {
+        $this->loginBackdrop = $loginBackdrop ?: 'bundles/mapbendercore/image/login-backdrop.jpg';
+        // $this->loginBackdrop = 'bundles/mapbendercore/kapfe.jpg'; //$loginBackdrop ?: 'bundles/mapbendercore/image/login-backdrop.jpg';
+        $hqBackdrop = preg_replace('#(\.\w+)$#', '-4k${1}', $this->loginBackdrop);
+        // NOTE: assumes cwd == docroot
+        if (@\is_file($hqBackdrop) && @\is_readable($hqBackdrop)) {
+            $this->loginBackdropHq = $hqBackdrop;
+        }
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            'login_backdrop_asset' => new TwigFunction('login_backdrop_asset', array($this, 'login_backdrop_asset')),
+            'login_backdrop_asset_hq' => new TwigFunction('login_backdrop_asset_hq', array($this, 'login_backdrop_asset_hq')),
+        );
+    }
+
+    public function login_backdrop_asset()
+    {
+        return $this->loginBackdrop;
+    }
+
+    public function login_backdrop_asset_hq()
+    {
+        return $this->loginBackdropHq;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yml
@@ -12,6 +12,9 @@ parameters:
     branding.project_version: ~
     branding.logo: ~                # web-relative path
 
+    branding.login_backdrop: ~
+    branding.login_backdrop_hq: ~
+
     # Sitelinks displayed below login box and backend content
     # Should be a list of items each with keys 'link' and 'text'
     mapbender.sitelinks: []

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -77,6 +77,10 @@
             <tag name="twig.extension"/>
             <argument type="service" id="mapbender.element_inventory.service" />
         </service>
+        <service class="Mapbender\CoreBundle\Extension\BrandingExtension">
+            <tag name="twig.extension"/>
+            <argument>%branding.login_backdrop%</argument>
+        </service>
         <service id="mapbender.twig.element_markup" class="Mapbender\CoreBundle\Extension\ElementMarkupExtension">
             <tag name="twig.extension"/>
             <argument type="service" id="mapbender.presenter.application.service" />

--- a/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
@@ -20,7 +20,23 @@
   {% endblock %}
 {% block content %}
   <div class="authWrapper">
-    <div class="container-login-img"></div>
+    {%- set backdrop = asset(login_backdrop_asset()) -%}
+    {%- set hq_backdrop = login_backdrop_asset_hq() ? asset(login_backdrop_asset_hq()) : null -%}
+    <div class="container-login-img">
+    </div>
+    <style>
+      .container-login-img {
+        background-image: url("{{ asset(login_backdrop_asset())}}");
+      }
+      {%- if login_backdrop_asset_hq() -%}
+        @media screen and (min-width: 1921px) {
+          .container-login-img {
+            background-image: url("{{ asset(login_backdrop_asset_hq()) }}");
+          }
+        }
+      {%- endif -%}
+    </style>
+
     <div class="login-wrapper">
       {% set sitelinks = get_sitelinks() %}
       {% if sitelinks %}

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
@@ -24,12 +24,6 @@
   }
 
   .container-login-img {
-    @media (max-width: 1920px) {
-      background-image: url("/bundles/mapbendercore/image/login-backdrop.jpg");
-    }
-    @media (min-width: 1921px) {
-      background-image: url("/bundles/mapbendercore/image/login-backdrop-4k.jpg");
-    }
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;


### PR DESCRIPTION
The redesigned backend adds a large backdrop image to the login area.

Changes in this pull make this image customizable on the project level.

A new container parameter `branding.login_backdrop` is introduced. This should name an image asset located inside the web directory (=docroot), and should be a relative url path.

The image covers half the screen horizontally, is scaled to full height and centered. Thus the ideal aspect ratio is half the anticipated screen aspect ratio (8:9 for typical 16:9 FullHD screens).

