### PR TITLE
Feature/simplesearch geojson extension

### DIFF
--- a/src/Mapbender/CoreBundle/Element/SimpleSearch.php
+++ b/src/Mapbender/CoreBundle/Element/SimpleSearch.php
@@ -74,7 +74,6 @@ class SimpleSearch extends Element implements ConfigMigrationInterface
     {
         return array(
             'js'    => array(
-                '@FOMCoreBundle/Resources/public/js/widgets/autocomplete.js',
                 '@MapbenderCoreBundle/Resources/public/mapbender.element.simplesearch.js',
             ),
             'css'   => array(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -21,9 +21,14 @@ $.widget('mapbender.mbSimpleSearch', {
     marker: null,
     layer: null,
     iconUrl_: null,
+    acPosition_: undefined,
 
     _create: function() {
         this.iconUrl_ = this.options.result_icon_url || null;
+        if (this.element.closest('.toolBar.bottom').length) {
+            /** @see https://api.jqueryui.com/autocomplete/#option-position */
+            this.acPosition_ = {my: 'left bottom', at: 'left top', collision: 'none'};
+        }
         if (this.options.result_icon_url && !/^(\w+:)?\/\//.test(this.options.result_icon_url)) {
             // Local, asset-relative
             var parts = [
@@ -69,6 +74,7 @@ $.widget('mapbender.mbSimpleSearch', {
                     })
                 ;
             },
+            position: this.acPosition_,
             select: function(event, ui) {
                 // Adapt data format
                 self._onAutocompleteSelected(event, {data: ui.item});

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -90,10 +90,30 @@ $.widget('mapbender.mbSimpleSearch', {
         // @todo: SimpleSearch should have a 'target' for this, like virtually every other element
         return (Mapbender.elementRegistry.listWidgets())['mapbenderMbMap'];
     },
+    /**
+     * @param {Object} obj
+     * @param {String} path
+     * @return {string|null}
+     */
+    _extractAttribute: function(obj, path) {
+        var props = obj;
+        var parts = path.split('.');
+        var last = parts.pop();
+        for (var i = 0; i < parts.length; ++i) {
+            props = props && props[parts[i]];
+            if (!props) {
+                break;
+            }
+        }
+        if (props && (props[last] || (typeof props[last] === 'number'))) {
+            return [props[last]].join('');  // force to string
+        } else {
+            return null;
+        }
+    },
     _formatLabel: function(doc) {
-        // @todo: nested sub-attribute support
         // @todo: string template syntax support
-        return doc[this.options.label_attribute];
+        return this._extractAttribute(doc, this.options.label_attribute);
     },
     _onAutocompleteSelected: function(evt, evtData) {
         var format = new OpenLayers.Format[this.options.geom_format]();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -55,6 +55,8 @@ $.widget('mapbender.mbSimpleSearch', {
                             return Object.assign(item, {
                                 label: item[self.options.label_attribute]
                             });
+                        }).filter(function(item) {
+                            return item.label;
                         });
                         responseCallback(formatted);
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -129,13 +129,15 @@ $.widget('mapbender.mbSimpleSearch', {
                 var attributeValue = attributePath && this._extractAttribute(doc, attributePath);
                 if (attributeValue) {
                     parts.push(fixedText);
-                    parts.push(this._extractAttribute(doc, attributePath));
+                    parts.push(attributeValue);
                 } else {
-                    // @todo: filter separator texts between empty attribute lookups
-                    parts.push(fixedText);
+                    // Show text before label component only if attribute data was non-empty
+                    if (!attributePath) {
+                        parts.push(fixedText);
+                    }
                 }
             }
-            return parts.join('');
+            return parts.join('').replace(/(^[\s.,:]+)|([\s.,:]+$)/g, '');
         } else {
             return this._extractAttribute(doc, this.options.label_attribute);
         }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -53,7 +53,7 @@ $.widget('mapbender.mbSimpleSearch', {
                     .then(function(response) {
                         var formatted =  (response || []).map(function(item) {
                             return Object.assign(item, {
-                                label: item[self.options.label_attribute]
+                                label: self._formatLabel(item)
                             });
                         }).filter(function(item) {
                             var geomEmpty = !item[self.options.geom_attribute];
@@ -89,6 +89,11 @@ $.widget('mapbender.mbSimpleSearch', {
     _getMbMap: function() {
         // @todo: SimpleSearch should have a 'target' for this, like virtually every other element
         return (Mapbender.elementRegistry.listWidgets())['mapbenderMbMap'];
+    },
+    _formatLabel: function(doc) {
+        // @todo: nested sub-attribute support
+        // @todo: string template syntax support
+        return doc[this.options.label_attribute];
     },
     _onAutocompleteSelected: function(evt, evtData) {
         var format = new OpenLayers.Format[this.options.geom_format]();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -112,8 +112,27 @@ $.widget('mapbender.mbSimpleSearch', {
         }
     },
     _formatLabel: function(doc) {
-        // @todo: string template syntax support
-        return this._extractAttribute(doc, this.options.label_attribute);
+        // Find / match '${attribute_name}' / '${nested.attribute.path}' placeholders
+        var templateParts = this.options.label_attribute.split(/\${([^}]+)}/g);
+        if (templateParts.length > 1) {
+            var parts = [];
+            for (var i = 0; i < templateParts.length; i += 2) {
+                var fixedText = templateParts[i];
+                // NOTE: attributePath is undefined (index >= length of list) if label_attribute defines static text after last placeholder
+                var attributePath = templateParts[i + 1];
+                var attributeValue = attributePath && this._extractAttribute(doc, attributePath);
+                if (attributeValue) {
+                    parts.push(fixedText);
+                    parts.push(this._extractAttribute(doc, attributePath));
+                } else {
+                    // @todo: filter separator texts between empty attribute lookups
+                    parts.push(fixedText);
+                }
+            }
+            return parts.join('');
+        } else {
+            return this._extractAttribute(doc, this.options.label_attribute);
+        }
     },
     _onAutocompleteSelected: function(evt, evtData) {
         var format = new OpenLayers.Format[this.options.geom_format]();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.simplesearch.js
@@ -56,7 +56,11 @@ $.widget('mapbender.mbSimpleSearch', {
                                 label: item[self.options.label_attribute]
                             });
                         }).filter(function(item) {
-                            return item.label;
+                            var geomEmpty = !item[self.options.geom_attribute];
+                            if (geomEmpty) {
+                                console.warn("Missing geometry in SimpleSearch item", item);
+                            }
+                            return item.label && !geomEmpty;
                         });
                         responseCallback(formatted);
 
@@ -88,11 +92,6 @@ $.widget('mapbender.mbSimpleSearch', {
     },
     _onAutocompleteSelected: function(evt, evtData) {
         var format = new OpenLayers.Format[this.options.geom_format]();
-        if(!evtData.data[this.options.geom_attribute]) {
-            $.notify( Mapbender.trans("mb.core.simplesearch.error.geometry.missing"));
-            return;
-        }
-
         var feature = format.read(evtData.data[this.options.geom_attribute]);
         // Unpack GeoJSON parsing result list => single feature
         while (feature && Array.isArray(feature)) { feature = feature[0]; }

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/simple_search.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/simple_search.scss
@@ -13,7 +13,6 @@
       position: absolute; // do not expand DOM size when showing items
       display: none;  // suppress border; will be shown via script when populated
       border: solid 1px #c8c8c8;
-      margin-top: -1px; // Overlap borders
       z-index: 20000;
       min-width: 100%;
       width: auto;
@@ -34,20 +33,18 @@
   }
 }
 
-.toolBar {
-  .mb-element-simplesearch {
-    .autocompleteList {
-      max-height: 250px;
-      li {
-        text-align: left;
-      }
-    }
+.sidePane .mb-element-simplesearch {
+  .autocompleteList {
+    max-width: 100%;
   }
-  &.bottom .mb-element-simplesearch {
-    .autocompleteList {
-      // "drop up"
-      bottom: 0;
-      margin-bottom: $inputHeight;
+}
+
+.toolBar .mb-element-simplesearch {
+  .autocompleteList {
+    max-height: 250px;
+    overflow-y: hidden;
+    li {
+      text-align: left;
     }
   }
 }


### PR DESCRIPTION
Extends SimpleSearch to allow nested attribute access and multiple data attributes when generating result item labels.
This allows generating valid labels for GeoJSON responses.
It also allows picking and choosing combinations of attributes for generating a nicer label from common OSM-based response data.

## Nested attribute access
The `label_attribute` option may now contain dots to traverse into sub-objects.
```yaml
## somewhere in elements: sidepane:
      osm-search-full-name:
          class: Mapbender\CoreBundle\Element\SimpleSearch
          query_url: 'https://nominatim.openstreetmap.org/search?format=geojson&polygon_geojson=1&addressdetails=1'
          collection_path: features
          geom_attribute: geometry
          geom_format: GeoJSON
          label_attribute: properties.display_name    # <== sub-object access with dots
```
![Screenshot_2021-06-04_12-43-13](https://user-images.githubusercontent.com/24895932/120791039-f804cc00-c533-11eb-93c6-17b17d8ce3db.png)

As you can see, the display_name values are usually quite verbose. To produce nicer labels from OSM base data, you will usually want to combine several individual attributes yourself.

## Multiple attribute access and custom formatting
The `label_attribute` option may now contain a mix static text and (multiple) `${some_attribute_name}` placeholders. This allows combining multiple attributes into a label, and interjecting custom text or separating characters.
```yaml
## somewhere in elements: sidepane:
      osm-search-multi-attribute-labels:
          class: Mapbender\CoreBundle\Element\SimpleSearch
          query_url: 'https://nominatim.openstreetmap.org/search?format=geojson&polygon_geojson=1&addressdetails=1'
          collection_path: features
          geom_attribute: geometry
          geom_format: GeoJSON
          label_attribute: >-
              ${properties.address.office} ${properties.address.amenity},
              ${properties.address.road} ${properties.address.house_number}
              ${properties.address.postcode} ${properties.address.city}

```

![Screenshot_2021-06-04_12-45-04](https://user-images.githubusercontent.com/24895932/120791395-75c8d780-c534-11eb-9360-2badc2d27186.png)

Several things of note  in this example:
1) Dotted sub-object access is valid in `${...}` placeholders as well
2) We can add both the mutually exclusive `address.office` and `address.amenity` to get proper names both for companies and e.g. hospitals. The empty attribute does not produce any visible output.
3) This example only uses a single comma as a static string, but static strings can be anything. Consider (not very end-user friendly) `Osm-ID: ${properties.osm_id}`.

## Filtering of results without a (generated) label
Search results that cannot generate a non-empty label are no longer shown.

NOTE: please treat the public openstreetmap.org server gently. This is a great facility for testing, but should not be used in production deployments.
