### PR TITLE
add iconCopyright to the icon array

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Type/IconClassType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/IconClassType.php
@@ -43,7 +43,8 @@ class IconClassType extends AbstractType
             'iconGpsTarget'     => 'Gps Target (FontAwesome)',
             'iconPoi'           => 'POI (FontAwesome)',
             'iconImageExport'   => 'Image Export (FontAwesome)',
-            'iconSketch'        => 'Sketch (FontAwesome)');
+            'iconSketch'        => 'Sketch (FontAwesome)',
+            'iconCopyright'     => 'Copyright (FontAwesome)');
 
         asort($icons);
 


### PR DESCRIPTION
copyright is an Mapbender element and does not have a button yet.
The css for 'iconCopyright' is already defined in the file _icons.scss. 

With this PR it can be used for as button icon for the element copyright.

https://github.com/mapbender/mapbender/blob/master/src/Mapbender/CoreBundle/Resources/public/sass/libs/_icons.scss#L75