### PR TITLE
link element label visibility - fix for ticket 1383

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/views/Element/link_button.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/link_button.html.twig
@@ -2,7 +2,7 @@
   {% if icon %}
     <span class="iconBig {{ icon }}"></span>
   {% endif %}
-  {% if label %}
+  {% if show_label and label %}
   <span{% if icon %} class="hidden-sm hidden-xs hidden-md-down"{% endif %}>{{ label|trans }}</span>
   {% endif %}
 </a>


### PR DESCRIPTION
- https://github.com/mapbender/mapbender/issues/1383
- only show label, when checkbox show label is activ