### PR TITLE
Fixed Download PDF/ZIP Files GetFeatureInfo #1377

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -205,7 +205,7 @@
             switch (mimetype.toLowerCase()) {
                 case 'text/html':
                     var script = self._getInjectionScript(source.id);
-                    var iframe = $('<iframe sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox">');
+                    var iframe = $('<iframe sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads">');
                     iframe.attr("srcdoc",script+data);
                     self._addContent(source, layerTitle, iframe);
                     break;


### PR DESCRIPTION
This fix resolves issues with downloading linked ZIP files.

![pdf_zip_download](https://user-images.githubusercontent.com/465714/139248718-2e26b230-36f3-41a1-82a3-b4931821cdc0.png)


If PDF files are not displayed inline in Chrome, the download now also works with this fix.

![chrome_download_pdf](https://user-images.githubusercontent.com/465714/139248745-0942e7b5-99f3-4eb3-8a75-ea6f101bcc32.png)

