### PR TITLE
Enh/separate sass variable customization

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -112,9 +112,12 @@ class ApplicationAssetService
      */
     public function collectAssetReferences(Application $application, $type)
     {
-        $referenceLists = array(
-            $this->getBaseAssetReferences($type),
-        );
+        $referenceLists = array();
+        if ($type === 'css') {
+            $template = $this->getDummyTemplateComponent($application);
+            $referenceLists[] = $template->getSassVariablesAssets($application);
+        }
+        $referenceLists[] = $this->getBaseAssetReferences($type);
         if ($type === 'js') {
             $referenceLists[] = array(
                 '@MapbenderCoreBundle/Resources/public/init/frontend.js',

--- a/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
+++ b/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
@@ -4,6 +4,8 @@
 namespace Mapbender\CoreBundle\Component\Application\Template;
 
 
+use Mapbender\CoreBundle\Entity\Application;
+
 interface IApplicationTemplateAssetDependencyInterface
 {
     /**
@@ -27,6 +29,14 @@ interface IApplicationTemplateAssetDependencyInterface
      * @return string[]
      */
     public function getAssets($type);
+
+    /**
+     * Should return a list of file references containing sass variables definitions
+     *
+     * @param Application $application
+     * @return string[]
+     */
+    public function getSassVariablesAssets(Application $application);
 
     /**
      * Should return 'late' assets, to be loaded at the very end, particularly after all Element assets.

--- a/src/Mapbender/CoreBundle/Resources/public/sass/template/fullscreen.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/template/fullscreen.scss
@@ -1,5 +1,3 @@
-@import "libs/variables";
-@import "bundles/mapbendercore/sass/template/fullscreen_variables.scss";
 @import "libs/mixins";
 @import "libs/icons";
 @import "theme/mapbender3";

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -65,6 +65,14 @@ class Fullscreen extends Template
         return $classes;
     }
 
+    public function getSassVariablesAssets(Application $application)
+    {
+        return array(
+            '@MapbenderCoreBundle/Resources/public/sass/libs/_variables.scss',
+            '@MapbenderCoreBundle/Resources/public/sass/template/fullscreen_variables.scss',
+        );
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Mapbender/FrameworkBundle/EventListener/AutomaticLocaleListener.php
+++ b/src/Mapbender/FrameworkBundle/EventListener/AutomaticLocaleListener.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\EventListener;
+
+
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+
+class AutomaticLocaleListener
+{
+    /** @var bool */
+    protected $enabled;
+
+    /**
+     * @param bool $enableAutomaticLocale
+     */
+    public function __construct($enableAutomaticLocale)
+    {
+        $this->enabled = $enableAutomaticLocale;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if ($this->enabled && $event->getRequestType() !== HttpKernelInterface::SUB_REQUEST) {
+            $request = $event->getRequest();
+            $accept = $request->headers->get('Accept-Language', '');
+            $languages = \array_filter(explode(',', $accept));
+            foreach ($languages as $language) {
+                $parts = explode(';', $language);   // Split off "q=" weighting factor
+                if ($parts[0] && \preg_match('#^(de|en|es|fr|it|tr|ru)#i', $parts[0])) {
+                    try {
+                        $request->setLocale($parts[0]);
+                    } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodNotImplementedException $e) {
+                        // ignore
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -3,7 +3,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services
         https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="mapbender.automatic_locale">true</parameter>
+    </parameters>
     <services>
+        <service id="mapbender.auto_locale_listener" class="Mapbender\FrameworkBundle\EventListener\AutomaticLocaleListener">
+            <!-- exceed priority 100 of LocaleListener
+                 see Note in https://symfony.com/doc/3.4/translation/locale.html -->
+            <tag name="kernel.event_listener" event="kernel.request" priority="120" />
+            <argument>%mapbender.automatic_locale%</argument>
+        </service>
         <service id="mapbender.renderer.element_markup" class="Mapbender\FrameworkBundle\Component\Renderer\ElementMarkupRenderer">
             <argument type="service" id="templating" />
             <argument type="service" id="translator" />

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/applications.scss
@@ -1,6 +1,4 @@
 /* Main backend styles */
-@import "libs/variables";
-@import "bundles/mapbendermanager/sass/manager/variables.scss";
 @import "libs/mixins";
 @import "libs/icons";
 

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/manager/login.scss
@@ -1,5 +1,3 @@
-@import "libs/variables";
-@import "bundles/mapbendermanager/sass/manager/variables.scss";
 @import "libs/mixins";
 @import "libs/icons";
 @import 'bundles/mapbendermanager/sass/manager/manager.scss';

--- a/src/Mapbender/ManagerBundle/Template/LoginTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/LoginTemplate.php
@@ -8,6 +8,8 @@ class LoginTemplate extends ManagerTemplate
         switch ($type) {
             case 'css':
                 return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/libs/_variables.scss',
+                    '@MapbenderManagerBundle/Resources/public/sass/manager/variables.scss',
                     '@MapbenderManagerBundle/Resources/public/sass/manager/login.scss',
                 );
             case 'trans':

--- a/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
+++ b/src/Mapbender/ManagerBundle/Template/ManagerTemplate.php
@@ -11,6 +11,8 @@ class ManagerTemplate implements TemplateAssetDependencyInterface
         switch ($type) {
             case 'css':
                 return array(
+                    '@MapbenderCoreBundle/Resources/public/sass/libs/_variables.scss',
+                    '@MapbenderManagerBundle/Resources/public/sass/manager/variables.scss',
                     '@MapbenderManagerBundle/Resources/public/sass/manager/applications.scss',
                 );
             case 'js':

--- a/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
+++ b/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
@@ -1,6 +1,3 @@
-@import "libs/variables";
-// extend / replace some variables with mobile-specific values
-@import "bundles/mapbendermobile/sass/theme/variables.scss";
 @import "libs/mixins";
 @import "libs/normalize";
 @import "libs/icons";

--- a/src/Mapbender/MobileBundle/Template/Mobile.php
+++ b/src/Mapbender/MobileBundle/Template/Mobile.php
@@ -24,6 +24,14 @@ class Mobile extends Template
         );
     }
 
+    public function getSassVariablesAssets(Application $application)
+    {
+        return array(
+            '@MapbenderCoreBundle/Resources/public/sass/libs/_variables.scss',
+            '@MapbenderMobileBundle/Resources/public/sass/theme/variables.scss',
+        );
+    }
+
     public function getAssets($type)
     {
         switch ($type) {


### PR DESCRIPTION
Adds a new frontend Template method `getSassVariablesAssets` to simplify customization of colors / fonts etc in project specific templates.

Replaces Sass-level `@import` of the files defining these variables.

With this change, it is sufficient to redeclare new Sass variables to e.g. customize button colors. It is no longer necessary to reinclude or copy&paste the entire button css again.
