### PR TITLE
Prefer browser locale

### DIFF
--- a/src/Mapbender/FrameworkBundle/EventListener/AutomaticLocaleListener.php
+++ b/src/Mapbender/FrameworkBundle/EventListener/AutomaticLocaleListener.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\EventListener;
+
+
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+
+class AutomaticLocaleListener
+{
+    /** @var bool */
+    protected $enabled;
+
+    /**
+     * @param bool $enableAutomaticLocale
+     */
+    public function __construct($enableAutomaticLocale)
+    {
+        $this->enabled = $enableAutomaticLocale;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if ($this->enabled && $event->getRequestType() !== HttpKernelInterface::SUB_REQUEST) {
+            $request = $event->getRequest();
+            $accept = $request->headers->get('Accept-Language', '');
+            $languages = \array_filter(explode(',', $accept));
+            foreach ($languages as $language) {
+                $parts = explode(';', $language);   // Split off "q=" weighting factor
+                if ($parts[0] && \preg_match('#^(de|en|es|fr|it|tr|ru)#i', $parts[0])) {
+                    try {
+                        $request->setLocale($parts[0]);
+                    } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodNotImplementedException $e) {
+                        // ignore
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -3,7 +3,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services
         https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="mapbender.automatic_locale">true</parameter>
+    </parameters>
     <services>
+        <service id="mapbender.auto_locale_listener" class="Mapbender\FrameworkBundle\EventListener\AutomaticLocaleListener">
+            <!-- exceed priority 100 of LocaleListener
+                 see Note in https://symfony.com/doc/3.4/translation/locale.html -->
+            <tag name="kernel.event_listener" event="kernel.request" priority="120" />
+            <argument>%mapbender.automatic_locale%</argument>
+        </service>
         <service id="mapbender.renderer.element_markup" class="Mapbender\FrameworkBundle\Component\Renderer\ElementMarkupRenderer">
             <argument type="service" id="templating" />
             <argument type="service" id="translator" />


### PR DESCRIPTION
Auto-detects browser language preference to control translation target language. This takes precedence over the configured default locale.

Adds a new parameter `mapbender.automatic_locale` (boolean; default true) to disable auto-detection. This is intended mainly to aid in testing different language translations.