### PR TITLE
Sketch: editable circle radius

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Sketch.php
+++ b/src/Mapbender/CoreBundle/Element/Sketch.php
@@ -100,6 +100,7 @@ class Sketch extends AbstractElementService
         $view->attributes['class'] = 'mb-element-sketch';
         $view->variables['geometrytypes'] = $element->getConfiguration()['geometrytypes'];
         $view->variables['radiusEditing'] = $this->getRadiusEditing($element);
+        $view->variables['dialogMode'] = !\preg_match('#sidepane|mobilepane#i', $element->getRegion());
         return $view;
     }
 

--- a/src/Mapbender/CoreBundle/Element/Sketch.php
+++ b/src/Mapbender/CoreBundle/Element/Sketch.php
@@ -90,6 +90,7 @@ class Sketch extends AbstractElementService
     {
         return array_replace($element->getConfiguration(), array(
             'title' => $element->getTitle(),
+            'radiusEditing' => $this->getRadiusEditing($element),
         ));
     }
 
@@ -98,6 +99,17 @@ class Sketch extends AbstractElementService
         $view = new TemplateView('MapbenderCoreBundle:Element:sketch.html.twig');
         $view->attributes['class'] = 'mb-element-sketch';
         $view->variables['geometrytypes'] = $element->getConfiguration()['geometrytypes'];
+        $view->variables['radiusEditing'] = $this->getRadiusEditing($element);
         return $view;
+    }
+
+    /**
+     * @param Element $element
+     * @return bool
+     */
+    protected function getRadiusEditing(Element $element)
+    {
+        $config = $element->getConfiguration() + $this->getDefaultConfiguration();
+        return $element->getApplication()->getMapEngineCode() !== 'ol2' && \in_array('circle', $config['geometrytypes']);
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -5,6 +5,7 @@
             auto_activate: false,
             deactivate_on_close: true,
             geometrytypes: ['point', 'line', 'polygon', 'rectangle', 'text'],
+            radiusEditing: false,
             paintstyles: {
                 'strokeColor': '#ff0000',
                 'fillColor': '#ff0000',
@@ -273,7 +274,7 @@
                     }
                 });
                 this.trackLabelInput_($('input[name="label-text"]', $popoverContent));
-                if ('circle' === this._getFeatureAttribute(feature, 'toolName')) {
+                if ('circle' === this._getFeatureAttribute(feature, 'toolName') && this.options.radiusEditing) {
                     var $radiusInput = $('input[name="radius"]', $popoverContent);
                     $radiusInput.val(this.getFeatureRadius_(feature).toLocaleString());
                     this.trackRadiusInput_($radiusInput);

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -265,6 +265,8 @@
             var $row = this._getFeatureAttribute(feature, 'row');
             $('.geometry-item', this.element).not($row).removeClass('current-row');
             $row.addClass('current-row');
+            var toolName = this._getFeatureAttribute(feature, 'toolName');
+            var formScope;
             if (Mapbender.mapEngine.code === 'ol2') {
                 this.editControl.selectFeature(feature);
                 this.editControl.activate();
@@ -275,36 +277,34 @@
                     features: new ol.Collection([feature])
                 });
                 this.mbMap.getModel().olMap.addInteraction(this.editControl);
-                var toolName = this._getFeatureAttribute(feature, 'toolName');
-                var formScope;
-                if (this.useDialog_) {
-                    formScope = this.element;
-                } else {
-                    var $popoverContent = $($.parseHTML(this.editContent_));
-                    $('[data-toolnames]', $popoverContent).each(function() {
-                        var $this = $(this);
-                        var allowed = $this.attr('data-toolnames').split(',');
-                        if (-1 === allowed.indexOf(toolName)) {
-                            $this.remove();
-                        }
-                    });
-                    formScope = $popoverContent;
-                    this.trackLabelInput_($('input[name="label-text"]', $popoverContent));
-                    this.trackRadiusInput_($('input[name="radius"]', $popoverContent));
-                    this._showRecordPopover($row, $popoverContent);
-                }
-                $('input[name="label-text"]', formScope)
+            }
+            if (this.useDialog_) {
+                formScope = this.element;
+            } else {
+                var $popoverContent = $($.parseHTML(this.editContent_));
+                $('[data-toolnames]', $popoverContent).each(function() {
+                    var $this = $(this);
+                    var allowed = $this.attr('data-toolnames').split(',');
+                    if (-1 === allowed.indexOf(toolName)) {
+                        $this.remove();
+                    }
+                });
+                formScope = $popoverContent;
+                this.trackLabelInput_($('input[name="label-text"]', $popoverContent));
+                this.trackRadiusInput_($('input[name="radius"]', $popoverContent));
+                this._showRecordPopover($row, $popoverContent);
+            }
+            $('input[name="label-text"]', formScope)
+                .prop('disabled', false)
+                .val(this._getFeatureAttribute(feature, 'label') || '')
+            ;
+            if ('circle' === this._getFeatureAttribute(feature, 'toolName') && this.options.radiusEditing) {
+                $('input[name="radius"]', formScope)
                     .prop('disabled', false)
-                    .val(this._getFeatureAttribute(feature, 'label') || '')
+                    .val((this.getFeatureRadius_(feature) || 0).toLocaleString())
                 ;
-                if ('circle' === this._getFeatureAttribute(feature, 'toolName') && this.options.radiusEditing) {
-                    $('input[name="radius"]', formScope)
-                        .prop('disabled', false)
-                        .val((this.getFeatureRadius_(feature) || 0).toLocaleString())
-                    ;
-                } else {
-                    $('input[name="radius"]', formScope).prop('disabled', true).val('');
-                }
+            } else {
+                $('input[name="radius"]', formScope).prop('disabled', true).val('');
             }
         },
         _endEdit: function() {

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -34,4 +34,18 @@
     // Undo Bootstrap default right-aligned labels
     text-align: left;
   }
+  table {
+    td.compact, th.compact {
+      width: 1%;
+    }
+    >tbody>tr>td.geometry-name, >tbody>tr>td.row-marker {
+      padding-left: 0;
+    }
+    .row-marker {
+      opacity: 0;
+    }
+    .current-row .row-marker {
+      opacity: 1;
+    }
+  }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -4,4 +4,34 @@
       text-align:right;
     }
   }
+  .static-popover-wrap {
+    position: relative; // for anchoring of absolute-positioned .popover
+    .popover {
+      font-size: inherit;
+      min-width: 20em;
+      display: initial;
+      padding: 1em;
+      left: initial;
+      right: -2.5ch;
+
+      .arrow {
+        right: 2ch;
+        left: initial;
+      }
+
+      &.bottom {
+        top: 2ex;
+      }
+      .form-horizontal {
+        min-width: 17em;
+      }
+      .form-horizontal, .form-group {
+        margin-bottom: 0.75em;
+      }
+    }
+  }
+  .form-horizontal .control-label {
+    // Undo Bootstrap default right-aligned labels
+    text-align: left;
+  }
 }

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -379,6 +379,7 @@ mb:
         text: Text
       inputs:
         label: Beschriftung
+        radius: Radius
       error:
         notext: 'Kein Text eingetragen'
       geometry:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -378,6 +378,7 @@ mb:
         text: Text
       inputs:
         label: Label
+        radius: Radius
       error:
         notext: 'Text required'
       geometry:

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -43,6 +43,7 @@
                 <label for="label-text" class="control-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.label' | trans -}}</label>
                 <div class="col-8 col-xs-8"><input type="text" name="label-text" class="form-control"></div>
             </div>
+            {%- if radiusEditing -%}
             <div class="form-group" data-toolnames="circle">
                 <label for="radius" class="control-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
                 <div class="col-8 col-xs-8">
@@ -51,6 +52,7 @@
                     </div>
                 </div>
             </div>
+            {%- endif -%}
         </div>
         <div class="text-nowrap text-right">
             <button type="button" class="btn btn-sm btn-default -fn-close">{{ 'mb.actions.close' | trans }}</button>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -30,8 +30,29 @@
             <td class="geometry-name"></td>
             <td class="geometry-actions">
                 <i class="geometry-remove fa fa-trash-o far fa-trash-alt clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.remove" | trans }}"></i>
-                <i class="geometry-edit fa fas fa-pencil-alt fa-pencil clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.edit" | trans }}"></i>
+                <span class="static-popover-wrap -js-edit-content-anchor">
+                    <i class="geometry-edit fa fas fa-pencil-alt fa-pencil clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.edit" | trans }}"></i>
+                </span>
                 <i class="geometry-zoom fa fas fa-search-plus clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.zoom" | trans }}"></i>
             </td>
         </tr>
     </table>
+    <div class="hidden -js-edit-content">
+        <div class="form-horizontal">
+            <div class="form-group">
+                <label for="label-text" class="control-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.label' | trans -}}</label>
+                <div class="col-8 col-xs-8"><input type="text" name="label-text" class="form-control"></div>
+            </div>
+            <div class="form-group" data-toolnames="circle">
+                <label for="radius" class="control-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
+                <div class="col-8 col-xs-8">
+                    <div class="input-group">
+                        <input type="text" name="radius" class="form-control"><div class="input-group-addon">m</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="text-nowrap text-right">
+            <button type="button" class="btn btn-sm btn-default -fn-close">{{ 'mb.actions.close' | trans }}</button>
+        </div>
+    </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -21,14 +21,28 @@
         </div>
         <button type="button" disabled="disabled" title="{{ "mb.core.sketch.geometry.action.stop_drawing"|trans }}" class="btn btn-sm btn-default -fn-tool-off"><i class="fa fas fa-stop"></i></button>
     </div>
-    <div class="form-group">
-        <label for="label-text" class="labelInput">{{ "mb.core.sketch.inputs.label"|trans}}</label>
-        <input name="label-text" type="text" class="form-control" disabled="disabled">
+    <div class="row">
+        <div class="form-group{{- (radiusEditing and dialogMode) ? ' col-7 col-xs-7' : ' col-12 col-xs-12' -}}">
+            <label for="label-text" class="labelInput">{{ "mb.core.sketch.inputs.label"|trans}}</label>
+            <input name="label-text" type="text" class="form-control" disabled="disabled">
+        </div>
+        {%- if radiusEditing and dialogMode -%}
+        <div class="form-group col-5 col-xs-5">
+            <label for="label-text" class="labelInput">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
+            <div class="input-group">
+                <input name="radius" type="text" class="form-control" disabled="disabled">
+                <div class="input-group-addon">m</div>
+            </div>
+        </div>
+        {%- endif -%}
     </div>
     <table class="table table-striped geometry-table">
         <tr class="geometry-item" data-id="">
+            <td class="compact row-marker">
+                <i class="fa fas fa-fw fa-angle-double-right"></i>
+            </td>
             <td class="geometry-name"></td>
-            <td class="geometry-actions">
+            <td class="geometry-actions compact text-nowrap">
                 <i class="geometry-remove fa fa-trash-o far fa-trash-alt clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.remove" | trans }}"></i>
                 <span class="static-popover-wrap -js-edit-content-anchor">
                     <i class="geometry-edit fa fas fa-pencil-alt fa-pencil clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.edit" | trans }}"></i>


### PR DESCRIPTION
Adds manual circle radius editing to Sketch element.

Initial circle drawing remains freehand. Radius can only be edited after circle drawing is completed.

Comes bundled with a slight Sketch usability overhaul in sidepane mode, hopefully resolving some confusion about the semantics of the label input.

A feature that is currently being edited is now marked with a little icon for clarity.

Label (and potentially the new radius) input field(s) now pop out from the table row, making it much clearer what feature they will affect.

Due to unresolved layouting issues, popovers are _not_ used when Sketch is operated as a dialog (i.e. placed in "content" region and opened with a button or automatically). In this case, there is only on (set of) input field(s), shared between editing and new features.

Radius editing requires running to application on Openlayers 6. The corresponding input(s) will not display in legacy Openlayers 2 applications.