### PR TITLE
FeatureInfo: Extend feature coloring options

### DIFF
--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -71,6 +71,10 @@ class FeatureInfo extends AbstractElementService
             'highlighting' => false,
             'fillColorDefault' => '#ffa500',
             'fillColorHover' => '#ff0000',
+            'strokeColorDefault' => '#ff4466',
+            'strokeColorHover' => '#ff0000',
+            'opacityDefault' => 40,
+            'opacityHover' => 70,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle\Element;
 
 use Mapbender\Component\Element\AbstractElementService;
 use Mapbender\Component\Element\TemplateView;
+use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 
@@ -15,6 +16,7 @@ use Mapbender\CoreBundle\Utils\ArrayUtil;
  * @author Christian Wygoda
  */
 class FeatureInfo extends AbstractElementService
+    implements ConfigMigrationInterface
 {
     /**
      * @inheritdoc
@@ -67,8 +69,8 @@ class FeatureInfo extends AbstractElementService
             "height" => 500,
             "maxCount" => 100,
             'highlighting' => false,
-            'featureColorDefault' => '#ffa500',
-            'featureColorHover' => '#ff0000',
+            'fillColorDefault' => '#ffa500',
+            'fillColorHover' => '#ff0000',
         );
     }
 
@@ -129,5 +131,19 @@ class FeatureInfo extends AbstractElementService
     public static function getFormTemplate()
     {
         return 'MapbenderCoreBundle:ElementAdmin:featureinfo.html.twig';
+    }
+
+    public static function updateEntityConfig(Element $entity)
+    {
+        $config = $entity->getConfiguration();
+        if (!empty($config['featureColorDefault'])) {
+            $config += array('fillColorDefault' => $config['featureColorDefault']);
+        }
+        if (!empty($config['featureColorHover'])) {
+            $config += array('fillColorHover' => $config['featureColorHover']);
+        }
+        unset($config['featureColorDefault']);
+        unset($config['featureColorHover']);
+        $entity->setConfiguration($config);
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -50,11 +50,49 @@ class FeatureInfoAdminType extends AbstractType
             ))
             ->add('featureColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                 'required' => true,
-                'label' => 'mb.core.admin.featureinfo.label.featureColorDefault',
+                'label' => 'mb.core.admin.featureinfo.label.fillColor',
+                'attr' => array(
+                    'class' => '-js-init-colorpicker',
+                ),
+            ))
+            ->add('strokeColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.strokeColor',
+                'attr' => array(
+                    'class' => '-js-init-colorpicker',
+                ),
+            ))
+            ->add('opacityDefault', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', array(
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.opacity_pct',
+                'attr' => array(
+                    'min' => 0,
+                    'max' => 100,
+                    'class' => 'text-right',
+                ),
             ))
             ->add('featureColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-                'required' => true,
-                'label' => 'mb.core.admin.featureinfo.label.featureColorHover',
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.fillColor',
+                'attr' => array(
+                    'class' => '-js-init-colorpicker',
+                ),
+            ))
+            ->add('strokeColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.strokeColor',
+                'attr' => array(
+                    'class' => '-js-init-colorpicker',
+                ),
+            ))
+            ->add('opacityHover', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', array(
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.opacity_pct',
+                'attr' => array(
+                    'min' => 0,
+                    'max' => 100,
+                    'class' => 'text-right',
+                ),
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -68,7 +68,6 @@ class FeatureInfoAdminType extends AbstractType
                 'attr' => array(
                     'min' => 0,
                     'max' => 100,
-                    'class' => 'text-right',
                 ),
             ))
             ->add('fillColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
@@ -91,7 +90,6 @@ class FeatureInfoAdminType extends AbstractType
                 'attr' => array(
                     'min' => 0,
                     'max' => 100,
-                    'class' => 'text-right',
                 ),
             ))
         ;

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -48,7 +48,7 @@ class FeatureInfoAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.admin.featureinfo.label.highlighting',
             ))
-            ->add('featureColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('fillColorDefault', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                 'required' => true,
                 'label' => 'mb.core.admin.featureinfo.label.fillColor',
                 'attr' => array(
@@ -71,7 +71,7 @@ class FeatureInfoAdminType extends AbstractType
                     'class' => 'text-right',
                 ),
             ))
-            ->add('featureColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('fillColorHover', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                 'required' => false,
                 'label' => 'mb.core.admin.featureinfo.label.fillColor',
                 'attr' => array(

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -8,8 +8,8 @@
             printResult: false,
             onlyValid: false,
             highlighting: false,
-            featureColorDefault: '#ffa500',
-            featureColorHover: 'ff0000',
+            fillColorDefault: '#ffa500',
+            fillColorHover: 'ff0000',
             maxCount: 100,
             width: 700,
             height: 500
@@ -367,14 +367,14 @@
         },
         _createLayerStyle: function () {
             var settingsDefault = {
-                fill: this.options.featureColorDefault,
-                stroke: this.options.strokeColorDefault || this.options.featureColorDefault,
+                fill: this.options.fillColorDefault,
+                stroke: this.options.strokeColorDefault || this.options.fillColorDefault,
                 opacity: this.options.opacityDefault,
                 fallbackOpacity: 0.7
             };
             var settingsHover = {
-                fill: this.options.featureColorHover || settingsDefault.fill,
-                stroke: this.options.strokeColorHover || this.options.featureColorHover || settingsDefault.stroke,
+                fill: this.options.fillColorHover || settingsDefault.fill,
+                stroke: this.options.strokeColorHover || this.options.fillColorHover || settingsDefault.stroke,
                 opacity: this.options.opacityHover,
                 fallbackOpacity: 0.4
             };

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -326,8 +326,11 @@ mb:
           onlyvalid: 'Nur valide zeigen'
           highlighting_group: 'Highlighting'
           highlighting: Highlighting aktiv
-          featureColorDefault: Grundfarbe
-          featureColorHover: Hover-Farbe
+          default_group: Standard
+          hover_group: Hover
+          fillColor: Füllfarbe
+          strokeColor: Strichfarbe
+          opacity_pct: Deckkraft (%)
       printclient:
         label:
           autoopen: 'Automatisches Öffnen'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -325,8 +325,11 @@ mb:
           onlyvalid: 'Only valid'
           highlighting_group: 'Highlighting'
           highlighting: 'Highlighting enabled'
-          featureColorDefault: Default color
-          featureColorHover: Hover color
+          default_group: Default
+          hover_group: On hover
+          fillColor: Fill color
+          strokeColor: Stroke color
+          opacity_pct: Opacity (%)
       printclient:
         label:
           autoopen: Auto-open

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -15,13 +15,13 @@
     <div class="row">
         <fieldset class="col-12 col-xs-12 col-md-6">
             <legend>{{- 'mb.core.admin.featureinfo.label.default_group' | trans() -}}</legend>
-            {{- form_row(form.configuration.featureColorDefault) -}}
+            {{- form_row(form.configuration.fillColorDefault) -}}
             {{- form_row(form.configuration.strokeColorDefault) -}}
             {{- form_row(form.configuration.opacityDefault) -}}
         </fieldset>
         <fieldset class="col-12 col-xs-12 col-md-6">
             <legend>{{- 'mb.core.admin.featureinfo.label.hover_group' | trans() -}}</legend>
-            {{ form_row(form.configuration.featureColorHover) }}
+            {{ form_row(form.configuration.fillColorHover) }}
             {{ form_row(form.configuration.strokeColorHover) }}
             {{ form_row(form.configuration.opacityHover) }}
         </fieldset>

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/featureinfo.html.twig
@@ -12,11 +12,24 @@
     {{ form_row(form.configuration.height) }}
     <h3>{{ 'mb.core.admin.featureinfo.label.highlighting_group' | trans }}</h3>
     {{ form_row(form.configuration.highlighting) }}
-    {{ form_rest(form.configuration) }}
+    <div class="row">
+        <fieldset class="col-12 col-xs-12 col-md-6">
+            <legend>{{- 'mb.core.admin.featureinfo.label.default_group' | trans() -}}</legend>
+            {{- form_row(form.configuration.featureColorDefault) -}}
+            {{- form_row(form.configuration.strokeColorDefault) -}}
+            {{- form_row(form.configuration.opacityDefault) -}}
+        </fieldset>
+        <fieldset class="col-12 col-xs-12 col-md-6">
+            <legend>{{- 'mb.core.admin.featureinfo.label.hover_group' | trans() -}}</legend>
+            {{ form_row(form.configuration.featureColorHover) }}
+            {{ form_row(form.configuration.strokeColorHover) }}
+            {{ form_row(form.configuration.opacityHover) }}
+        </fieldset>
+        {{- form_rest(form.configuration) -}}
+    </div>
 </div>
 <script type="text/javascript">
     !(function($) {
-        var $pickers = $('#{{ form.configuration.featureColorDefault.vars.id | raw }},#{{ form.configuration.featureColorHover.vars.id | raw}}');
-        $pickers.colorpicker({format: 'hex'});
+        $('#{{ form.vars.attr.id }} .-js-init-colorpicker').colorpicker({format: 'hex'});
     }(jQuery));
 </script>


### PR DESCRIPTION
For [renderable features extracted from FeatureInfo HTML responses](https://github.com/mapbender/mapbender/pull/1270), stroke color and opacities have [previously](https://github.com/mapbender/mapbender/pull/1323) been hardcoded.

Pull extends configurability and allows customizing stroke color and feature opacity, separately for default rendering and hover states.

![Screenshot_2022-07-15_12-41-32](https://user-images.githubusercontent.com/24895932/179208139-673d9e53-a293-48d0-b550-bd94eacbf033.png)

For Yaml applications, use the new configuration values `strokeColorDefault`, `strokeColorHover`, `opacityDefault` and `opacityHover`. _NOTE_ that previous `featureColorDefault` and `featuerColorHover` have been renamed to `fillColorDefault` and `fillColorHover` to reduce amgibuity.

Colors should be in CSS six-digit hex format (including leading `#`). Opacities are percentages.

```yml
            featureinfo:
                class: Mapbender\CoreBundle\Element\FeatureInfo
                <...>
                highlighting: true
                fillColorDefault: '#5555ff'     # renamed
                strokeColorDefault: '#ffffff'   # new
                opacityDefault: 25              # new
                fillColorHover: '#4444ff'       # renamed
                strokeColorHover: '#ff0000'     # new
                opacityHover: 80                # new
```
