### PR TITLE
Sketch: multiple, configurable drawing colors + frontend customizable color

### DIFF
--- a/src/Mapbender/CoreBundle/Element/Sketch.php
+++ b/src/Mapbender/CoreBundle/Element/Sketch.php
@@ -4,9 +4,11 @@ namespace Mapbender\CoreBundle\Element;
 
 use Mapbender\Component\Element\AbstractElementService;
 use Mapbender\Component\Element\TemplateView;
+use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
 use Mapbender\CoreBundle\Entity\Element;
 
 class Sketch extends AbstractElementService
+    implements ConfigMigrationInterface
 {
 
     /**
@@ -120,5 +122,16 @@ class Sketch extends AbstractElementService
     {
         $config = $element->getConfiguration() + $this->getDefaultConfiguration();
         return $element->getApplication()->getMapEngineCode() !== 'ol2' && \in_array('circle', $config['geometrytypes']);
+    }
+
+    public static function updateEntityConfig(Element $entity)
+    {
+        // Bridge undocumented legacy "paintstyles" to "colors"
+        $config = $entity->getConfiguration();
+        if (!empty($config['paintstyles']['fillColor'])) {
+            $config += array('colors' => array($config['paintstyles']['fillColor']));
+        }
+        unset($config['paintstyles']);
+        $entity->setConfiguration($config);
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Sketch.php
+++ b/src/Mapbender/CoreBundle/Element/Sketch.php
@@ -72,6 +72,7 @@ class Sketch extends AbstractElementService
                 '#3333ff',
                 '#44ee44',
             ),
+            'allow_custom_color' => true,
         );
     }
 
@@ -107,6 +108,7 @@ class Sketch extends AbstractElementService
         $view->variables['radiusEditing'] = $this->getRadiusEditing($element);
         $view->variables['dialogMode'] = !\preg_match('#sidepane|mobilepane#i', $element->getRegion());
         $view->variables['colors'] = $element->getConfiguration()['colors'];
+        $view->variables['allow_custom_color'] = $element->getConfiguration()['allow_custom_color'];
         return $view;
     }
 

--- a/src/Mapbender/CoreBundle/Element/Sketch.php
+++ b/src/Mapbender/CoreBundle/Element/Sketch.php
@@ -67,6 +67,11 @@ class Sketch extends AbstractElementService
                 "rectangle",
                 "circle",
             ),
+            'colors' => array(
+                '#ff3333',
+                '#3333ff',
+                '#44ee44',
+            ),
         );
     }
 
@@ -101,6 +106,7 @@ class Sketch extends AbstractElementService
         $view->variables['geometrytypes'] = $element->getConfiguration()['geometrytypes'];
         $view->variables['radiusEditing'] = $this->getRadiusEditing($element);
         $view->variables['dialogMode'] = !\preg_match('#sidepane|mobilepane#i', $element->getRegion());
+        $view->variables['colors'] = $element->getConfiguration()['colors'];
         return $view;
     }
 

--- a/src/Mapbender/CoreBundle/Element/Type/SketchAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/SketchAdminType.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle\Element\Type;
 
 use Mapbender\ManagerBundle\Form\DataTransformer\ArrayToCsvScalarTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -37,6 +38,11 @@ class SketchAdminType extends AbstractType
             ))
             ->add('colors', TextType::class, array(
                 'required' => false,
+                'label' => 'mb.core.sketch.admin.colors'
+            ))
+            ->add('allow_custom_color', CheckboxType::class, array(
+                'required' => false,
+                'label' => 'mb.core.sketch.admin.allow_custom_color'
             ))
         ;
         $builder->get('colors')->addModelTransformer(new ArrayToCsvScalarTransformer());

--- a/src/Mapbender/CoreBundle/Element/Type/SketchAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/SketchAdminType.php
@@ -2,7 +2,9 @@
 
 namespace Mapbender\CoreBundle\Element\Type;
 
+use Mapbender\ManagerBundle\Form\DataTransformer\ArrayToCsvScalarTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SketchAdminType extends AbstractType
@@ -33,6 +35,10 @@ class SketchAdminType extends AbstractType
                     'mb.core.sketch.geometrytype.text' => 'text',
                 ),
             ))
+            ->add('colors', TextType::class, array(
+                'required' => false,
+            ))
         ;
+        $builder->get('colors')->addModelTransformer(new ArrayToCsvScalarTransformer());
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -55,13 +55,25 @@
                 self._deactivateControl();
                 $(this).prop('disabled', true);
             });
-            $('.-js-pallette-container', this.element).on('click', '.color-select', function() {
+            $('.-js-pallette-container', this.element).on('click', '.color-select[data-color]', function() {
                 var $btn = $(this);
-                self.selectedColor_ = $btn.attr('data-color');
-                $btn.siblings().removeClass('active');
-                $btn.addClass('active');
+                self.setColor_($btn.attr('data-color'), $btn);
             });
             this.selectedColor_ = $('.color-select', this.element).eq(0).attr('data-color') || '#ff3333';
+            $('.-fn-color-customize', this.element).colorpicker({
+                format: 'hex',
+                input: false,
+                component: false
+            }).on('changeColor', function(evt) {
+                var color = evt.color.toString(true, 'hex');
+                var $btn = $('.custom-color-select', self.element);
+                $('.color-preview', $btn).css('background', color);
+                $btn
+                    .attr('data-color', color)
+                    .prop('disabled', false)
+                ;
+                self.setColor_(color, $btn);
+            });
 
             this.layer = Mapbender.vectorLayerPool.getElementLayer(this, 0);
             this.layer.customizeStyle({
@@ -488,6 +500,13 @@
             var upm = this.mbMap.getModel().getUnitsPerMeterAt(center);
             var radius_ = radius * upm.h;
             geom.setRadius(radius_);
+        },
+        setColor_: function(color, $button) {
+            this.selectedColor_ = color;
+            $('.-js-pallette-container .color-select', this.element).not($button).removeClass('active');
+            if ($button.length) {
+                $button.addClass('active');
+            }
         },
         __dummy__: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -13,7 +13,6 @@
             }
         },
         mbMap: null,
-        map: null,
         layer: null,
         geomCounter: 0,
         rowTemplate: null,
@@ -47,8 +46,6 @@
         },
         _setup: function(){
             var $geomTable = $('.geometry-table', this.element);
-            // @todo: remove direct access to OpenLayers 2 map
-            this.map = this.mbMap.map.olMap;
             this.rowTemplate = $('tr', $geomTable).remove().removeClass('hidden');
             $geomTable.on('click', '.geometry-remove', $.proxy(this._removeFromGeomList, this));
             $geomTable.on('click', '.geometry-edit', $.proxy(this._modifyFeature, this));

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -507,6 +507,13 @@
             if ($button.length) {
                 $button.addClass('active');
             }
+            if (this.editing_) {
+                this._setFeatureAttribute(this.editing_, 'color', color);
+                // OpenLayers 2 only
+                if (this.editing_.layer) {
+                    this.editing_.layer.redraw();
+                }
+            }
         },
         __dummy__: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -6,11 +6,7 @@
             deactivate_on_close: true,
             geometrytypes: ['point', 'line', 'polygon', 'rectangle', 'text'],
             radiusEditing: false,
-            paintstyles: {
-                'strokeColor': '#ff0000',
-                'fillColor': '#ff0000',
-                'strokeWidth': '3'
-            }
+            colors: []
         },
         mbMap: null,
         layer: null,
@@ -23,6 +19,7 @@
         useDialog_: false,
         editContent_: null,
         decimalSeparator_: ((0.5).toLocaleString().substring(1, 2)),
+        selectedColor_: null,
 
         _create: function() {
             Object.assign(this.toolLabels, {
@@ -58,9 +55,23 @@
                 self._deactivateControl();
                 $(this).prop('disabled', true);
             });
+            $('.-js-pallette-container', this.element).on('click', '.color-select', function() {
+                var $btn = $(this);
+                self.selectedColor_ = $btn.attr('data-color');
+                $btn.siblings().removeClass('active');
+                $btn.addClass('active');
+            });
+            this.selectedColor_ = $('.color-select', this.element).eq(0).attr('data-color') || '#ff3333';
 
             this.layer = Mapbender.vectorLayerPool.getElementLayer(this, 0);
-            this.layer.customizeStyle(Object.assign({}, this.options.paintstyles, {
+            this.layer.customizeStyle({
+                strokeWidth: 3,
+                fillColor: function(feature) {
+                    return self._getFeatureAttribute(feature, 'color') || self.selectedColor_;
+                },
+                strokeColor: function(feature) {
+                    return self._getFeatureAttribute(feature, 'color') || self.selectedColor_;
+                },
                 label: function(feature) {
                     return self._getFeatureAttribute(feature, 'label') || '';
                 },
@@ -78,7 +89,7 @@
                         return 0;
                     }
                 }
-            }));
+            });
 
             if (Mapbender.mapEngine.code === 'ol2') {
                 // OpenLayers 2: keep reusing single edit control
@@ -209,6 +220,7 @@
         },
         _onFeatureAdded: function(toolName, feature) {
             this._setFeatureAttribute(feature, 'toolName', toolName);
+            this._setFeatureAttribute(feature, 'color', this.selectedColor_);
             var text = this.$labelInput_.val().trim();
             this._updateFeatureLabel(feature, text);
             this.$labelInput_.val('');

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -327,6 +327,7 @@
             } else {
                 $('input[name="radius"]', formScope).prop('disabled', true).val('');
             }
+            this.setPickerColor_(this._getFeatureAttribute(feature, 'color') || this.selectedColor_);
         },
         _endEdit: function() {
             if (this.editControl) {
@@ -514,6 +515,12 @@
                     this.editing_.layer.redraw();
                 }
             }
+        },
+        setPickerColor_: function(color) {
+            $('.-fn-color-customize', this.element).colorpicker('updatePicker', color);
+            var $btn = $('.custom-color-select', this.element);
+            $('.color-preview', $btn).css('background', color);
+            $btn.prop('disabled', false);
         },
         __dummy__: null
     });

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -48,4 +48,14 @@
       opacity: 1;
     }
   }
+
+  .btn.color-select {
+    // Squarify button padding on .btn-sm (default: 5px 10px)
+    padding-left: 5px;
+    padding-right: 5px;
+    .color-preview {
+      display: inline-block;
+      min-width: 1.5em;
+    }
+  }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -49,13 +49,13 @@
     }
   }
 
-  .btn.color-select {
+  .btn.btn-sm-square, .btn-group-sm-square > .btn {
     // Squarify button padding on .btn-sm (default: 5px 10px)
     padding-left: 5px;
     padding-right: 5px;
-    .color-preview {
-      display: inline-block;
-      min-width: 1.5em;
-    }
+  }
+  .btn .color-preview {
+    display: inline-block;
+    min-width: 1.5em;
   }
 }

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -397,6 +397,8 @@ mb:
       admin:
         auto_activate: 'Automatisches Aktivieren'
         deactivate_on_close: 'Beim Schließen deaktivieren'
+        colors: Farben
+        allow_custom_color: Farbanpassung erlauben
     # (imported) Yaml application amenity
     redlining:
       class:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -396,6 +396,8 @@ mb:
       admin:
         auto_activate: Auto activate
         deactivate_on_close: Deactivate on close
+        colors: Colors
+        allow_custom_color: Allow custom color
     # (imported) Yaml application amenity
     redlining:
       class:

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -21,17 +21,19 @@
         </div>
         <button type="button" disabled="disabled" title="{{ "mb.core.sketch.geometry.action.stop_drawing"|trans }}" class="btn btn-sm btn-default -fn-tool-off"><i class="fa fas fa-stop"></i></button>
     </div>
-    <div class="form-group -js-pallette-container{{- colors | length <= 1 ? ' hidden' : '' -}}">
+    <div class="form-group -js-pallette-container{{- not allow_custom_color and colors | length <= 1 ? ' hidden' : '' -}}">
         <div class="btn-toolbar">
             <div class="btn-group btn-group-sm btn-group-sm-square">
                 {%- for color in colors -%}
                     <button type="button" class="btn btn-default color-select{{- loop.first ? ' active' : '' -}}" data-color="{{ color }}"><i class="color-preview" style="background: {{ color }};">&nbsp;</i></button>
                 {%- endfor -%}
             </div>
+            {%- if allow_custom_color -%}
             <div class="btn-group btn-group-sm btn-group-sm-square">
                 <button type="button" class="btn btn-default color-select custom-color-select" disabled><i class="color-preview">&nbsp;</i></button>
                 <button type="button" class="-fn-color-customize btn btn-default"><i class="fa fas fa-fw fa-caret-down"></i></button>
             </div>
+            {%- endif -%}
         </div>
     </div>
 

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -21,6 +21,16 @@
         </div>
         <button type="button" disabled="disabled" title="{{ "mb.core.sketch.geometry.action.stop_drawing"|trans }}" class="btn btn-sm btn-default -fn-tool-off"><i class="fa fas fa-stop"></i></button>
     </div>
+    <div class="form-group -js-pallette-container{{- colors | length <= 1 ? ' hidden' : '' -}}">
+        <div class="btn-toolbar">
+            <div class="btn-group btn-group-sm">
+                {%- for color in colors -%}
+                    <button type="button" class="btn btn-default color-select{{- loop.first ? ' active' : '' -}}" data-color="{{ color }}"><i class="color-preview" style="background: {{ color }};">&nbsp;</i></button>
+                {%- endfor -%}
+            </div>
+        </div>
+    </div>
+
     <div class="row">
         <div class="form-group{{- (radiusEditing and dialogMode) ? ' col-7 col-xs-7' : ' col-12 col-xs-12' -}}">
             <label for="label-text" class="labelInput">{{ "mb.core.sketch.inputs.label"|trans}}</label>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -23,10 +23,14 @@
     </div>
     <div class="form-group -js-pallette-container{{- colors | length <= 1 ? ' hidden' : '' -}}">
         <div class="btn-toolbar">
-            <div class="btn-group btn-group-sm">
+            <div class="btn-group btn-group-sm btn-group-sm-square">
                 {%- for color in colors -%}
                     <button type="button" class="btn btn-default color-select{{- loop.first ? ' active' : '' -}}" data-color="{{ color }}"><i class="color-preview" style="background: {{ color }};">&nbsp;</i></button>
                 {%- endfor -%}
+            </div>
+            <div class="btn-group btn-group-sm btn-group-sm-square">
+                <button type="button" class="btn btn-default color-select custom-color-select" disabled><i class="color-preview">&nbsp;</i></button>
+                <button type="button" class="-fn-color-customize btn btn-default"><i class="fa fas fa-fw fa-caret-down"></i></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds a multi-entry color pallette to Sketch element to replace the previous hardcoded red default.

![Screenshot_2022-07-18_12-47-11](https://user-images.githubusercontent.com/24895932/179497985-bc7f3fe0-d946-4b9e-938e-6965a33fcac4.png)

Main pallette entries are predetermined by element configuration. The default (as seen above) is to offer red, green and blue.
Additionally, users can edit their own extra color with a color picker.

Clicking on one of the color buttons determines the color for the next feature drawn, or, if currently editing a feature (click on edit icon in table listing), immediately updates that feature to that color.

If the element is configured with only a single color _and_ the frontend color picker is disabled, the pallette region is not shown.

For yaml elements:
```yaml
    class: Mapbender\CoreBundle\Element\Sketch
    colors:          # new; optional list of strings; use CSS hex notation; omit completely for defaults
      - '#4488ff'
      - '#ff8844'
    allow_custom_color: true           # new; default true; set to false to disable frontend color picker
```

_Note_ that in the backend form, `colors` is a scalar input field. Color values must be comma separated.