### PR TITLE
Fix/application html caching unbounded entries

### DIFF
--- a/src/Mapbender/Component/Element/ElementView.php
+++ b/src/Mapbender/Component/Element/ElementView.php
@@ -10,4 +10,5 @@ namespace Mapbender\Component\Element;
 abstract class ElementView
 {
     public $attributes = array();
+    public $cacheable = true;
 }

--- a/src/Mapbender/CoreBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/controllers.xml
@@ -42,6 +42,7 @@
                  public="true">
             <argument type="service" id="mapbender.application.yaml_entity_repository" />
             <argument type="service" id="mapbender.element_filter" />
+            <argument type="service" id="mapbender.renderer.element_markup" />
         </service>
         <service id="Mapbender\CoreBundle\Controller\ConfigController"
                  class="Mapbender\CoreBundle\Controller\ConfigController"

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -105,8 +105,20 @@ Mapbender.ElementRegistry = (function($){
         this.addTrackingByClass_(bundle, node);
         // register one-time listener for ready event, which will trigger promise
         // resolution
+        var self = this;
         if (readyEventName) {
-            $(node).one(readyEventName, this.markReady.bind(this, nodeId));
+            // Listen on parent. For uncacheable elements, original node may be replaced with
+            // new content, losing directly bound listeners.
+            $(node).parent().one(readyEventName, (function(nodeId) {
+                return function(evt) {
+                    if (evt.target && evt.target.id === nodeId) {
+                        self.markReady(nodeId);
+                        return false;
+                    } else {
+                        return true;
+                    }
+                };
+            }(nodeId)));
         }
     };
     /**
@@ -294,24 +306,24 @@ $.extend(Mapbender, (function($) {
      * @return {*}
      */
     function initElement(id, data) {
-        var selector = '#' + id;
-        if (!$(selector).length) {
-            throw new Error("No DOM match for element selector " + selector);
-        }
         var instance;
+        var $node = $(document.getElementById(id));
+        if (!$node.length) {
+            throw new Error('Element #' + id + ' not found in DOM');
+        }
         if (data.init) {
             var initInfo = _getElementInitInfo(data.init);
             if (!initInfo.initMethod) {
                 Mapbender.elementRegistry.markFailed(id);
                 throw new Error("No such widget " + data.init);
             }
-            instance = (initInfo.initMethod)(data.configuration, selector);
+            instance = (initInfo.initMethod)(data.configuration, $node);
             Mapbender.elementRegistry.markCreated(id, instance);
         } else {
             // no widget constructor, do a little thing that at least has the element property in the
             // same place as a jquery ui widget
             instance = {
-                element: $(selector)
+                element: $node
             };
             Mapbender.elementRegistry.markCreated(id, instance);
             Mapbender.elementRegistry.markReady(id);
@@ -332,31 +344,57 @@ $.extend(Mapbender, (function($) {
             }
         }
     }
-    function _initElements(config, debug) {
+    function _initElements(config) {
         var elementIds = Object.keys(config);
+        var uncacheable = {};
+        var node;
         for (var i = 0; i < elementIds.length; ++i) {
             var elementId = elementIds[i];
             // Note: config may reference Elements that have been suppressed in markup (grants)
-            if (!document.getElementById(elementId)) {
+            node = document.getElementById(elementId);
+            if (!node) {
                 continue;
             }
             var elementData = config[elementId];
-            try {
-                initElement(elementId, elementData);
-            } catch(e) {
-                Mapbender.elementRegistry.markFailed(elementId);
-                // NOTE: console.error produces a NEW stack trace that ends right here, and as such
-                //       won't point to the origin of the Error at all.
-                console.error("Element " + elementId + " failed to initialize:", e.message, elementData);
-                if (debug) {
-                    // Log original stack trace (clickable in Chrome, unfortunately not in Firefox) separately
-                    console.log(e.stack);
-                }
-                $.notify('Your element with id ' + elementId + ' (widget ' + elementData.init + ') failed to initialize properly.', 'error');
+            if ($(node).hasClass('-js-reload-uncacheable')) {
+                uncacheable[elementId] = elementData;
+            } else {
+                _initElement(elementId, elementData);
             }
         }
+        var uncacheableIds = Object.keys(uncacheable);
+        if (uncacheableIds.length) {
+            var reloadUrl = ['.', Mapbender.configuration.application.slug, 'elements'].join('/');
+            $.getJSON(reloadUrl, {
+                ids: uncacheableIds.join(',')
+            }).then(function(response) {
+                var selectors = Object.keys(response);
+                for (var s = 0; s < selectors.length; ++s) {
+                    var selector = selectors[s];
+                    $(selectors[s]).replaceWith(response[selector]);
+                }
+                for (i = 0; i < uncacheableIds.length; ++i) {
+                    var id = uncacheableIds[i];
+                    _initElement(id, uncacheable[id]);
+                }
+            });
+        }
     }
-
+    function _initElement(id, elementData) {
+        try {
+            initElement(id, elementData);
+        } catch(e) {
+            Mapbender.elementRegistry.markFailed(id);
+            // NOTE: console.error produces a NEW stack trace that ends right here, and as such
+            //       won't point to the origin of the Error at all.
+            console.error("Element " + id + " failed to initialize:", e.message, elementData);
+            if (window.Mapbender.configuration.application.debug) {
+                // Log original stack trace (clickable in Chrome, unfortunately not in Firefox) separately
+                console.log(e.stack);
+            }
+            $.notify('Your element with id ' + id + ' (widget ' + elementData.init + ') failed to initialize properly.', 'error');
+        }
+    }
 
     function setup() {
         // Disable ~"functional" a href="#" links from opening new tab / breaking fragment-based navigation history
@@ -379,7 +417,7 @@ $.extend(Mapbender, (function($) {
         var defaultStackTraceLimit = Error.stackTraceLimit;
         // NOTE: do not set undefined; undefined captures NO STACK TRACE AT ALL in some browsers
         Error.stackTraceLimit = 100;
-        _initElements(Mapbender.configuration.elements, Mapbender.configuration.application.debug || false);
+        _initElements(Mapbender.configuration.elements);
 
         Error.stackTraceLimit = defaultStackTraceLimit;
 

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupCache.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupCache.php
@@ -50,6 +50,11 @@ class ApplicationMarkupCache
             \clearstatcache($filePath, true);
             $response = new Response($html);
         }
+        $response->setVary(array(
+            'Accept-Language',
+            // Bust browser cache on session / login state change
+            'Cookie',
+        ));
         return $response;
     }
 

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
@@ -133,6 +133,10 @@ class ElementMarkupRenderer
      */
     protected function renderView(ElementView $view, $wrapperTag, $baseAttributes)
     {
+        if (!$view->cacheable) {
+            $baseAttributes += array('class' => '');
+            $baseAttributes['class'] = ltrim($baseAttributes['class'] . ' -js-reload-uncacheable');
+        }
         $attributes = $this->prepareAttributes($view->attributes, $baseAttributes);
         if ($view instanceof TemplateView) {
             $content = $this->templatingEngine->render($view->getTemplate(), $view->variables);

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -36,6 +36,7 @@
                  class="Mapbender\FrameworkBundle\Component\Renderer\ApplicationMarkupCache"
                  lazy="true">
             <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="translator" />
             <argument>%kernel.cache_dir%</argument>
         </service>


### PR DESCRIPTION
Application frontend html caching has historically baked the session id into the cache file identifier. This means for every application, every time a user logged in for any reason (including session expiry), new cache files have been created. These files could pile up infinitely. The more users access an installation, the faster this pileup occurred.

This was done to avoid serving the same cached html to users with different allowed element visibility (after evaluating per-element grants).

Changes in this pull reimplement the intended effect without the unintended file system pileup: frontend html cache is steered directly by the granted subset of elements in the application, instead of the session id.

This limits the maximum number of cached html variants per application. All visitors to an application with the same effective element grants will be served from the same html cache entry.