### PR TITLE
Application template class dropins

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -9,10 +9,10 @@ use Mapbender\Component\Application\TemplateAssetDependencyInterface;
 use Mapbender\CoreBundle\Component\ElementInventoryService;
 use Mapbender\CoreBundle\Component\Exception\ElementErrorException;
 use Mapbender\CoreBundle\Component\Source\TypeDirectoryService;
-use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Mapbender\FrameworkBundle\Component\ElementFilter;
 use Mapbender\Utils\AssetReferenceUtil;
 
@@ -34,6 +34,8 @@ class ApplicationAssetService
     protected $inventory;
     /** @var TypeDirectoryService */
     protected $sourceTypeDirectory;
+    /** @var ApplicationTemplateRegistry */
+    protected $templateRegistry;
     /** @var bool */
     protected $debug;
     /** @var bool */
@@ -45,6 +47,7 @@ class ApplicationAssetService
                                 ElementFilter $elementFilter,
                                 ElementInventoryService $inventory,
                                 TypeDirectoryService $sourceTypeDirectory,
+                                ApplicationTemplateRegistry $templateRegistry,
                                 $debug=false,
                                 $strict=false)
     {
@@ -54,6 +57,7 @@ class ApplicationAssetService
         $this->elementFilter = $elementFilter;
         $this->inventory = $inventory;
         $this->sourceTypeDirectory = $sourceTypeDirectory;
+        $this->templateRegistry = $templateRegistry;
         $this->debug = $debug;
         $this->strict = $strict;
     }
@@ -114,7 +118,7 @@ class ApplicationAssetService
     {
         $referenceLists = array();
         if ($type === 'css') {
-            $template = $this->getDummyTemplateComponent($application);
+            $template = $this->templateRegistry->getApplicationTemplate($application);
             $variables = $template->getSassVariablesAssets($application);
 
             $customVariables = $this->extractSassVariables($application->getCustomCss() ?: '');
@@ -295,7 +299,7 @@ class ApplicationAssetService
      */
     public function getTemplateBaseAssetReferences(Application $application, $type)
     {
-        $templateComponent = $this->getDummyTemplateComponent($application);
+        $templateComponent = $this->templateRegistry->getApplicationTemplate($application);
         $refs = $templateComponent->getAssets($type);
         return $this->qualifyAssetReferencesBulk($templateComponent, $refs, $type);
     }
@@ -366,21 +370,9 @@ class ApplicationAssetService
      */
     public function getTemplateLateAssetReferences(Application $application, $type)
     {
-        $templateComponent = $this->getDummyTemplateComponent($application);
+        $templateComponent = $this->templateRegistry->getApplicationTemplate($application);
         $refs = $templateComponent->getLateAssets($type);
         return $this->qualifyAssetReferencesBulk($templateComponent, $refs, $type);
-    }
-
-    /**
-     * @param Application $application
-     * @return Template
-     */
-    protected function getDummyTemplateComponent(Application $application)
-    {
-        $templateClassName = $application->getTemplate();
-        /** @var Template $instance */
-        $instance = new $templateClassName();
-        return $instance;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
+++ b/src/Mapbender/CoreBundle/MapbenderCoreBundle.php
@@ -50,18 +50,6 @@ class MapbenderCoreBundle extends MapbenderBundle
     /**
      * @inheritdoc
      */
-    public function getTemplates()
-    {
-        return array
-            (
-                'Mapbender\CoreBundle\Template\Fullscreen',
-                'Mapbender\CoreBundle\Template\FullscreenAlternative',
-            );
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getElements()
     {
         return array(
@@ -110,6 +98,7 @@ class MapbenderCoreBundle extends MapbenderBundle
             'constraints.yml',
             'formTypes.yml',
             'elements.xml',
+            'templates.xml',
         );
     }
 

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -21,6 +21,7 @@
         <parameter key="mapbender.application_exporter.service.class">Mapbender\ManagerBundle\Component\ExportHandler</parameter>
         <parameter key="mapbender.source.url_processor.service.class">Mapbender\CoreBundle\Component\Source\UrlProcessor</parameter>
         <parameter key="mapbender.sqlite_connection_listener.class">Mapbender\CoreBundle\Component\EventListener\SqliteConnectionListener</parameter>
+        <parameter key="mapbender.application_template.fallback">Mapbender\CoreBundle\Template\Fullscreen</parameter>
         <!-- strict mode flag cascade; set mapbender.strict to true to enable all checks at once -->
         <parameter key="mapbender.strict">false</parameter>
         <parameter key="mapbender.strict.element_api">%mapbender.strict%</parameter>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -240,6 +240,7 @@
             <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="mapbender.element_inventory.service" />
             <argument type="service" id="mapbender.source.typedirectory.service" />
+            <argument type="service" id="mapbender.application_template_registry" />
             <argument>%kernel.debug%</argument>
             <argument>%mapbender.strict.asset.bundle_scopes%</argument>
         </service>

--- a/src/Mapbender/CoreBundle/Resources/config/templates.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="mapbender.application_template.fullscreen"
+                 class="Mapbender\CoreBundle\Template\Fullscreen"
+                 abstract="true">
+            <tag name="mapbender.application_template" />
+        </service>
+        <service id="mapbender.application_template.fullscreen_alternative"
+                 class="Mapbender\CoreBundle\Template\FullscreenAlternative"
+                 abstract="true">
+            <tag name="mapbender.application_template" />
+        </service>
+    </services>
+</container>

--- a/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
+++ b/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\Component;
+
+
+use Mapbender\CoreBundle\Component\Application\Template\IApplicationTemplateInterface;
+use Mapbender\CoreBundle\Component\Template;
+use Mapbender\CoreBundle\Entity\Application;
+
+class ApplicationTemplateRegistry
+{
+    /** @var IApplicationTemplateInterface[]|Template[] */
+    protected $handlers = array();
+
+    /**
+     * @param array<string, IApplicationTemplateInterface|string> $collection
+     */
+    public function __construct($collection)
+    {
+        foreach ($collection as $handling => $item) {
+            if (\is_object($item)) {
+                $this->handlers[$handling] = $item;
+            } else {
+                $this->handlers[$handling] = new $item;
+            }
+        }
+    }
+
+    /**
+     * @return IApplicationTemplateInterface[]|Template[]
+     */
+    public function getAll()
+    {
+        $noDuplicates = array();
+        foreach ($this->handlers as $handler) {
+            $noDuplicates += array(\get_class($handler) => $handler);
+        }
+        return \array_values($noDuplicates);
+    }
+
+    /**
+     * @param Application $application
+     * @return Template
+     */
+    public function getApplicationTemplate(Application $application)
+    {
+        return $this->handlers[$application->getTemplate()];
+    }
+}

--- a/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
+++ b/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
@@ -41,10 +41,13 @@ class ApplicationTemplateRegistry
 
     /**
      * @param Application $application
-     * @return Template
+     * @return Template|null
      */
     public function getApplicationTemplate(Application $application)
     {
-        return $this->handlers[$application->getTemplate()];
+        $setting = $application->getTemplate();
+        // Return null only for uninitialized application template prop
+        // (may happen when submitting new application form)
+        return $setting ? $this->handlers[$setting] : null;
     }
 }

--- a/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
+++ b/src/Mapbender/FrameworkBundle/Component/ApplicationTemplateRegistry.php
@@ -12,11 +12,13 @@ class ApplicationTemplateRegistry
 {
     /** @var IApplicationTemplateInterface[]|Template[] */
     protected $handlers = array();
+    /** @var IApplicationTemplateInterface|Template */
+    protected $fallback;
 
     /**
      * @param array<string, IApplicationTemplateInterface|string> $collection
      */
-    public function __construct($collection)
+    public function __construct($collection, $fallback)
     {
         foreach ($collection as $handling => $item) {
             if (\is_object($item)) {
@@ -24,6 +26,12 @@ class ApplicationTemplateRegistry
             } else {
                 $this->handlers[$handling] = new $item;
             }
+        }
+        if ($fallback) {
+            if (!\is_object($fallback)) {
+                $fallback = new $fallback;
+            }
+            $this->fallback = $fallback;
         }
     }
 
@@ -48,6 +56,14 @@ class ApplicationTemplateRegistry
         $setting = $application->getTemplate();
         // Return null only for uninitialized application template prop
         // (may happen when submitting new application form)
-        return $setting ? $this->handlers[$setting] : null;
+        if ($setting) {
+            if (!empty($this->handlers[$setting])) {
+                return $this->handlers[$setting];
+            } else {
+                return $this->fallback;
+            }
+        } else {
+            return null;
+        }
     }
 }

--- a/src/Mapbender/FrameworkBundle/DependencyInjection/Compiler/RegisterApplicationTemplatesPass.php
+++ b/src/Mapbender/FrameworkBundle/DependencyInjection/Compiler/RegisterApplicationTemplatesPass.php
@@ -1,0 +1,83 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\DependencyInjection\Compiler;
+
+
+use Mapbender\CoreBundle\Component\MapbenderBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterApplicationTemplatesPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    /** @var string */
+    protected $targetServiceId;
+
+    public function __construct($targetServiceId = 'mapbender.application_template_registry')
+    {
+        $this->targetServiceId = $targetServiceId;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $priorityMap = array();
+        $bundleTemplateClasses = $this->getBundleTemplates($container);
+        foreach ($bundleTemplateClasses as $templateClass) {
+            $priorityMap += array(0 => array());
+            $priorityMap[0][] = array(
+                'class' => $templateClass,
+                'class_or_ref' => $templateClass,
+                'tag' => array(),
+            );
+        }
+
+        $tagged = $container->findTaggedServiceIds('mapbender.application_template', false);
+        foreach ($tagged as $serviceId => $tags) {
+            $definition = $container->getDefinition($serviceId);
+            $classOrRef = $definition->isAbstract() ? $definition->getClass() : new Reference($serviceId);
+            foreach ($tags as $tag) {
+                $priority = ($tag + array('priority' => 1))['priority'];
+                $priorityMap += array($priority => array());
+                $priorityMap[$priority][] = array(
+                    'class' => $definition->getClass(),
+                    'class_or_ref' => $classOrRef,
+                    'tag' => $tag,
+                );
+            }
+        }
+        \krsort($priorityMap, SORT_NUMERIC);
+
+        $handlers = array();
+        foreach ($priorityMap as $priorityBucket) {
+            foreach ($priorityBucket as $templateInfo) {
+                $handlers += array($templateInfo['class'] => $templateInfo['class_or_ref']);
+                if (!empty($templateInfo['tag']['replaces'])) {
+                    $handlers += array($templateInfo['tag']['replaces'] => $templateInfo['class_or_ref']);
+                }
+            }
+        }
+        $targetDefinition = $container->getDefinition($this->targetServiceId);
+        $targetDefinition->setArgument(0, $handlers);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @return string[]
+     */
+    protected function getBundleTemplates(ContainerBuilder $container)
+    {
+        $templateClasses = array();
+        foreach ($container->getParameter('kernel.bundles') as $bundleClass) {
+            if (\is_a($bundleClass, MapbenderBundle::class, true)) {
+                /** @var MapbenderBundle $bundle */
+                $bundle = new $bundleClass();
+                $templateClasses = \array_merge($templateClasses, $bundle->getTemplates());
+            }
+        }
+        return $templateClasses;
+    }
+}

--- a/src/Mapbender/FrameworkBundle/MapbenderFrameworkBundle.php
+++ b/src/Mapbender/FrameworkBundle/MapbenderFrameworkBundle.php
@@ -4,6 +4,7 @@
 namespace Mapbender\FrameworkBundle;
 
 
+use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterApplicationTemplatesPass;
 use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterElementServicesPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -24,6 +25,9 @@ class MapbenderFrameworkBundle extends Bundle
         // Register service elements
         // Run pass with reduced priority, so it happens after non-service inventory building has completed
         $container->addCompilerPass(new RegisterElementServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
+        // Forward available application template classes to registry service
+        /** @see \Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry */
+        $container->addCompilerPass(new RegisterApplicationTemplatesPass('mapbender.application_template_registry'));
     }
 
     public function getContainerExtension()

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameters>
         <parameter key="mapbender.automatic_locale">true</parameter>
         <parameter key="mapbender.force_engine">null</parameter>
+        <parameter key="mapbender.application_template.fallback">null</parameter>
     </parameters>
     <services>
         <service id="mapbender.auto_locale_listener" class="Mapbender\FrameworkBundle\EventListener\AutomaticLocaleListener">
@@ -52,6 +53,7 @@
         <service id="mapbender.application_template_registry" class="Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry">
             <!-- NOTE: argument populated by RegisterApplicationTemplatesPass -->
             <argument type="collection" />
+            <argument>%mapbender.application_template.fallback%</argument>
         </service>
         <service id="mapbender.element_shim_factory" class="Mapbender\FrameworkBundle\Component\ElementShimFactory">
             <argument type="service" id="mapbender.element_shim_factory.container" />

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -26,9 +26,10 @@
         <service id="mapbender.renderer.application_markup"
                  class="Mapbender\FrameworkBundle\Component\Renderer\ApplicationMarkupRenderer"
                  lazy="true">
+            <argument type="service" id="twig" />
+            <argument type="service" id="mapbender.application_template_registry" />
             <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="mapbender.renderer.element_markup" />
-            <argument type="service" id="twig" />
             <argument type="service" id="mapbender.uploads_manager.service" />
             <argument>%mapbender.responsive.containers%</argument>
         </service>
@@ -47,6 +48,10 @@
         <service id="mapbender.element_entity_factory" class="Mapbender\FrameworkBundle\Component\ElementEntityFactory">
             <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="translator" />
+        </service>
+        <service id="mapbender.application_template_registry" class="Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry">
+            <!-- NOTE: argument populated by RegisterApplicationTemplatesPass -->
+            <argument type="collection" />
         </service>
         <service id="mapbender.element_shim_factory" class="Mapbender\FrameworkBundle\Component\ElementShimFactory">
             <argument type="service" id="mapbender.element_shim_factory.container" />

--- a/src/Mapbender/IntrospectionBundle/Command/InspectTranslationTwigsCommand.php
+++ b/src/Mapbender/IntrospectionBundle/Command/InspectTranslationTwigsCommand.php
@@ -6,9 +6,8 @@ namespace Mapbender\IntrospectionBundle\Command;
 
 use Mapbender\Component\Application\TemplateAssetDependencyInterface;
 use Mapbender\CoreBundle\Component\ElementInventoryService;
-use Mapbender\CoreBundle\Component\MapbenderBundle;
-use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Mapbender\FrameworkBundle\Component\ElementEntityFactory;
 use Mapbender\ManagerBundle\Template\LoginTemplate;
 use Mapbender\ManagerBundle\Template\ManagerTemplate;
@@ -26,17 +25,18 @@ class InspectTranslationTwigsCommand extends Command
     protected $inventory;
     /** @var ElementEntityFactory */
     protected $entityFactory;
-    protected $bundles;
+    /** @var ApplicationTemplateRegistry */
+    protected $templateRegistry;
 
     public function __construct(FilesystemLoader $twigLoader,
                                 ElementInventoryService $inventory,
                                 ElementEntityFactory $entityFactory,
-                                $bundles)
+                                ApplicationTemplateRegistry $templateRegistry)
     {
         $this->twigLoader = $twigLoader;
         $this->inventory = $inventory;
         $this->entityFactory = $entityFactory;
-        $this->bundles = $bundles;
+        $this->templateRegistry = $templateRegistry;
         parent::__construct(null);
     }
 
@@ -134,19 +134,7 @@ class InspectTranslationTwigsCommand extends Command
 
     protected function collectTemplateResourcePaths()
     {
-        $templateClasses = array();
-        foreach ($this->bundles as $bundleClassName) {
-            if (\is_a($bundleClassName, 'Mapbender\CoreBundle\Component\MapbenderBundle', true)) {
-                /** @var MapbenderBundle $bundle */
-                $bundle = new $bundleClassName();
-                $templateClasses = array_merge($templateClasses, array_values($bundle->getTemplates()));
-            }
-        }
-        $templateInstances = array();
-        foreach ($templateClasses as $className) {
-            /** @var Template|string $className */
-            $templateInstances[] = new $className();
-        }
+        $templateInstances = $this->templateRegistry->getAll();
         return $this->extractTemplateTranslationDependencies($templateInstances);
     }
 

--- a/src/Mapbender/IntrospectionBundle/Resources/config/commands.xml
+++ b/src/Mapbender/IntrospectionBundle/Resources/config/commands.xml
@@ -31,7 +31,7 @@
             <argument type="service" id="twig.loader" />
             <argument type="service" id="mapbender.element_inventory.service" />
             <argument type="service" id="mapbender.element_entity_factory" />
-            <argument>%kernel.bundles%</argument>
+            <argument type="service" id="mapbender.application_template_registry" />
         </service>
     </services>
 </container>

--- a/src/Mapbender/ManagerBundle/Extension/Twig/ApplicationRegionTitleExtension.php
+++ b/src/Mapbender/ManagerBundle/Extension/Twig/ApplicationRegionTitleExtension.php
@@ -4,13 +4,21 @@
 namespace Mapbender\ManagerBundle\Extension\Twig;
 
 
-use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class ApplicationRegionTitleExtension extends AbstractExtension
 {
+    /** @var ApplicationTemplateRegistry */
+    protected $templateRegistry;
+
+    public function __construct(ApplicationTemplateRegistry $templateRegistry)
+    {
+        $this->templateRegistry = $templateRegistry;
+    }
+
     public function getFunctions()
     {
         return array(
@@ -20,12 +28,7 @@ class ApplicationRegionTitleExtension extends AbstractExtension
 
     public function application_region_title(Application $application, $regionName)
     {
-        /** @var Template|string $tpl */
-        $tpl = $application->getTemplate();
-        if ($tpl) {
-            return $tpl::getRegionTitle($regionName);
-        } else {
-            return \ucfirst($regionName);
-        }
+        $template = $this->templateRegistry->getApplicationTemplate($application);
+        return $template::getRegionTitle($regionName);
     }
 }

--- a/src/Mapbender/ManagerBundle/Form/Type/Application/RegionPropertiesMapper.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/Application/RegionPropertiesMapper.php
@@ -7,14 +7,21 @@ namespace Mapbender\ManagerBundle\Form\Type\Application;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
-use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\RegionProperties;
-use Mapbender\CoreBundle\Utils\ArrayUtil;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Symfony\Component\Form\DataMapperInterface;
 
 class RegionPropertiesMapper implements DataMapperInterface
 {
+    /** @var ApplicationTemplateRegistry */
+    protected $templateRegistry;
+
+    public function __construct(ApplicationTemplateRegistry $templateRegistry)
+    {
+        $this->templateRegistry = $templateRegistry;
+    }
+
     /**
      * @param Collection|Selectable|RegionProperties[] $viewData
      * @param \Symfony\Component\Form\FormInterface[]|\Traversable $forms
@@ -83,9 +90,8 @@ class RegionPropertiesMapper implements DataMapperInterface
 
     protected function getRegionDefaults(Application $application, $regionName)
     {
-        /** @var Template|string $templateClass */
-        $templateClass = $application->getTemplate();
-        $defaults = $templateClass::getRegionPropertiesDefaults($regionName);
+        $template = $this->templateRegistry->getApplicationTemplate($application);
+        $defaults = $template->getRegionPropertiesDefaults($regionName);
         unset($defaults['label']);
         return $defaults;
     }

--- a/src/Mapbender/ManagerBundle/Form/Type/Application/RegionPropertiesType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/Application/RegionPropertiesType.php
@@ -4,8 +4,8 @@
 namespace Mapbender\ManagerBundle\Form\Type\Application;
 
 
-use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -13,22 +13,30 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RegionPropertiesType extends AbstractType
 {
+    /** @var ApplicationTemplateRegistry */
+    protected $templateRegistry;
+
+    public function __construct(ApplicationTemplateRegistry $templateRegistry)
+    {
+        $this->templateRegistry = $templateRegistry;
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
+        $templateRegistry = $this->templateRegistry;
         $resolver->setDefaults(array(
             'application' => null,
             'compound' => true,
             'label_attr' => array(
                 'class' => 'hidden',
             ),
-            'region_names' => function (Options $options) {
+            'region_names' => function (Options $options) use ($templateRegistry) {
                 /** @var Application $application */
                 $application = $options['application'];
-                /** @var Template|string $templateClass */
-                $templateClass = $application->getTemplate();
+                $template = $templateRegistry->getApplicationTemplate($application);
                 // Guard against empty template (creating new Application)
-                if ($templateClass) {
-                    return $templateClass::getRegions();
+                if ($template) {
+                    return $template->getRegions() ?: array();
                 } else {
                     return array();
                 }
@@ -40,17 +48,16 @@ class RegionPropertiesType extends AbstractType
     {
         /** @var Application $application */
         $application = $options['application'];
-        $templateClass = $application->getTemplate();
+        $template = $this->templateRegistry->getApplicationTemplate($application);
         // Guard against empty template (creating new Application)
-        if ($templateClass) {
-            /** @var string|Template $templateClass */
+        if ($template) {
             foreach ($options['region_names'] as $regionName) {
-                $formType = $templateClass::getRegionSettingsFormType($regionName);
+                $formType = $template->getRegionSettingsFormType($regionName);
                 if ($formType) {
                     $builder->add($regionName, $formType);
                 }
             }
         }
-        $builder->setDataMapper(new RegionPropertiesMapper());
+        $builder->setDataMapper(new RegionPropertiesMapper($this->templateRegistry));
     }
 }

--- a/src/Mapbender/ManagerBundle/Form/Type/Application/TemplateChoiceType.php
+++ b/src/Mapbender/ManagerBundle/Form/Type/Application/TemplateChoiceType.php
@@ -4,8 +4,7 @@
 namespace Mapbender\ManagerBundle\Form\Type\Application;
 
 
-use Mapbender\CoreBundle\Component\MapbenderBundle;
-use Mapbender\CoreBundle\Component\Template;
+use Mapbender\FrameworkBundle\Component\ApplicationTemplateRegistry;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -13,19 +12,10 @@ class TemplateChoiceType extends AbstractType
 {
     protected $choices = array();
 
-    public function __construct($bundleClassNames)
+    public function __construct(ApplicationTemplateRegistry $registry)
     {
-        foreach ($bundleClassNames as $bundleClassName) {
-            if (\is_a($bundleClassName, 'Mapbender\CoreBundle\Component\MapbenderBundle', true)) {
-                /** @var MapbenderBundle $bundle */
-                $bundle = new $bundleClassName();
-                $bundleTemplateClasses = $bundle->getTemplates();
-                foreach ($bundleTemplateClasses as $templateClass) {
-                    /** @var string|Template $templateClass */
-                    $title = $templateClass::getTitle();
-                    $this->choices[$title] = $templateClass;
-                }
-            }
+        foreach ($registry->getAll() as $template) {
+            $this->choices[$template->getTitle()] = \get_class($template);
         }
         ksort($this->choices);
     }

--- a/src/Mapbender/ManagerBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/ManagerBundle/Resources/config/controllers.xml
@@ -7,6 +7,7 @@
                  class="Mapbender\ManagerBundle\Controller\ApplicationController"
                  public="true">
             <argument type="service" id="security.acl.provider" />
+            <argument type="service" id="mapbender.application_template_registry" />
             <argument type="service" id="fom.acl.manager" />
             <argument type="service" id="mapbender.uploads_manager.service" />
             <argument>%mapbender.responsive.elements%</argument>

--- a/src/Mapbender/ManagerBundle/Resources/config/services.xml
+++ b/src/Mapbender/ManagerBundle/Resources/config/services.xml
@@ -37,6 +37,7 @@
 
         <service id="mapbender.twig.manager.application_region_title" class="Mapbender\ManagerBundle\Extension\Twig\ApplicationRegionTitleExtension">
             <tag name="twig.extension"/>
+            <argument type="service" id="mapbender.application_template_registry" />
         </service>
         <service id="mapbender.form_type.application" class="Mapbender\ManagerBundle\Form\Type\ApplicationType">
             <tag name="form.type" />
@@ -44,7 +45,11 @@
         </service>
         <service id="mapbender.form_type.application_template_choice" class="Mapbender\ManagerBundle\Form\Type\Application\TemplateChoiceType">
             <tag name="form.type" />
-            <argument>%kernel.bundles%</argument>
+            <argument type="service" id="mapbender.application_template_registry" />
+        </service>
+        <service id="mapbender.form_type.application.region_properties" class="Mapbender\ManagerBundle\Form\Type\Application\RegionPropertiesType">
+            <tag name="form.type" />
+            <argument type="service" id="mapbender.application_template_registry" />
         </service>
         <service id="mabender.form_type.source_instance_item" class="Mapbender\ManagerBundle\Form\Type\SourceInstanceItemType">
             <tag name="form.type" />

--- a/src/Mapbender/MobileBundle/MapbenderMobileBundle.php
+++ b/src/Mapbender/MobileBundle/MapbenderMobileBundle.php
@@ -2,7 +2,11 @@
 
 namespace Mapbender\MobileBundle;
 
-use Mapbender\CoreBundle\Component\MapbenderBundle;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Class MapbenderMobileBundle
@@ -11,24 +15,18 @@ use Mapbender\CoreBundle\Component\MapbenderBundle;
  * @author Paul Schmidt <paul.schmidt@wheregroup.com>
  * @author Andriy Oblivantsev <eslider@gmail.com>
  */
-class MapbenderMobileBundle extends MapbenderBundle
+class MapbenderMobileBundle extends Bundle
 {
-
-    /**
-     * @inheritdoc
-     */
-    public function getTemplates()
+    public function build(ContainerBuilder $container)
     {
-        return array('Mapbender\MobileBundle\Template\Mobile');
+        $configLocator = new FileLocator(__DIR__ . '/Resources/config');
+        $loader = new XmlFileLoader($container, $configLocator);
+        $loader->load('templates.xml');
+        $container->addResource(new FileResource($configLocator->locate('templates.xml')));
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getElements()
+    public function getContainerExtension()
     {
-        return array(
-
-        );
+        return null;
     }
 }

--- a/src/Mapbender/MobileBundle/Resources/config/templates.xml
+++ b/src/Mapbender/MobileBundle/Resources/config/templates.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="mapbender.mobile.template_mobile"
+                 class="Mapbender\MobileBundle\Template\Mobile"
+                 abstract="true">
+            <tag name="mapbender.application_template" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Application template classes in Mapbender are PHP classes determining the region structure, region-specific form types, twig skins for frontend rendering and so forth.

Changes in this pull replace and extend the (circa 2013) template registration mechanism.

Template classes can now be declared as services tagged with `mapbender.application_template`.
The tag can optionally carry a `replaces` attribute. This allows replacing a shipping mapbender template completely with a project-specific class. A `priority` attribute can also be set to resolve bundle loading order conflicts.

```xml
<service id="project.application_template.custom_fullscreen"
         class="ProjectBundle\CustomFullscreen">
    <tag name="mapbender.application_template" replaces="Mapbender\CoreBundle\Template\Fullscreen" />
</services>
```

Previously, replacing the template class required manual database manipulation. After altering the database contents, the affected applications would no longer work if the bundle defining the newly set template class was deactivated for testing or any other purpose.

After these changes, developers can
1) modify the design of many applications at once only by registering a new template tagged to replace another
2) somewhat safely deactivate a bundle declaring a custom PHP template class, to make live comparisons with the pre-customization state

Finally, if a currently undefined template class is loaded from the application table, Mapbender will now quietly fall back to the default fullscreen template instead of throwing a server error.