### PR TITLE
Client side user info

### DIFF
--- a/src/Mapbender/CoreBundle/Controller/UserInfoController.php
+++ b/src/Mapbender/CoreBundle/Controller/UserInfoController.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Controller;
+
+
+use Mapbender\FrameworkBundle\Component\UserInfoProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UserInfoController
+{
+    /** @var UserInfoProvider */
+    protected $provider;
+
+    public function __construct(UserInfoProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Provides current user information for client-side script evaluation.
+     * Inherently not cachable, thus separate from config.
+     *
+     * @Route("/userinfo.json")
+     * @return JsonResponse
+     * @since v3.2.2
+     */
+    public function userinfoAction()
+    {
+        return new JsonResponse($this->provider->getValues(), 200, array(
+            'Vary' => 'Cookie',
+        ));
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/controllers.xml
@@ -44,6 +44,12 @@
             <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="mapbender.renderer.element_markup" />
         </service>
+        <service id="Mapbender\CoreBundle\Controller\UserInfoController"
+                 class="Mapbender\CoreBundle\Controller\UserInfoController"
+                 public="true"
+                 lazy="true">
+            <argument type="service" id="mapbender.user_info_provider" />
+        </service>
         <service id="Mapbender\CoreBundle\Controller\ConfigController"
                  class="Mapbender\CoreBundle\Controller\ConfigController"
                  public="true"

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -442,8 +442,9 @@ $.extend(Mapbender, (function($) {
          */
         loadUserInfo: (function() {
             // Fetch once, reuse response
-            var promise = $.getJSON('../userinfo.json').promise();
+            var promise = null;
             return function() {
+                promise = promise || $.getJSON('../userinfo.json').promise();
                 return promise;
             }
         }())

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -429,7 +429,24 @@ $.extend(Mapbender, (function($) {
     return {
         source: {},
         initElement: initElement,
-        setup: setup
+        setup: setup,
+        /**
+         * @typedef {Object} mbUserInfo
+         * @property {String|null} name
+         * @property {boolean} isAnonymous
+         * @property {Array<String>} roles
+         */
+        /**
+         * @returns {Promise<mbUserInfo>}
+         * @since v3.2.2
+         */
+        loadUserInfo: (function() {
+            // Fetch once, reuse response
+            var promise = $.getJSON('../userinfo.json').promise();
+            return function() {
+                return promise;
+            }
+        }())
     }
 }(jQuery)));
 

--- a/src/Mapbender/FrameworkBundle/Component/UserInfoProvider.php
+++ b/src/Mapbender/FrameworkBundle/Component/UserInfoProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\Component;
+
+
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Default implementation for `mapbender.user_info_provider`.
+ *
+ * If constructor is compatible, class may be respecified using the
+ * `mapbender.user_info_provider.class` container parameter.
+ *
+ * @since v3.2.2
+ */
+class UserInfoProvider
+{
+    /** @var TokenStorageInterface */
+    protected $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Must returns a cleanly JSON-serializable array
+     *
+     * @return mixed[]
+     */
+    public function getValues()
+    {
+        $token = $this->tokenStorage->getToken();
+        if ($token instanceof AnonymousToken) {
+            return array(
+                'name' => null,
+                'roles' => array(),
+                'isAnonymous' => true,
+            );
+        } else {
+            $values = array(
+                'name' => $token->getUsername(),
+                'roles' => $token->getRoleNames(),
+                'isAnonymous' => false,
+            );
+            return $values;
+        }
+    }
+}

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="mapbender.automatic_locale">true</parameter>
         <parameter key="mapbender.force_engine">null</parameter>
         <parameter key="mapbender.application_template.fallback">null</parameter>
+        <parameter key="mapbender.user_info_provider.class">Mapbender\FrameworkBundle\Component\UserInfoProvider</parameter>
     </parameters>
     <services>
         <service id="mapbender.auto_locale_listener" class="Mapbender\FrameworkBundle\EventListener\AutomaticLocaleListener">
@@ -54,6 +55,11 @@
             <!-- NOTE: argument populated by RegisterApplicationTemplatesPass -->
             <argument type="collection" />
             <argument>%mapbender.application_template.fallback%</argument>
+        </service>
+        <service id="mapbender.user_info_provider"
+                 class="%mapbender.user_info_provider.class%"
+                 lazy="true">
+            <argument type="service" id="security.token_storage" />
         </service>
         <service id="mapbender.icon_index"
                  class="Mapbender\FrameworkBundle\Component\IconIndex"


### PR DESCRIPTION
Adds a global userinfo.json url to help with user specific client-side logic.

Adds a client-side `Mapbender.loadUserInfo` method (returns a Promise-like) that will reuse the response if already fetched.

Default implementation returns a `name` (string or null for anons only), `roles` (list of strings) and a convenient `isAnonymous` boolean.

```js
Mapbender.loadUserInfo().then(function(info) {
  console.log("User info received", info);
});
```
For a fully authenticated user, the promise resolves with something like this:
```json
{
    "name": "root",
    "roles": [
        "ROLE_GROUP_TESTING-GROUP",
        "ROLE_USER"
    ],
    "isAnonymous": false
}
```
For anons, expect this:
```
{
    "name": null,
    "roles": [],
    "isAnonymous": true
}
```
