### PR TITLE
[Button] Show icon previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add responsive awareness for dialog elements with `autoOpen` enabled
 * Add collapsible collection type that displays as a bootstrap accordion in the backend with duplicate feature ([link to source](https://github.com/mapbender/mapbender/blob/a522c05de8058fcd194140bd7ce2afa9b1edb941/src/Mapbender/CoreBundle/Element/Type/CollapsibleCollectionType.php))
 * Add ability to add help texts to fields in backend. Use [`MapbenderTypeTrait::createInlineHelpText`](https://github.com/mapbender/mapbender/blob/a522c05de8058fcd194140bd7ce2afa9b1edb941/src/Mapbender/CoreBundle/Element/Type/MapbenderTypeTrait.php)
+* Show icon previews in the icon selection dropdown in the button element ([PR#1450](https://github.com/mapbender/mapbender/pull/1450))
 * [SearchRouter] fix no result filtering on "0" value
 * [SearchRouter], [WMSLoader] Fix missing visual feedback when submitting invalid form ([#1276](https://github.com/mapbender/mapbender/issues/1276))
 * [SimpleSearch] Extended simple search to handle multiple configurations switchable by a dropdown menu in frontend, to clear search by a button and to display all geometry types ([#1446](https://github.com/mapbender/mapbender/issues/1446))

--- a/src/Mapbender/CoreBundle/Component/IconPackageFa4.php
+++ b/src/Mapbender/CoreBundle/Component/IconPackageFa4.php
@@ -25,10 +25,12 @@ class IconPackageFa4 implements IconPackageInterface
             'Area ruler (FontAwesome)' => 'iconAreaRuler',
             'Feature info (FontAwesome)' => 'iconInfoActive',
             'GPS (FontAwesome)' => 'iconGps',
+            'Home (FontAwesome)' => 'iconHome',
             'Legend (FontAwesome)' => 'iconLegend',
             'Print (FontAwesome)' => 'iconPrint',
             'Search (FontAwesome)' => 'iconSearch',
             'Layer tree (FontAwesome)' => 'iconLayertree',
+            'Logout (FontAwesome)' => 'iconLogout',
             'WMS (FontAwesome)' => 'iconWms',
             'Help (FontAwesome)' => 'iconHelp',
             'Edit (FontAwesome)' => 'iconEdit',     // = formerly iconWmcEditor, iconSketch
@@ -57,8 +59,12 @@ class IconPackageFa4 implements IconPackageInterface
             case 'iconGps':
                 /** @todo FA5: confirm result is fa-map-marker-alt glyph (poked hole) */
                 $class = 'fa fas fa-map-marker-alt fa-map-marker'; break;
+            case 'iconHome':
+                $class = 'fa fas fa-home'; break;
             case 'iconLegend':
                 $class = 'fa fas fa-th-list'; break;
+            case 'iconLogout':
+                $class = 'fa fas fa-sign-out'; break;
             case 'iconPrint':
                 $class = 'fa fas fa-print'; break;
             case 'iconSearch':
@@ -99,7 +105,7 @@ class IconPackageFa4 implements IconPackageInterface
     {
         return \in_array($iconCode, $this->getChoices()) || \array_key_exists($iconCode, $this->getAliases());
     }
-    
+
     public function getAliases()
     {
         return array(

--- a/src/Mapbender/CoreBundle/Element/Type/IconClassType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/IconClassType.php
@@ -7,6 +7,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -20,6 +22,12 @@ class IconClassType extends AbstractType implements EventSubscriberInterface
         $this->iconIndex = $iconIndex;
     }
 
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['dropdown_elements_html'] = true;
+    }
+
+
     public function getParent()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
@@ -27,8 +35,12 @@ class IconClassType extends AbstractType implements EventSubscriberInterface
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $choices = $this->iconIndex->getChoices();
-        ksort($choices);
+        $choicesWithoutIcon = $this->iconIndex->getChoices();
+        ksort($choicesWithoutIcon);
+        $choices = [];
+        foreach ($choicesWithoutIcon as $label => $code) {
+            $choices[$this->iconIndex->getIconMarkup($code) . '&nbsp;&nbsp;' . $label] = $code;
+        }
 
         $resolver->setDefaults(array(
             'placeholder' => function(Options $options) {
@@ -53,7 +65,7 @@ class IconClassType extends AbstractType implements EventSubscriberInterface
             FormEvents::PRE_SET_DATA => 'preSetData',
         );
     }
-    
+
     public function preSetData(FormEvent $evt)
     {
         $value = $evt->getData();

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
@@ -38,7 +38,12 @@ $(function () {
         var $valueDisplay = $('>.dropdownValue', wrapper);
         if ($valueDisplay.hasClass('hide-value')) return;
         var $option = $('option:selected', $select).first();
-        $valueDisplay.text($option.text());
+        let text = $option.html();
+        if ($(wrapper).attr('data-html')) {
+            const parser = (new DOMParser()).parseFromString(text, 'text/html');
+            text = parser.documentElement.textContent;
+        }
+        $valueDisplay.html(text);
     }
     function installFormEvents(form) {
         var handler = function() {
@@ -113,7 +118,7 @@ $(function () {
         var val = $choice.attr('data-value');
         var opt = $('option[value="' + val.replace(/"/g, '\\"').replace(/\\/g, '\\\\') + '"]', $select);
         var $valueDisplay = $('>.dropdownValue', $dropdown);
-        if (!$valueDisplay.hasClass('hide-value')) $valueDisplay.text(opt.text());
+        if (!$valueDisplay.hasClass('hide-value')) $valueDisplay.html(opt.html());
         $select.val(opt.val());
         $select.trigger('change');
         $list.hide();

--- a/src/Mapbender/CoreBundle/Resources/views/form/fields.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/form/fields.html.twig
@@ -98,7 +98,12 @@
     {%- set _selected = get_value_choice(preferred_choices, value) | default(get_value_choice(choices, value)) -%}
     {%- set _selected = _selected | default(first_choice(preferred_choices)) | default(first_choice(choices)) -%}
     {%- if _selected -%}
-      {{ choice_translation_domain is same as(false) ? _selected.label : _selected.label|trans({}, choice_translation_domain) }}
+        {% set selectedLabel = choice_translation_domain is same as(false) ? _selected.label : _selected.label|trans({}, choice_translation_domain) %}
+        {%- if dropdown_elements_html is defined -%}
+           {{- selectedLabel | raw -}}
+        {%- else -%}
+           {{- selectedLabel -}}
+        {%- endif -%}
     {%- elseif placeholder -%}
       {{ placeholder }}
     {%- endif -%}
@@ -117,7 +122,12 @@
     {%- else -%}
     <li class="choice" data-value="{{ choice.value }}">
       {%- if choice.label -%}
-        {{- choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) -}}
+        {% set choiceLabel = choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) %}
+        {%- if dropdown_elements_html is defined -%}
+           {{- choiceLabel | raw -}}
+        {%- else -%}
+           {{- choiceLabel -}}
+        {%- endif -%}
       {%- else -%}
         &nbsp; {#- maintain height / prevent vertical collapse -#}
       {%- endif -%}
@@ -132,7 +142,7 @@
       {{- block('symfony_choice_widget_collapsed') -}}
     </div>
   {%- else -%}
-    <div class="dropdown"{%- if attr.title is defined -%} title="{{ translation_domain is same as(false) ? attr.title : attr.title|trans({}, translation_domain) }}"{%- endif -%}>
+    <div class="dropdown"{%- if attr.title is defined -%} title="{{ translation_domain is same as(false) ? attr.title : attr.title|trans({}, translation_domain) }}"{%- endif -%}{% if dropdown_elements_html is defined %} data-html="true"{% endif %}>
     {%- set attr = attr | merge({'class': ('hiddenDropdown ' ~ (attr.class | default (''))) | trim}) -%}
     {{- block('symfony_choice_widget_collapsed') -}}
     <div class="dropdownValue iconDown">


### PR DESCRIPTION
- In the Button element, show icon previews in the icon selection dropdown
- Add twig template option `dropdown_elements_html` which, when set, won't encode dropdown elements
- Add font awesome icons `home` and `sign-out`

fixes #1258 