### PR TITLE
Improve scale select and scale display elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [SearchRouter] fix no result filtering on "0" value
 * [SearchRouter], [WMSLoader] Fix missing visual feedback when submitting invalid form ([#1276](https://github.com/mapbender/mapbender/issues/1276))
 * [SimpleSearch] Extended simple search to handle multiple configurations switchable by a dropdown menu in frontend, to clear search by a button and to display all geometry types ([#1446](https://github.com/mapbender/mapbender/issues/1446))
+* [ScaleSelect], [ScaleDisplay] Format numbers with thousand separators, fix blank field in scale select, localise default prefix in scale display ([#1453](https://github.com/mapbender/mapbender/issues/1453))
 * Fix WMS and WMTS loading errors with PostgreSQL default database (correction) (#1441)
 * Fix: Show instance layer id in popover again (removed in v3.3.3, but is needed for referencing them, see [documentation](https://doc.mapbender.org/en/functions/basic/map.html#make-layer-visible) )
 * Fix: Show elements that can be floatable but don't need to as button targets ([#1446](https://github.com/mapbender/mapbender/pull/1446/commits/a522c05de8058fcd194140bd7ce2afa9b1edb941)) 

--- a/src/Mapbender/CoreBundle/Element/ScaleDisplay.php
+++ b/src/Mapbender/CoreBundle/Element/ScaleDisplay.php
@@ -35,10 +35,9 @@ class ScaleDisplay extends AbstractElementService implements FloatableElement
     public static function getDefaultConfiguration()
     {
         return array(
-            'title' => 'Scale Display',
+            'title' => self::getClassTitle(),
             'unitPrefix' => false,
-            /** @todo: fix this default value (1: nobody wants the '='; 2: translation) */
-            'scalePrefix' => 'Scale = ',
+            'scalePrefix' => 'mb.core.scaledisplay.label',
             'anchor' => 'right-bottom',
         );
     }

--- a/src/Mapbender/CoreBundle/Element/Type/ScaleDisplayAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/ScaleDisplayAdminType.php
@@ -1,22 +1,36 @@
 <?php
+
 namespace Mapbender\CoreBundle\Element\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ScaleDisplayAdminType extends AbstractType
 {
-    /**
-     * @inheritdoc
-     */
+    use MapbenderTypeTrait;
+
+    private TranslatorInterface $trans;
+
+    public function __construct(TranslatorInterface $trans)
+    {
+        $this->trans = $trans;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('scalePrefix', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('scalePrefix', 'Symfony\Component\Form\Extension\Core\Type\TextType', $this->createInlineHelpText([
                 'required' => false,
                 'trim' => false,
-            ))
-            ->add('unitPrefix', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array('required' => false))
+                'label' => 'mb.core.scaledisplay.scale_prefix',
+                'help' => 'mb.core.scaledisplay.scale_prefix.help',
+            ], $this->trans))
+            ->add('unitPrefix', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', $this->createInlineHelpText([
+                'required' => false,
+                'label' => 'mb.core.scaledisplay.unit_prefix',
+                'help' => 'mb.core.scaledisplay.unit_prefix.help',
+            ], $this->trans))
         ;
     }
 

--- a/src/Mapbender/CoreBundle/Extension/Twig/NumberExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/Twig/NumberExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Extension\Twig;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class NumberExtension extends AbstractExtension
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function getName()
+    {
+        return 'mbcore_number';
+    }
+
+    public function getFilters()
+    {
+        return array(
+            'formatted_number' => new TwigFilter('formatted_number', [$this, 'formatNumber']),
+        );
+    }
+
+    public function formatNumber($number)
+    {
+        $locale = $this->requestStack->getCurrentRequest()->getLocale();
+        return \NumberFormatter::create($locale, \NumberFormatter::DECIMAL)->format($number);
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -97,6 +97,11 @@
             <argument type="service" id="translator" />
         </service>
 
+        <service id="mapbender.form_type.scale_display_admin" class="Mapbender\CoreBundle\Element\Type\ScaleDisplayAdminType">
+            <tag name="form.type" />
+            <argument type="service" id="translator" />
+        </service>
+
         <service id="mapbender.form_type.target_element" class="Mapbender\CoreBundle\Element\Type\TargetElementType">
             <tag name="form.type" />
             <argument type="service" id="translator" />

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -130,6 +130,11 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="mapbender.twig.core.number" class="Mapbender\CoreBundle\Extension\Twig\NumberExtension">
+            <tag name="twig.extension"/>
+            <argument type="service" id="request_stack" />
+        </service>
+
         <service id="mapbender.assetic.filter.sass"
                  class="%assetic.filter.scss.class%"
                  lazy="true">

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaledisplay.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaledisplay.js
@@ -29,6 +29,7 @@
          */
         _setup: function() {
             var self = this;
+            this.$scaleSpan = $(this.element).find('span');
             $(this.mbMap.element).on('mbmapzoomchanged', function(e, data) {
                 self._updateDisplay(data.scaleExact);
             });
@@ -45,21 +46,17 @@
             var scaleText;
 
             if(this.options.unitPrefix){
-                if (scale >= 9500 && scale <= 950000) {
-                    scaleText = Math.round(scale / 1000) + "K";
+                if (scale >= 9500 && scale < 950000) {
+                    scaleText = Math.round(scale / 1000).toLocaleString() + "K";
                 } else if (scale >= 950000) {
-                    scaleText = Math.round(scale / 1000000) + "M";
+                    scaleText = Math.round(scale / 1000000).toLocaleString() + "M";
                 } else {
-                    scaleText = Math.round(scale);
+                    scaleText = Math.round(scale).toLocaleString();
                 }
             } else{
-                scaleText = Math.round(scale).toString();
+                scaleText = Math.round(scale).toLocaleString();
             }
-            var parts = ["1 : ", scaleText];
-            if (this.options.scalePrefix) {
-                parts.unshift(this.options.scalePrefix, ' ');
-            }
-            $(this.element).text(parts.join(''));
+            this.$scaleSpan.text('1 : ' + scaleText);
         },
         _autoUpdate: function() {
             this._updateDisplay(this.mbMap.getModel().getCurrentScale(false));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaleselector.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaleselector.js
@@ -63,7 +63,7 @@
          */
         _updateScale: function() {
             var scale = this.mbMap.getModel().getCurrentScale(false);
-            this.$select.val(scale).trigger('dropdown.changevisual');
+            this.$select.val(scale);
             if (!this.$select.val()) {
                 // unconfigured fractional scale
                 var $displayArea = $('.dropdownValue', this.$select.closest('.dropdown', this.element.get(0)));

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaleselector.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.scaleselector.js
@@ -67,7 +67,7 @@
             if (!this.$select.val()) {
                 // unconfigured fractional scale
                 var $displayArea = $('.dropdownValue', this.$select.closest('.dropdown', this.element.get(0)));
-                $displayArea.text(Math.round(scale));
+                $displayArea.text(Math.round(scale).toLocaleString());
             }
         },
 

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
@@ -34,16 +34,19 @@ $(function () {
         });
     }
     function updateValueDisplay(wrapper) {
-        var $select = $('select', wrapper).first();
-        var $valueDisplay = $('>.dropdownValue', wrapper);
+        const $wrapper = $(wrapper);
+        var $select = $('select', $wrapper).first();
+        var $valueDisplay = $('>.dropdownValue', $wrapper);
         if ($valueDisplay.hasClass('hide-value')) return;
         var $option = $('option:selected', $select).first();
         let text = $option.html();
-        if ($(wrapper).attr('data-html')) {
+        if ($wrapper.attr('data-html')) {
             const parser = (new DOMParser()).parseFromString(text, 'text/html');
             text = parser.documentElement.textContent;
         }
-        $valueDisplay.html(text);
+        if (text || !$wrapper.attr('data-prevent-empty')) {
+            $valueDisplay.html(text);
+        }
     }
     function installFormEvents(form) {
         var handler = function() {

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -302,6 +302,11 @@ mb:
         scale: Maßstab
         bar: Leiste
     scaledisplay:
+      label: Maßstab
+      scale_prefix: Präfix
+      scale_prefix.help:  Bezeichnung, die vor der Maßstabsangabe steht. Der Standard <code>mb.core.scaledisplay.label</code> wird als <code>Maßstab</code> in der Sprache des Benutzers gerendert.
+      unit_prefix: Maßstab abkürzen
+      unit_prefix.help: Falls aktiviert, werden Maßstabszahlen über 1.000 nicht ausgeschrieben, sondern mit nachgestelltem <code>K</code> oder <code>M</code> versehen.
       class:
         title: Maßstabsanzeige
         description: 'Der aktuelle Maßstab wird angezeigt.'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -300,6 +300,11 @@ mb:
         scale: scale
         bar: bar
     scaledisplay:
+      label: Scale
+      scale_prefix: Prefix
+      scale_prefix.help:  Description shown before the actual scale. The standard <code>mb.core.scaledisplay.label</code> is rendered as <code>Scale</code> in the user's language.
+      unit_prefix: Shorten scale
+      unit_prefix.help: If checked, scale numbers higher than 1,000 will be shortened with a postpositioned <code>K</code> or <code>M</code>.
       class:
         title: 'Scale display'
         description: 'Displays the current map scale'

--- a/src/Mapbender/CoreBundle/Resources/views/Element/scaledisplay.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/scaledisplay.html.twig
@@ -1,1 +1,1 @@
-{{scalePrefix|trans}} <span></span>
+{{scalePrefix | trans}} <span></span>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/scaleselector.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/scaleselector.html.twig
@@ -1,7 +1,7 @@
 {% if show_label %}
   <span class="labelInput">{{ title|trans }}</span>
 {% endif %}
-  <div class="dropdown numeric">
+  <div class="dropdown numeric" data-prevent-empty="true">
     <select class="hiddenDropdown">
       {%- for scale in scales -%}
         <option value="{{ scale }}">{{ scale | formatted_number }}</option>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/scaleselector.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/scaleselector.html.twig
@@ -4,7 +4,7 @@
   <div class="dropdown numeric">
     <select class="hiddenDropdown">
       {%- for scale in scales -%}
-        <option value="{{ scale }}">{{ scale }}</option>
+        <option value="{{ scale }}">{{ scale | formatted_number }}</option>
       {%- endfor -%}
     </select>
     <div class="dropdownValue iconDown"></div>

--- a/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
+++ b/src/Mapbender/ManagerBundle/Resources/public/sass/element/form.scss
@@ -31,6 +31,10 @@
     }
 }
 
+.checkbox ~ .help-text-inline {
+    margin-top: -20px;
+}
+
 .popover {
     width: 300px;
     max-width: 500px;


### PR DESCRIPTION
- Add thousand separators in all places within the two elements (using JS's [toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) and PHP's [NumberFormatter](https://www.php.net/manual/de/numberformatter.create.php))
- Fix bug where the current scale in the scale select element became blank after selecting a scale
- Make the scale prefix localisable in scale display
- Set default prefix in scale display to a localised string
- Localised backend form of scale display and added help texts