### PR TITLE
Security settings could not be saved if a user or group where access control has been previously defined is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## dev-master @ df7481c88
+## v3.3.4-RC1
 * Add Ukranian translations by sacredkesha ([PR#1442](https://github.com/mapbender/mapbender/pull/1442))
 * Enable Ukranian in locale auto-detection ([#1443](https://github.com/mapbender/mapbender/issues/1443))
 * Add configurability for Layerset initial (Layertree) selection state (use `selected: false` in YAML-defined applications)
@@ -11,11 +11,12 @@
 * [SearchRouter] fix no result filtering on "0" value
 * [SearchRouter] Zoom to feature automatically if there is only one result ([PR#1454](https://github.com/mapbender/mapbender/pull/1454))
 * [SearchRouter], [WMSLoader] Fix missing visual feedback when submitting invalid form ([#1276](https://github.com/mapbender/mapbender/issues/1276))
-* [SimpleSearch] Extended simple search to handle multiple configurations switchable by a dropdown menu in frontend, to clear search by a button and to display all geometry types ([#1446](https://github.com/mapbender/mapbender/issues/1446))
+* [SimpleSearch] Extended simple search to handle multiple configurations switchable by a dropdown menu in frontend, to clear search by a button and to display all geometry types ([PR#1446](https://github.com/mapbender/mapbender/issues/1446))
 * [ScaleSelect], [ScaleDisplay] Format numbers with thousand separators, fix blank field in scale select, localise default prefix in scale display ([#1453](https://github.com/mapbender/mapbender/issues/1453))
-* Fix WMS and WMTS loading errors with PostgreSQL default database (correction) (#1441)
+* Fix: Security settings could not be saved if a user or group where access control has been previously defined is deleted. Execute `./app/console mapbender:security:fixacl` if you already have this problem.  ([PR#1455](https://github.com/mapbender/mapbender/pull/1455))
+* Fix WMS and WMTS loading errors with PostgreSQL default database (correction) ([PR#1448](https://github.com/mapbender/mapbender/pull/1448))
 * Fix: Show instance layer id in popover again (removed in v3.3.3, but is needed for referencing them, see [documentation](https://doc.mapbender.org/en/functions/basic/map.html#make-layer-visible) )
-* Fix: Show elements that can be floatable but don't need to as button targets ([#1446](https://github.com/mapbender/mapbender/pull/1446/commits/a522c05de8058fcd194140bd7ce2afa9b1edb941)) 
+* Fix: Show elements that can be floatable but don't need to as button targets ([PR#1446](https://github.com/mapbender/mapbender/pull/1446/commits/a522c05de8058fcd194140bd7ce2afa9b1edb941)) 
 * Fix inconsistent labelling for open (dialog) automatically vs activate automatically settings
 * Fix mouse cursor behaviour on misc interactions on "Layersets" backend page
 * Fix Openlayers 7 incompatibility in print rotation control

--- a/src/FOM/UserBundle/Command/FixAceOrderCommand.php
+++ b/src/FOM/UserBundle/Command/FixAceOrderCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FOM\UserBundle\Command;
+
+use FOM\UserBundle\Service\FixAceOrderService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixAceOrderCommand extends Command
+{
+    const COMMAND = 'mapbender:security:fixacl';
+
+    private FixAceOrderService $fixAceOrderService;
+
+    public function __construct(FixAceOrderService $fixAceOrderService)
+    {
+        parent::__construct(self::COMMAND);
+        $this->fixAceOrderService = $fixAceOrderService;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Fixes the indices of access control lists')
+            ->setHelp(<<<EOT
+The (deprecated) symfony/acl-bundle has a bug that prevents an access control list (ACL) from being saved,
+when a security identify (e.g. a user) was deleted that had an entry in the component's ACL and was not the
+last one in the list. The ACL expects the ace_order column to start with zero and increase one by one,
+otherwise array indexing fails.
+For example: An application has access rights for user A, B and C. User B is deleted. Then, the acl_entries
+table will have only entries for users A (ace_order 0) and C (ace_order 2) which can't be saved anymore
+This command goes through the whole acl_entries table and resets the indices of entries where the ace_order
+contains gaps.
+EOT
+            )
+            ->setName(self::COMMAND)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->fixAceOrderService->fixAceOrder();
+        $output->writeln("Command completed.");
+        return null;
+    }
+}

--- a/src/FOM/UserBundle/Controller/GroupController.php
+++ b/src/FOM/UserBundle/Controller/GroupController.php
@@ -4,6 +4,7 @@ namespace FOM\UserBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use FOM\UserBundle\Entity\Group;
+use FOM\UserBundle\Service\FixAceOrderService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -26,9 +27,15 @@ class GroupController extends AbstractController
     /** @var MutableAclProviderInterface */
     protected $aclProvider;
 
-    public function __construct(MutableAclProviderInterface $aclProvider)
+    private FixAceOrderService $fixAceOrderService;
+
+    public function __construct(
+        MutableAclProviderInterface $aclProvider,
+        FixAceOrderService $fixAceOrderService
+    )
     {
         $this->aclProvider = $aclProvider;
+        $this->fixAceOrderService = $fixAceOrderService;
     }
 
     /**
@@ -166,6 +173,7 @@ class GroupController extends AbstractController
 
             $em->flush();
             $em->commit();
+            $this->fixAceOrderService->fixAceOrder();
         } catch(\Exception $e) {
             $em->rollback();
             $this->addFlash('error', "The group couldn't be deleted.");

--- a/src/FOM/UserBundle/Controller/UserController.php
+++ b/src/FOM/UserBundle/Controller/UserController.php
@@ -6,6 +6,7 @@ use FOM\ManagerBundle\Configuration\Route as ManagerRoute;
 use FOM\UserBundle\Component\AclManager;
 use FOM\UserBundle\Component\UserHelperService;
 use FOM\UserBundle\Entity\User;
+use FOM\UserBundle\Service\FixAceOrderService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -33,9 +34,12 @@ class UserController extends UserControllerBase
     protected $profileEntityClass;
     protected $profileTemplate;
 
+    private FixAceOrderService $fixAceOrderService;
+
     public function __construct(MutableAclProviderInterface $aclProvider,
                                 UserHelperService $userHelper,
                                 AclManager $aclManager,
+                                FixAceOrderService $fixAceOrderService,
                                 $userEntityClass,
                                 $profileEntityClass,
                                 $profileTemplate)
@@ -44,6 +48,7 @@ class UserController extends UserControllerBase
         $this->aclProvider = $aclProvider;
         $this->userHelper = $userHelper;
         $this->aclManager = $aclManager;
+        $this->fixAceOrderService = $fixAceOrderService;
         $this->profileEntityClass = $profileEntityClass;
         $this->profileTemplate = $profileTemplate;
     }
@@ -189,8 +194,6 @@ class UserController extends UserControllerBase
      * @ManagerRoute("/user/{id}/delete", methods={"POST"})
      * @param string $id
      * @return Response
-     *
-     * @todo : Delete ACEs for given user
      */
     public function deleteAction($id)
     {
@@ -223,6 +226,7 @@ class UserController extends UserControllerBase
             }
             $em->flush();
             $em->commit();
+            $this->fixAceOrderService->fixAceOrder();
             $this->addFlash('success', 'The user has been deleted.');
         } catch (\Exception $e) {
             $em->rollback();

--- a/src/FOM/UserBundle/Form/Type/UserPasswordMixinType.php
+++ b/src/FOM/UserBundle/Form/Type/UserPasswordMixinType.php
@@ -64,6 +64,7 @@ class UserPasswordMixinType extends AbstractType
                 'second_options' => array(
                     'label' => 'fom.user.registration.form.confirm_password',
                 ),
+                'options' => ['attr' => ['autocomplete' => 'new-password']],
                 'constraints' => $constraints,
             ))
         ;

--- a/src/FOM/UserBundle/Form/Type/UserType.php
+++ b/src/FOM/UserBundle/Form/Type/UserType.php
@@ -41,6 +41,7 @@ class UserType extends AbstractType
                 'label' => 'fom.user.user.container.username',
                 'attr' => array(
                     'autofocus' => true,
+                    'autocomplete' => 'off',
                 ),
                 'disabled' => !$options['allow_name_editing'],
                 'required' => $options['allow_name_editing'],

--- a/src/FOM/UserBundle/Resources/config/commands.xml
+++ b/src/FOM/UserBundle/Resources/config/commands.xml
@@ -10,5 +10,9 @@
             <argument type="service" id="fom.user_helper.service" />
             <argument>%fom.user_entity%</argument>
         </service>
+        <service id="mapbender:security:fixacl" class="FOM\UserBundle\Command\FixAceOrderCommand">
+            <tag name="console.command" />
+            <argument type="service" id="FOM\UserBundle\Service\FixAceOrderService" />
+        </service>
     </services>
 </container>

--- a/src/FOM/UserBundle/Resources/config/controllers.xml
+++ b/src/FOM/UserBundle/Resources/config/controllers.xml
@@ -7,6 +7,7 @@
                  class="FOM\UserBundle\Controller\GroupController"
                  public="true">
             <argument type="service" id="security.acl.provider" />
+            <argument type="service" id="FOM\UserBundle\Service\FixAceOrderService" />
         </service>
         <service id="FOM\UserBundle\Controller\PasswordController"
                  class="FOM\UserBundle\Controller\PasswordController"
@@ -37,12 +38,18 @@
             <argument type="service" id="fom.acl_assignment_filter" />
             <argument>%fom.user.acl_classes%</argument>
         </service>
+        <service id="FOM\UserBundle\Service\FixAceOrderService"
+                 class="FOM\UserBundle\Service\FixAceOrderService"
+                 public="true">
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
+        </service>
         <service id="FOM\UserBundle\Controller\UserController"
                  class="FOM\UserBundle\Controller\UserController"
                  public="true">
             <argument type="service" id="security.acl.provider" />
             <argument type="service" id="fom.user_helper.service" />
             <argument type="service" id="fom.acl.manager" />
+            <argument type="service" id="FOM\UserBundle\Service\FixAceOrderService" />
             <argument>%fom.user_entity%</argument>
             <argument>%fom_user.profile_entity%</argument>
             <argument>%fom_user.profile_template%</argument>

--- a/src/FOM/UserBundle/Resources/views/Group/list.html.twig
+++ b/src/FOM/UserBundle/Resources/views/Group/list.html.twig
@@ -23,7 +23,7 @@
               title="{{"fom.user.group.index.delete_group"|trans}} {{ group.title }}"
               data-url="{{ path('fom_user_group_delete', { 'id': group.id}) }}"
               data-id="{{ group.id }}"
-            ><i class="fa fas fa-times"></i></span>
+            ><i class="fa fas fa-trash-o"></i></span>
             {% endif %}
         </td>
       </tr>

--- a/src/FOM/UserBundle/Resources/views/User/list.html.twig
+++ b/src/FOM/UserBundle/Resources/views/User/list.html.twig
@@ -44,7 +44,7 @@
                 title="{{"fom.user.user.index.delete_user" | trans}}"
                 data-url="{{ path('fom_user_user_delete', { 'id': user.id}) }}"
                 data-id="{{ user.id }}"
-              ><i class="fa fas fa-times"></i></span>
+              ><i class="fa fas fa-trash-o"></i></span>
             {% endif %}
           </td>
         </tr>

--- a/src/FOM/UserBundle/Service/FixAceOrderService.php
+++ b/src/FOM/UserBundle/Service/FixAceOrderService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace FOM\UserBundle\Service;
+
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PgSQLDriver;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver as SQLiteDriver;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * The (deprecated) symfony/acl-bundle has a bug that prevents an access control list (ACL) from being saved,
+ * when a security identify (e.g. a user) was deleted that had an entry in the component's ACL and was not the
+ * last one in the list. The ACL expects the ace_order column to start with zero and increase one by one,
+ * otherwise array indexing fails.
+ * For example: An application has access rights for user A, B and C. User B is deleted. Then, the acl_entries
+ * table will have only entries for users A (ace_order 0) and C (ace_order 2) which can't be saved anymore
+ * This service goes through the whole acl_entries table and resets the indices of entries where the ace_order
+ * contains gaps.
+ */
+class FixAceOrderService
+{
+    private EntityManagerInterface $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    public function fixAceOrder(): void
+    {
+        $connection = $this->em->getConnection();
+
+        $result = $connection->executeQuery('SELECT * FROM acl_entries ORDER BY class_id, object_identity_id, ace_order')->fetchAllAssociative();
+        $previousRow = null;
+        $expectedOrder = 0;
+
+        $stmt = $connection->prepare('UPDATE acl_entries SET ace_order = :neworder WHERE id = :id');
+        foreach ($result as $row) {
+            if ($this->sameEntry($previousRow, $row)) {
+                $expectedOrder++;
+            } else {
+                $expectedOrder = 0;
+            }
+            if ($row['ace_order'] !== $expectedOrder) {
+                $stmt->bindValue(':neworder', $expectedOrder);
+                $stmt->bindValue(':id', $row['id']);
+                $stmt->executeStatement();
+            }
+            $previousRow = $row;
+        }
+    }
+
+    private function sameEntry(?array $row1, array $row2): bool
+    {
+        if ($row1 === null) return false;
+        if ($row1['class_id'] !== $row2['class_id']) return false;
+        if ($row1['object_identity_id'] !== $row2['object_identity_id']) return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
The (deprecated) symfony/acl-bundle has a bug that prevents an access control list (ACL) from being saved,
when a security identify (e.g. a user) was deleted that had an entry in the component's ACL and was not the
last one in the list. The ACL expects the ace_order column to start with zero and increase one by one,
otherwise array indexing fails.

For example: An application has access rights for user A, B and C. User B is deleted. Then, the acl_entries
table will have only entries for users A (ace_order 0) and C (ace_order 2) which can't be saved anymore.

Implemented workaround: After deleting groups or users (and after manual trigger), a service goes through the whole acl_entries table and resets the indices of entries where the ace_order contains gaps.