### PR TITLE
Fixes in LayerTree element concering sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ Features:
 * Add ability to add help texts to fields in backend. Use [`MapbenderTypeTrait::createInlineHelpText`](https://github.com/mapbender/mapbender/blob/a522c05de8058fcd194140bd7ce2afa9b1edb941/src/Mapbender/CoreBundle/Element/Type/MapbenderTypeTrait.php)
 * Show icon previews in the icon selection dropdown in the button element ([PR#1450](https://github.com/mapbender/mapbender/pull/1450))
 * Layersets are now sorted alphabetically ([PR#1452](https://github.com/mapbender/mapbender/pull/1452))
+* [LayerTree] Sorting layers is now also possible on mobile devices ([PR#1457](https://github.com/mapbender/mapbender/pull/1457))
 * [SearchRouter] Zoom to feature automatically if there is only one result ([PR#1454](https://github.com/mapbender/mapbender/pull/1454))
 * [ScaleSelect], [ScaleDisplay] Format numbers with thousand separators, fix blank field in scale select, localise default prefix in scale display ([PR#1453](https://github.com/mapbender/mapbender/pull/1453))
 * [SimpleSearch] Extended simple search to handle multiple configurations switchable by a dropdown menu in frontend, to clear search by a button and to display all geometry types ([PR#1446](https://github.com/mapbender/mapbender/pull/1446))
 
 Bugfixes:
-* Fix: Security settings could not be saved if a user or group where access control has been previously defined is deleted. Execute `./app/console mapbender:security:fixacl` if you already have this problem.  ([PR#1455](https://github.com/mapbender/mapbender/pull/1455))
+* Security settings could not be saved if a user or group where access control has been previously defined is deleted. Execute `./app/console mapbender:security:fixacl` if you already have this problem.  ([PR#1455](https://github.com/mapbender/mapbender/pull/1455))
+* Reordering layers in layertree element was not possible on devices with touch support ([PR#1457](https://github.com/mapbender/mapbender/pull/1457))
 * WMS and WMTS loading errors with PostgreSQL default database (correction) (#1441)
 * Show instance layer id in popover again (removed in v3.3.3, but is needed for referencing them, see [documentation](https://doc.mapbender.org/en/functions/basic/map.html#make-layer-visible) )
 * Show elements that can be floatable but don't need to as button targets ([#1446](https://github.com/mapbender/mapbender/pull/1446/commits/a522c05de8058fcd194140bd7ce2afa9b1edb941)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Bugfixes:
 * mouse cursor behaviour on misc interactions on "Layersets" backend page
 * Openlayers 7 incompatibility in print rotation control 
 * Instantly show/hide "No instance added" notice in layerset configuration ([PR#1458](https://github.com/mapbender/mapbender/pull/1458/commits/2452f9d1d30a2f4b55691d76b9c73729fb6777b4))
+* On Mac (all browsers) and on Firefox (all platforms) the layer tree hamburger menu was unusable when the area is scrolling ([PR#1457](https://github.com/mapbender/mapbender/pull/1457))
+* When the layer tree was used in a mobile pane the pane was closed on each checkbox toggle ([#1404](https://github.com/mapbender/mapbender/issues/1404))
 * [SearchRouter], [WMSLoader] Fix missing visual feedback when submitting invalid form ([#1276](https://github.com/mapbender/mapbender/issues/1276))
 * [SearchRouter] fix no result filtering on "0" value
 * [Sketch] Remove buggy geometry type 'text', all its features are already represented by 'point' ([PR#1456](https://github.com/mapbender/mapbender/pull/1456))

--- a/src/Mapbender/CoreBundle/Controller/ComponentsController.php
+++ b/src/Mapbender/CoreBundle/Controller/ComponentsController.php
@@ -79,7 +79,8 @@ class ComponentsController
                 $path = $this->getVendorPath() . "/components/{$packageName}";
                 break;
             case 'bootstrap-colorpicker':
-                $path = $this->getWebPath() . '/bundles/mapbendercore/bootstrap-colorpicker';
+            case 'jquery-ui-touch-punch':
+                $path = $this->getWebPath() . "/bundles/mapbendercore/{$packageName}";
                 break;
             case 'mapbender-icons':
                 $path = $this->getVendorPath() . "/mapbender/{$packageName}";

--- a/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
@@ -1,0 +1,181 @@
+/*!
+ * Original version from https://github.com/furf/jquery-ui-touch-punch/blob/master/jquery.ui.touch-punch.js
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+(function ($) {
+
+  // Detect touch support
+  $.support.touch = 'ontouchend' in document;
+
+  // Ignore browsers without touch support
+  if (!$.support.touch) {
+    return;
+  }
+
+  var mouseProto = $.ui.mouse.prototype,
+      _mouseInit = mouseProto._mouseInit,
+      _mouseDestroy = mouseProto._mouseDestroy,
+      touchHandled;
+
+  /**
+   * Simulate a mouse event based on a corresponding touch event
+   * @param {Object} event A touch event
+   * @param {String} simulatedType The corresponding mouse event
+   */
+  function simulateMouseEvent (event, simulatedType) {
+
+    // Ignore multi-touch events
+    if (event.originalEvent.touches.length > 1) {
+      return;
+    }
+
+    event.preventDefault();
+
+    var touch = event.originalEvent.changedTouches[0],
+        simulatedEvent = document.createEvent('MouseEvents');
+
+    // Initialize the simulated mouse event using the touch event's coordinates
+    simulatedEvent.initMouseEvent(
+      simulatedType,    // type
+      true,             // bubbles
+      true,             // cancelable
+      window,           // view
+      1,                // detail
+      touch.screenX,    // screenX
+      touch.screenY,    // screenY
+      touch.clientX,    // clientX
+      touch.clientY,    // clientY
+      false,            // ctrlKey
+      false,            // altKey
+      false,            // shiftKey
+      false,            // metaKey
+      0,                // button
+      null              // relatedTarget
+    );
+
+    // Dispatch the simulated event to the target element
+    event.target.dispatchEvent(simulatedEvent);
+  }
+
+  /**
+   * Handle the jQuery UI widget's touchstart events
+   * @param {Object} event The widget element's touchstart event
+   */
+  mouseProto._touchStart = function (event) {
+
+    var self = this;
+
+    // Ignore the event if another widget is already being handled
+    if (touchHandled || !self._mouseCapture(event.originalEvent.changedTouches[0])) {
+      return;
+    }
+
+    // Set the flag to prevent other widgets from inheriting the touch event
+    touchHandled = true;
+
+    // Track movement to determine if interaction was a click
+    self._touchMoved = false;
+
+    // Simulate the mouseover event
+    simulateMouseEvent(event, 'mouseover');
+
+    // Simulate the mousemove event
+    simulateMouseEvent(event, 'mousemove');
+
+    // Simulate the mousedown event
+    simulateMouseEvent(event, 'mousedown');
+  };
+
+  /**
+   * Handle the jQuery UI widget's touchmove events
+   * @param {Object} event The document's touchmove event
+   */
+  mouseProto._touchMove = function (event) {
+
+    // Ignore event if not handled
+    if (!touchHandled) {
+      return;
+    }
+
+    // Interaction was not a click
+    this._touchMoved = true;
+
+    // Simulate the mousemove event
+    simulateMouseEvent(event, 'mousemove');
+  };
+
+  /**
+   * Handle the jQuery UI widget's touchend events
+   * @param {Object} event The document's touchend event
+   */
+  mouseProto._touchEnd = function (event) {
+
+    // Ignore event if not handled
+    if (!touchHandled) {
+      return;
+    }
+
+    // Simulate the mouseup event
+    simulateMouseEvent(event, 'mouseup');
+
+    // Simulate the mouseout event
+    simulateMouseEvent(event, 'mouseout');
+
+    // If the touch interaction did not move, it should trigger a click
+    if (!this._touchMoved) {
+
+      // Simulate the click event
+      simulateMouseEvent(event, 'click');
+    }
+
+    // Unset the flag to allow other widgets to inherit the touch event
+    touchHandled = false;
+  };
+
+  /**
+   * A duck punch of the $.ui.mouse _mouseInit method to support touch events.
+   * This method extends the widget with bound touch event handlers that
+   * translate touch events to mouse events and pass them to the widget's
+   * original mouse event handling methods.
+   */
+  mouseProto._mouseInit = function () {
+
+    var self = this;
+
+    // Delegate the touch handlers to the widget's element
+    self.element.bind({
+      touchstart: $.proxy(self, '_touchStart'),
+      touchmove: $.proxy(self, '_touchMove'),
+      touchend: $.proxy(self, '_touchEnd')
+    });
+
+    // Call the original $.ui.mouse init method
+    _mouseInit.call(self);
+  };
+
+  /**
+   * Remove the touch event handlers
+   */
+  mouseProto._mouseDestroy = function () {
+
+    var self = this;
+
+    // Delegate the touch handlers to the widget's element
+    self.element.unbind({
+      touchstart: $.proxy(self, '_touchStart'),
+      touchmove: $.proxy(self, '_touchMove'),
+      touchend: $.proxy(self, '_touchEnd')
+    });
+
+    // Call the original $.ui.mouse destroy method
+    _mouseDestroy.call(self);
+  };
+
+})(jQuery);

--- a/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
@@ -12,7 +12,7 @@
 (function ($) {
 
   // Detect touch support
-  $.support.touch = 'ontouchend' in document;
+  $.support.touch = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
 
   // Ignore browsers without touch support
   if (!$.support.touch) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -16,11 +16,9 @@
         popup: null,
         _mobilePane: null,
         useDialog_: false,
-        isTouch_: false,
 
         _create: function() {
             // see https://stackoverflow.com/a/4819886
-            this.isTouch_ = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0);
             this.useDialog_ = this.checkDialogMode();
             var self = this;
             this._mobilePane = $(this.element).closest('#mobilePane').get(0) || null;
@@ -74,17 +72,16 @@
             this._reset();
         },
         _reset: function() {
-            // Prevent initializing sortable on touch devices, as it breaks touch clicks on folder toggle
-            if (this.options.allowReorder && !this.isTouch_) {
+            if (this.options.allowReorder) {
                 this._createSortable();
             }
         },
         _createEvents: function() {
             var self = this;
-            this.element.on('click', '.-fn-toggle-info:not(.disabled)', $.proxy(self._toggleInfo, self));
-            this.element.on('click', '.-fn-toggle-children', $.proxy(this._toggleFolder, this));
-            this.element.on('click', '.-fn-toggle-selected:not(.disabled)', $.proxy(self._toggleSelected, self));
-            this.element.on('click', '.layer-menu-btn', $.proxy(self._toggleMenu, self));
+            this.element.on('click', '.-fn-toggle-info:not(.disabled)', this._toggleInfo.bind(this));
+            this.element.on('click', '.-fn-toggle-children', this._toggleFolder.bind(this));
+            this.element.on('click', '.-fn-toggle-selected:not(.disabled)', this._toggleSelected.bind(this));
+            this.element.on('click', '.layer-menu-btn', this._toggleMenu.bind(this));
             this.element.on('click', '.layer-menu .exit-button', function() {
                 $(this).closest('.layer-menu').remove();
             });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -376,9 +376,7 @@
                     this.model.setSourceVisibility(source, newState);
                 }
             }
-            if (this._mobilePane) {
-                $('#mobilePaneClose', this._mobilePane).click();
-            }
+
             return false;
         },
         _toggleInfo: function(e) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -44,6 +44,12 @@
             }
             this._createEvents();
             this._trigger('ready');
+
+            const hasNonPersistentScrollbars = navigator.userAgent.indexOf('Mac') >= 0 || navigator.userAgent.indexOf('Firefox') >= 0;
+            if (hasNonPersistentScrollbars && this.element.closest('.sideContent').length) {
+                this.element.closest('.container-accordion').css('width', 'calc(100% + 15px)');
+                this.element.closest('.accordion-cell').css('padding-right', '15px');
+            }
         },
         _createTree: function() {
             var sources = this.model.getSources();

--- a/src/Mapbender/CoreBundle/Resources/views/index.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/index.html.twig
@@ -19,6 +19,7 @@
 {% block content %}{% endblock %}
 <script src="{{ asset('components/jquery/jquery.min.js')}}"></script>
 <script src="{{ asset('components/jquery-ui/jquery-ui.min.js')}}"></script>
+<script src="{{ asset('components/jquery-ui-touch-punch/jquery.ui.touch-punch.js')}}"></script>
 {% include 'MapbenderCoreBundle::cookieconsent.html.twig' %}
 {% block trans %}{% endblock %}
 {% block js %}{% endblock %}

--- a/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
+++ b/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
@@ -34,6 +34,7 @@ $toolBarBorderColor: rgba($ciColor, 0.6) !default;
   background-color: #fff;
   height: 100%;
   padding: $space $space 0 $space;
+  z-index: 3;
   .panel-content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
- Add jquery-ui-touch-punch library for touch support
- Do not close mobile pane when selecting a theme (see #1404)
- Do not disable sortable functionality in layertree when on devices that support touch

- Fix z-index of mobile pane so it is always above map elements like the simple search