### PR TITLE
Allow installation of Openlayers 7 container package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "components/bootstrap": "^3 || ^4",
         "components/jqueryui": "^1",
 
-        "mapbender/openlayers6-es5": "^0.4.3.2 || ^6.4.3.2",
+        "mapbender/openlayers6-es5": "^0.4.3.2 || ^6.4.3.2 || ^7",
         "mapbender/mapquery": "1.x"
     },
     "provide": {


### PR DESCRIPTION
Trivial composer.json dependency version unlock.

Allows updating mapbender/openlayers6-es5 to 7.* versions (presently at [7.3.0.0](https://github.com/mapbender/openlayers6-es5/releases/tag/7.3.0.0)).

Openlayers 7.3.0 contains many performance fixes and other enhancements (e.g. WebGL vector tile rendering etc).