### PR TITLE
Fix style cannot be unserialized when updating from mapbender <3.2.5 versions in PHP >= 8.2

### DIFF
--- a/src/Mapbender/WmsBundle/Component/Style.php
+++ b/src/Mapbender/WmsBundle/Component/Style.php
@@ -22,6 +22,13 @@ class Style implements MutableUrlTarget
     /** @var LegendUrl|null */
     public $legendUrl;
 
+    public function __unserialize(array $array)
+    {
+        foreach (['name', 'title', 'abstract', 'legendUrl'] as $key) {
+            if (array_key_exists($key, $array)) $this->$key = $array[$key];
+        }
+    }
+
     /**
      * Set name
      *
@@ -37,7 +44,7 @@ class Style implements MutableUrlTarget
     /**
      * Get name
      *
-     * @return string 
+     * @return string
      */
     public function getName()
     {
@@ -59,7 +66,7 @@ class Style implements MutableUrlTarget
     /**
      * Get title
      *
-     * @return string 
+     * @return string
      */
     public function getTitle()
     {
@@ -81,7 +88,7 @@ class Style implements MutableUrlTarget
     /**
      * Get abstract
      *
-     * @return string 
+     * @return string
      */
     public function getAbstract()
     {


### PR DESCRIPTION
Mapbender 3.2.5 removed properties from WmsBundle/Component/Style ([see commit](https://github.com/mapbender/mapbender/commit/f318cc6611ecfdfa6a036e6ba76d77d512ba3b2e)). The style is stored serialised in the database. PHP 8.2 does not ignore unknown properties like previous version but issues a deprecated message that symfony converts into an error (see [PHP changelog](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties)).

As a workaround, overwrite `__unserialize` and check for known properties ignoring the old ones.  