### PR TITLE
Add sourcemap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming Bugfix-Release
+* [Mapbender Development] Add source map support when in development environment ([PR#1468](https://github.com/mapbender/mapbender/pull/1468))
+
+
 ## v3.3.4
 Manual changes required during upgrade:
 * In `app/config/security.yml` add the following line at `security.firewalls.secured_area.form_login`: 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "ext-dom": "*",
         "ext-gd": "*",
         "ext-curl": "*",
+        "ext-json": "*",
         "symfony/symfony": "^4.3",
         "symfony/security-acl": "~2.8 || ~3.0",
         "symfony/acl-bundle": "^1 || ^2",

--- a/src/Mapbender/CoreBundle/Asset/Base64VLQ.php
+++ b/src/Mapbender/CoreBundle/Asset/Base64VLQ.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Based on the implementation in SCSSPHP:
+ * https://raw.githubusercontent.com/leafo/scssphp/v0.8.4/src/SourceMap/Base64VLQ.php
+ *
+ * Based on the Base 64 VLQ implementation in Closure Compiler:
+ * https://github.com/google/closure-compiler/blob/master/src/com/google/debugging/sourcemap/Base64VLQ.java
+ *
+ * Copyright 2011 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author John Lenz <johnlenz@google.com>
+ * @author Anthon Pang <anthon.pang@gmail.com>
+ */
+
+namespace Mapbender\CoreBundle\Asset;
+
+class Base64VLQ
+{
+    // A Base64 VLQ digit can represent 5 bits, so it is base-32.
+    const VLQ_BASE_SHIFT = 5;
+
+    // A mask of bits for a VLQ digit (11111), 31 decimal.
+    const VLQ_BASE_MASK = 31;
+
+    // The continuation bit is the 6th bit.
+    const VLQ_CONTINUATION_BIT = 32;
+
+    private static array $encodingMap = [
+         0 => 'A',  1 => 'B',  2 => 'C',  3 => 'D',  4 => 'E',  5 => 'F',  6 => 'G',  7 => 'H',
+         8 => 'I',  9 => 'J', 10 => 'K', 11 => 'L', 12 => 'M', 13 => 'N', 14 => 'O', 15 => 'P',
+        16 => 'Q', 17 => 'R', 18 => 'S', 19 => 'T', 20 => 'U', 21 => 'V', 22 => 'W', 23 => 'X',
+        24 => 'Y', 25 => 'Z', 26 => 'a', 27 => 'b', 28 => 'c', 29 => 'd', 30 => 'e', 31 => 'f',
+        32 => 'g', 33 => 'h', 34 => 'i', 35 => 'j', 36 => 'k', 37 => 'l', 38 => 'm', 39 => 'n',
+        40 => 'o', 41 => 'p', 42 => 'q', 43 => 'r', 44 => 's', 45 => 't', 46 => 'u', 47 => 'v',
+        48 => 'w', 49 => 'x', 50 => 'y', 51 => 'z', 52 => '0', 53 => '1', 54 => '2', 55 => '3',
+        56 => '4', 57 => '5', 58 => '6', 59 => '7', 60 => '8', 61 => '9', 62 => '+', 63 => '/',
+    ];
+
+    /**
+     * Returns the VLQ encoded value.
+     *
+     * @param integer $value
+     *
+     * @return string
+     */
+    public static function encode($value): string
+    {
+        $encoded = '';
+        $vlq = self::toVLQSigned($value);
+
+        do {
+            $digit = $vlq & self::VLQ_BASE_MASK;
+            $vlq >>= self::VLQ_BASE_SHIFT;
+
+            if ($vlq > 0) {
+                $digit |= self::VLQ_CONTINUATION_BIT;
+            }
+
+            $encoded .= self::encodeDigit($digit);
+        } while ($vlq > 0);
+
+        return $encoded;
+    }
+
+    /**
+     * Converts from a two-complement value to a value where the sign bit is
+     * is placed in the least significant bit.  For example, as decimals:
+     *   1 becomes 2 (10 binary), -1 becomes 3 (11 binary)
+     *   2 becomes 4 (100 binary), -2 becomes 5 (101 binary)
+     *
+     * @param integer $value
+     *
+     * @return integer
+     */
+    private static function toVLQSigned($value): int
+    {
+        if ($value < 0) {
+            return ((-$value) << 1) + 1;
+        }
+
+        return ($value << 1) + 0;
+    }
+
+    private static function encodeDigit($value): string
+    {
+        return self::$encodingMap[$value];
+    }
+
+}

--- a/src/Mapbender/CoreBundle/Asset/JsCompiler.php
+++ b/src/Mapbender/CoreBundle/Asset/JsCompiler.php
@@ -4,6 +4,9 @@
 namespace Mapbender\CoreBundle\Asset;
 
 
+use Assetic\Asset\FileAsset;
+use Assetic\Asset\StringAsset;
+
 /**
  * Locates and merges JavaScript assets for applications.
  * Default implementation for service mapbender.asset_compiler.js
@@ -19,9 +22,14 @@ class JsCompiler extends AssetFactoryBase
      * @param bool $debug to enable file input markers
      * @return string
      */
-    public function compile($inputs, $configSlug, $debug)
+    public function compile($inputs, $configSlug, bool $debug, ?string $sourceMapRoute)
     {
-        return $this->concatenateContents($inputs, $debug);
+        return $this->concatenateContents($inputs, $debug ? $sourceMapRoute : null);
+    }
+
+    public function compileMap($inputs)
+    {
+        return $this->createMap($inputs);
     }
 
     protected function getMigratedReferencesMapping()

--- a/src/Mapbender/CoreBundle/Asset/JsCompiler.php
+++ b/src/Mapbender/CoreBundle/Asset/JsCompiler.php
@@ -27,11 +27,6 @@ class JsCompiler extends AssetFactoryBase
         return $this->concatenateContents($inputs, $debug ? $sourceMapRoute : null);
     }
 
-    public function compileMap($inputs)
-    {
-        return $this->createMap($inputs);
-    }
-
     protected function getMigratedReferencesMapping()
     {
         return array(

--- a/src/Mapbender/CoreBundle/Asset/SourceMapBundler.php
+++ b/src/Mapbender/CoreBundle/Asset/SourceMapBundler.php
@@ -4,5 +4,98 @@ namespace Mapbender\CoreBundle\Asset;
 
 class SourceMapBundler
 {
+    private array $files = [];
+    private array $mappings = [];
+    private string $outFilename;
+
+    /** @var resource */
+    private $outFile;
+    private int $offset = 0;
+
+    public function __construct(string $sourceMapFilename)
+    {
+        $this->outFile = fopen($sourceMapFilename, 'w');
+        $this->outFilename = $sourceMapFilename;
+    }
+
+    public function addScript(string $path): self
+    {
+        $index = count($this->files);
+        $this->files[] = $path;
+
+        $data = file_get_contents($path);
+        fwrite($this->outFile, $data . "\n");
+
+        $lines = explode("\n", $data);
+        for ($i = 0; $i < count($lines); ++$i) {
+            $this->mappings[] = [
+                'gen_line' => $this->offset + $i,
+                'gen_col' => 0,
+                'src_index' => $index,
+                'src_line' => $i,
+                'src_col' => 0];
+        }
+        $this->offset += count($lines);
+        return $this;
+    }
+
+    /**
+     * creates the source map
+     * Write the output to a file and link to it in the generated source file:
+     * `/*# sourceMappingURL=$sourceFile * /`
+     */
+    public function build(): string
+    {
+        return $this->buildMap($this->outFilename);
+    }
+
+    private function buildMap(string $mapFile): string
+    {
+        return json_encode(array(
+            "version" => 3,
+            "file" => $mapFile,
+            "sourceRoot" => "",
+            "sources" => $this->files,
+            "names" => array(),
+            "mappings" => $this->generateMappings()
+        ));
+    }
+
+
+    public function generateMappings(): string
+    {
+        $mappingEncoded = array();
+
+        $last_gen_line = 0;
+        $last_src_index = 0;
+        $last_src_line = 0;
+        $last_src_col = 0;
+
+        foreach ($this->mappings as $m) {
+            $gen_line = $m['gen_line'];
+            while (++$last_gen_line < $gen_line) {
+                $mappingEncoded[] = ";";
+            }
+
+            $line_map_enc = array();
+
+            $m_enc = Base64VLQ::encode($m['gen_col']);
+            if (isset($m['src_index'])) {
+                $m_enc .= Base64VLQ::encode($m['src_index'] - $last_src_index);
+                $last_src_index = $m['src_index'];
+
+                $m_enc .= Base64VLQ::encode($m['src_line'] - $last_src_line);
+                $last_src_line = $m['src_line'];
+
+                $m_enc .= Base64VLQ::encode($m['src_col'] - $last_src_col);
+                $last_src_col = $m['src_col'];
+            }
+            $line_map_enc[] = $m_enc;
+
+            $mappingEncoded[] = implode(",", $line_map_enc) . ";";
+        }
+
+        return implode($mappingEncoded);
+    }
 
 }

--- a/src/Mapbender/CoreBundle/Asset/SourceMapBundler.php
+++ b/src/Mapbender/CoreBundle/Asset/SourceMapBundler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mapbender\CoreBundle\Asset;
+
+class SourceMapBundler
+{
+
+}

--- a/src/Mapbender/CoreBundle/Controller/AssetsController.php
+++ b/src/Mapbender/CoreBundle/Controller/AssetsController.php
@@ -44,13 +44,16 @@ class AssetsController extends YamlApplicationAwareController
     /**
      * @Route("/application/{slug}/assets/{type}",
      *     name="mapbender_core_application_assets",
-     *     requirements={"type" = "js|css|trans|map.js|map.css"})
+     *     requirements={"type" = "js|css|trans"})
+     * @Route("/application/{slug}/sourcemap/{type}",
+     *     name="mapbender_core_application_sourcemap",
+     *     requirements={"type" = "js|css|trans"})
      * @param Request $request
      * @param string $slug of Application
      * @param string $type one of 'css', 'js' or 'trans'
      * @return Response
      */
-    public function assetsAction(Request $request, $slug, $type)
+    public function assetsAction(Request $request, $slug, $type, $_route)
     {
         $cacheFile = $this->getCachePath($request, $slug, $type);
         if ($source = $this->getManagerAssetDependencies($slug)) {
@@ -78,12 +81,15 @@ class AssetsController extends YamlApplicationAwareController
             return $response;
         }
 
-        $sourceMapRoute = $this->getSourceMapRoute($type, $slug);
+        $sourceMap = $_route === 'mapbender_core_application_sourcemap';
+        $sourceMapRoute = $this->generateUrl('mapbender_core_application_sourcemap', [
+            'slug' => $slug, 'type' => $type
+        ]);
 
         if ($source instanceof Application) {
-            $content = $this->assetService->getAssetContent($source, $type, $sourceMapRoute);
+            $content = $this->assetService->getAssetContent($source, $type, $sourceMap,$sourceMapRoute);
         } else {
-            $content = $this->assetService->getBackendAssetContent($source, $type, $sourceMapRoute);
+            $content = $this->assetService->getBackendAssetContent($source, $type, $sourceMap, $sourceMapRoute);
         }
 
         if (!$this->isDebug) {
@@ -148,20 +154,5 @@ class AssetsController extends YamlApplicationAwareController
                 // Uh-oh
                 return null;
         }
-    }
-
-    private function getSourceMapRoute(string $type, string $slug): ?string
-    {
-        if ($type === 'js') {
-            return $this->generateUrl('mapbender_core_application_assets',
-                ['slug' => $slug, 'type' => 'map.js']
-            );
-        }
-        if ($type === 'css') {
-            return $this->generateUrl('mapbender_core_application_assets',
-                ['slug' => $slug, 'type' => 'map.css']
-            );
-        }
-        return null;
     }
 }


### PR DESCRIPTION
To greatly improve debugging experience in mapbender, the generated js and css files in dev mode will now provide a source map. The debug markers are removed in the process, finding them in a 5 MB, >100.000 lines file was not convenient anyway.

Limitations:
- does only work in local installations since the source files are not publicly exposed
- works in chrome, not flawlessly in firefox though. The file protocol is weakly supported there