### PR TITLE
Fix search router highlighting was reset after hovering over another item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Upcoming Bugfix-Release
+* [SearchRouter] Fix highlighting was reset after hovering over another item ([PR#1469](https://github.com/mapbender/mapbender/pull/1469))
 * [Mapbender Development] Add source map support when in development environment ([PR#1468](https://github.com/mapbender/mapbender/pull/1468))
 
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
@@ -372,7 +372,7 @@
                 })
                 .on('mouseleave', 'tbody tr', function() {
                     var feature = $(this).data('feature');
-                    var styleName = feature === this.currentFeature ? 'select' : 'default';
+                    var styleName = feature === self.currentFeature ? 'select' : 'default';
                     self._highlightFeature(feature, styleName);
                 })
             ;


### PR DESCRIPTION
Steps to reproduce:
- setup search router with different highlight styles for 'select' and 'temporary'
- Click on a search result to select it
- Hover over the item list without selecting another result
- After mouseout from the previously selected result it returned to the default selection state instead of staying in select mode