### PR TITLE
Fixes for FeatureInfo in Mobile Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Upcoming Bugfix-Release
+* [FeatureInfo][Mobile Template] Auto-activate did not work in mobile template; empty popups are now prevented when triggering the FeatureInfo via a button ([#1467](https://github.com/mapbender/mapbender/issues/1467), [PR#1471](https://github.com/mapbender/mapbender/pull/1471))
 * [SearchRouter] Fix highlighting was reset after hovering over another item ([PR#1469](https://github.com/mapbender/mapbender/pull/1469))
 * [Mapbender Development] Add source map support when in development environment ([PR#1468](https://github.com/mapbender/mapbender/pull/1468))
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.button.js
@@ -278,7 +278,8 @@
                 ;
                 if (state) {
                     var isDialog = this.targetWidget.element.closest('.contentPane').length
-                        || this.targetWidget.element.closest('.popup').length;
+                        || this.targetWidget.element.closest('.popup').length
+                        || this.targetWidget.element.closest('.mobilePane').length;
                     state = state && isDialog;
                 }
                 this._setActive(!!state);

--- a/src/Mapbender/CoreBundle/Resources/public/util.js
+++ b/src/Mapbender/CoreBundle/Resources/public/util.js
@@ -470,8 +470,12 @@ Mapbender.ElementUtil = {
      * @returns boolean
      */
     checkResponsiveVisibility: function(element) {
+        const $element = $(element);
+        // Only check for responsive visibility if the element has one of the hide classes
+        if (!$element.hasClass('hide-screentype-desktop') && !$element.hasClass('hide-screentype-mobile')) return true;
+
         // Use (non-cascaded!) applied CSS visibility rule
         // Mapbender responsive controls use display: none
-        return $(element).css('display') !== 'none';
+        return $element.css('display') !== 'none';
     }
 };

--- a/src/Mapbender/MobileBundle/Resources/public/js/mapbender.mobile.js
+++ b/src/Mapbender/MobileBundle/Resources/public/js/mapbender.mobile.js
@@ -14,7 +14,7 @@ $(function(){
         var button = $button.data('mapbenderMbButton');
         var targetId = ((button || {}).options || {}).target;
         var target = targetId && document.getElementById(targetId);
-        if (!target || !$(target).closest('.mobilePane').length) {
+        if (!target || !$(target).closest('.mobilePane').length || ($(target).data('open-mobilepane') === false)) {
             return;
         }
         e.stopImmediatePropagation();


### PR DESCRIPTION
- Feature Info now working again in mobile template. The problem here was, that `util:checkReponsiveVisibility` checked only for visibility, but not why the element was invisible. Added check for ''hide-screentype-*" classes.
- When feature info is managed via a button, it is now prevented that the mobile popup appears each time the state is toggled

fixes #1467