### PR TITLE
[Application Markup Cache] Make markup cache more configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bugfixes:
 * [SearchRouter] Fix search failed due to cached csrf tokens in production environment ([PR#1475](https://github.com/mapbender/mapbender/pull/1475))
 * [SearchRouter] Fix highlighting was reset after hovering over another item ([PR#1470](https://github.com/mapbender/mapbender/pull/1470))
 * [SearchRouter] Fix additional search properties were ignored ([#1474](https://github.com/mapbender/mapbender/issues/1474), [PR#1476](https://github.com/mapbender/mapbender/pull/1476))
+* [Application Markup Cache] Added parameter `mapbender.markup_cache.include_session_id` (default false). For details see PR description. ([PR#1481](https://github.com/mapbender/mapbender/pull/1481))
 * [Mapbender Development] Add source map support when in development environment ([PR#1468](https://github.com/mapbender/mapbender/pull/1468))
 
 

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupCache.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupCache.php
@@ -24,15 +24,19 @@ class ApplicationMarkupCache
     protected $basePath;
     protected $isDebug;
 
-    public function __construct(TokenStorageInterface $tokenStorage,
+    protected bool $includeSessionId = false;
+
+    public function __construct(TokenStorageInterface          $tokenStorage,
                                 AccessDecisionManagerInterface $accessDecisionManager,
-                                LocaleAwareInterface $localeProvider,
-                                $basePath)
+                                LocaleAwareInterface           $localeProvider,
+                                                               $basePath,
+                                bool                           $includeSessionId)
     {
         $this->accessDecisionManager = $accessDecisionManager;
         $this->tokenStorage = $tokenStorage;
         $this->localeProvider = $localeProvider;
         $this->basePath = $basePath;
+        $this->includeSessionId = $includeSessionId;
     }
 
     /**
@@ -104,6 +108,10 @@ class ApplicationMarkupCache
                 }
             }
             $parts[] = \md5(implode(';', $hashParts));
+
+            if ($this->includeSessionId) {
+                $parts[] = $request->getSession()->getId();
+            }
         }
         $name = \implode('.', $parts) . '.html';
         return $this->basePath . "/{$name}";

--- a/src/Mapbender/FrameworkBundle/Resources/config/services.xml
+++ b/src/Mapbender/FrameworkBundle/Resources/config/services.xml
@@ -8,6 +8,8 @@
         <parameter key="mapbender.force_engine">null</parameter>
         <parameter key="mapbender.application_template.fallback">null</parameter>
         <parameter key="mapbender.user_info_provider.class">Mapbender\FrameworkBundle\Component\UserInfoProvider</parameter>
+        <parameter key="mapbender.markup_cache.class">Mapbender\FrameworkBundle\Component\Renderer\ApplicationMarkupCache</parameter>
+        <parameter key="mapbender.markup_cache.include_session_id">false</parameter>
     </parameters>
     <services>
         <service id="mapbender.auto_locale_listener" class="Mapbender\FrameworkBundle\EventListener\AutomaticLocaleListener">
@@ -36,12 +38,13 @@
             <argument>%mapbender.responsive.containers%</argument>
         </service>
         <service id="mapbender.cache.application_markup"
-                 class="Mapbender\FrameworkBundle\Component\Renderer\ApplicationMarkupCache"
+                 class="%mapbender.markup_cache.class%"
                  lazy="true">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="translator" />
             <argument>%kernel.cache_dir%</argument>
+            <argument>%mapbender.markup_cache.include_session_id%</argument>
         </service>
         <service id="mapbender.cache.backend"
                  class="Mapbender\CoreBundle\Component\Cache\Backend\File"


### PR DESCRIPTION
### Added new parameter `mapbender.markup_cache.class`
default: `Mapbender\FrameworkBundle\Component\Renderer\ApplicationMarkupCache`.   
FQCN of the MarkupCache class. Change if you want to customise the class that is responsible for caching the markup of frontend applications

### Added new parameter `mapbender.markup_cache.include_session_id`
default: `false`  
The default markup cache caches an application based on application slug, locale, map engine code and element id that are visible to the user. This means however, that two people with the same rights will be delivdered the same markup. Usually that's fine, if however you display user-specific information, like their email address, in the frontend, set this new parameter to true to avoid them receiving the same markup. Note that for each user and application a file will be created on the server. Consider your application logic if you have a lot of users.