### PR TITLE
Add base dpi setting to map element to circumvent discrepancies in Mapbender and WMS resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 * Fix WMS configuration cannot be unserialized when updating from mapbender <3.2.4 versions in PHP >= 8.2 ([PR#1477](https://github.com/mapbender/mapbender/pull/1477))
 * Do not crash application after a layerset has been removed and the map element has not yet been saved ([PR#1482](https://github.com/mapbender/mapbender/pull/1482))
 * [FeatureInfo][Mobile Template] Auto-activate did not work in mobile template; empty popups are now prevented when triggering the FeatureInfo via a button ([#1467](https://github.com/mapbender/mapbender/issues/1467), [PR#1471](https://github.com/mapbender/mapbender/pull/1471))
+* [Map element] Make base dpi configurable to circumvent discrepancies in Mapbender and WMS resolutions ([PR#1485](https://github.com/mapbender/mapbender/pull/1485))
 * [LayerTree] Correctly show folder state (opened/closed) when thematic layers are active ([PR#1478](https://github.com/mapbender/mapbender/pull/1478))
 * [SearchRouter] Fix search failed due to cached csrf tokens in production environment ([PR#1475](https://github.com/mapbender/mapbender/pull/1475))
 * [SearchRouter] Fix highlighting was reset after hovering over another item ([PR#1470](https://github.com/mapbender/mapbender/pull/1470))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Bugfixes:
 * Fix WMS configuration cannot be unserialized when updating from mapbender <3.2.4 versions in PHP >= 8.2 ([PR#1477](https://github.com/mapbender/mapbender/pull/1477))
 * Do not crash application after a layerset has been removed and the map element has not yet been saved ([PR#1482](https://github.com/mapbender/mapbender/pull/1482))
 * [FeatureInfo][Mobile Template] Auto-activate did not work in mobile template; empty popups are now prevented when triggering the FeatureInfo via a button ([#1467](https://github.com/mapbender/mapbender/issues/1467), [PR#1471](https://github.com/mapbender/mapbender/pull/1471))
-* [Map element] Make base dpi configurable to circumvent discrepancies in Mapbender and WMS resolutions ([PR#1485](https://github.com/mapbender/mapbender/pull/1485))
+* [Map element] Make base dpi configurable to circumvent discrepancies in Mapbender and WMS resolutions ([PR#1486](https://github.com/mapbender/mapbender/pull/1486))
 * [LayerTree] Correctly show folder state (opened/closed) when thematic layers are active ([PR#1478](https://github.com/mapbender/mapbender/pull/1478))
 * [SearchRouter] Fix search failed due to cached csrf tokens in production environment ([PR#1475](https://github.com/mapbender/mapbender/pull/1475))
 * [SearchRouter] Fix highlighting was reset after hovering over another item ([PR#1470](https://github.com/mapbender/mapbender/pull/1470))

--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -57,6 +57,7 @@ class Map extends AbstractElementService
             'layersets' => array(),
             'srs' => 'EPSG:4326',
             'otherSrs' => array("EPSG:31466", "EPSG:31467"),
+            'base_dpi' => 96,
             'tileSize' => 512,
             'extent_max' => array(0, 40, 20, 60),
             'extent_start' => array(5, 45, 15, 55),

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -2,13 +2,28 @@
 
 namespace Mapbender\CoreBundle\Element\Type;
 
+use Mapbender\CoreBundle\Form\Type\ExtentType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MapAdminType extends AbstractType implements DataTransformerInterface
 {
+    use MapbenderTypeTrait;
+
+    private TranslatorInterface $trans;
+
+    public function __construct(TranslatorInterface $trans)
+    {
+        $this->trans = $trans;
+    }
+
+
     /**
      * @inheritdoc
      */
@@ -35,28 +50,34 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
                     'class' => 'input inputWrapper choiceExpandedSortable',
                 ),
             ))
-            ->add('tileSize', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
+            ->add('tileSize', NumberType::class, array(
                 'required' => false,
                 'label' => 'Tile size',
             ))
-            ->add('srs', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('srs', TextType::class, array(
                 'label' => 'SRS',
             ))
-            ->add('extent_max', 'Mapbender\CoreBundle\Form\Type\ExtentType', array(
+            ->add('base_dpi', NumberType::class, $this->createInlineHelpText([
+                'label' => 'mb.manager.admin.map.base_dpi',
+                'help' => 'mb.manager.admin.map.base_dpi.help',
+            ], $this->trans))
+            ->add('extent_max', ExtentType::class, $this->createInlineHelpText([
                 'label' => 'mb.manager.admin.map.max_extent',
-            ))
-            ->add('extent_start', 'Mapbender\CoreBundle\Form\Type\ExtentType', array(
+                'help' => 'mb.manager.admin.map.max_extent.help',
+            ], $this->trans))
+            ->add('extent_start', ExtentType::class, $this->createInlineHelpText([
                 'label' => 'mb.manager.admin.map.start_extent',
-            ))
-            ->add('fixedZoomSteps', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                'help' => 'mb.manager.admin.map.start_extent.help',
+            ], $this->trans))
+            ->add('fixedZoomSteps', CheckboxType::class, array(
                 'label' => 'mb.core.map.admin.fixedZoomSteps',
                 'required' => false,
             ))
-            ->add('scales', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('scales', TextType::class, array(
                 'label' => 'Scales (csv)',
                 'required' => true,
             ))
-            ->add('otherSrs', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('otherSrs', TextType::class, array(
                 'label' => 'Other SRS',
                 'required' => false,
             ))

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -97,6 +97,11 @@
             <argument type="service" id="translator" />
         </service>
 
+        <service id="mapbender.form_type.map_admin" class="Mapbender\CoreBundle\Element\Type\MapAdminType">
+            <tag name="form.type" />
+            <argument type="service" id="translator" />
+        </service>
+
         <service id="mapbender.form_type.scale_display_admin" class="Mapbender\CoreBundle\Element\Type\ScaleDisplayAdminType">
             <tag name="form.type" />
             <argument type="service" id="translator" />

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.map.js
@@ -9,7 +9,8 @@
                 yoffset: -38
             },
             srsDefs: [],
-            layersets: []
+            layersets: [],
+            baseDpi: 96,
         },
         elementUrl: null,
         model: null,
@@ -109,11 +110,12 @@
         detectDpi_: function() {
             // Auto-calculate dpi from device pixel ratio, to maintain reasonable canvas quality
             // see https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-            // Avoid calculating dpi >= 1.5*96dpi to avoid pushing (Mapproxy) caches into a resolution
+            // Avoid calculating dpi >= 1.5* (baseDpi) dpi to avoid pushing (Mapproxy) caches into a resolution
             // with too low label font size.
-            // Also avoid calculating less than 96dpi, to never perform client-side upscaling of Wms images
-            var dpr = window.devicePixelRatio || 1;
-            return 96. * Math.max(1, dpr / (1 +  Math.floor(dpr - 0.75)));
+            // Also avoid calculating less than (baseDpi) dpi, to never perform client-side upscaling of Wms images
+            const dpr = window.devicePixelRatio || 1;
+            const baseDpi = this.options.base_dpi || 96;
+            return baseDpi * Math.max(1, dpr / (1 +  Math.floor(dpr - 0.75)));
         },
         _comma_dangle_dummy: null
     });

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages.de.yml
@@ -86,8 +86,12 @@ mb:
           unreachable: 'Die Datenquelle ist nicht erreichbar'
         embedded_in_applications: '{0} Diese Datenquelle wird von keiner Anwendung genutzt|{1} Diese Datenquelle wird von einer Anwendung genutzt|]1,Inf[ Diese Datenquelle wird in %count% Anwendungen genutzt'
       map:
-        max_extent: 'Max. Extent'
-        start_extent: 'Start Extent'
+        max_extent: 'Max. Karten­ausdehnung'
+        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
+        start_extent: 'Initiale Karten­ausdehnung'
+        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
+        base_dpi: Standard-Auflösung [dpi]
+        base_dpi.help: Die Auflösung passt sich auf Basis dieses Wertes an die Auflösung des verwendeten Gerätes an.
       element:
         title: Titel
         type: Typ

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages.en.yml
@@ -88,6 +88,8 @@ mb:
       map:
         max_extent: 'Max. extent'
         start_extent: 'Start extent'
+        base_dpi: Default Resolution [dpi]
+        base_dpi.help: The resolution adapts to the screen resolution based on the configured value
       element:
         title: Title
         type: Type

--- a/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Element/map.html.twig
@@ -15,6 +15,7 @@
                 <div class="col-xs-6">{{ form_row(form.configuration.extent_max.3) }}</div>
             </div>
         </div>
+        {{ form_help(form.configuration.extent_start) }}
     </div>
     <div>
         {{ form_label(form.configuration.extent_start) }}
@@ -28,6 +29,7 @@
                 <div class="col-xs-6">{{ form_row(form.configuration.extent_start.3) }}</div>
             </div>
         </div>
+        {{ form_help(form.configuration.extent_start) }}
     </div>
     {{ form_rest(form.configuration) }}
 </div>


### PR DESCRIPTION
Mapbender did not show scale-dependent WMS layers on the map when the minimum scale is set. The layer tree shows the corresponding layer as active, but nothing was shown on map. Limit values from map files are used (no overwriting via layer settings in the MB backend).


Solution: The base resolution from Mapbender (96dpi)  did not match with the WMS layer's resolution. The base resolution is now configurable in the map element. 