### PR TITLE
[BaseSourceSwitcher] Element behaved incorrectly when "allow selected" was not set in the WMS instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bugfixes:
 * [SearchRouter] Highlighting was reset after hovering over another item ([PR#1470](https://github.com/mapbender/mapbender/pull/1470))
 * [SearchRouter] Additional search properties were ignored ([#1474](https://github.com/mapbender/mapbender/issues/1474), [PR#1476](https://github.com/mapbender/mapbender/pull/1476))
 * [Manager] Show message indicating too low max_input_vars value when editing instance layers ([PR#1491](https://github.com/mapbender/mapbender/pull/1491))
+* [BaseSourceSwitcher] Element behaved incorrectly when "allow selected" was not set in the WMS instance ([PR#1492](https://github.com/mapbender/mapbender/pull/1492))
 
 
 ## v3.3.4

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -174,13 +174,14 @@ window.Mapbender.MapModelBase = (function() {
          * @param {Mapbender.SourceLayer} layer
          * @param {boolean|null} [selected]
          * @param {boolean|null} [info]
+         * @param {boolean|null} [ignoreAllowSelectedSetting] if set to true the setting allowSelected will be ignored
          * engine-agnostic
          */
-        controlLayer: function controlLayer(layer, selected, info) {
+        controlLayer: function controlLayer(layer, selected, info, ignoreAllowSelectedSetting) {
             var updated = false;
             if (layer && selected !== null && typeof selected !== 'undefined') {
                 var selected0 = layer.options.treeOptions.selected;
-                var selectedAfter = !!selected && layer.options.treeOptions.allow.selected;
+                var selectedAfter = !!selected && (ignoreAllowSelectedSetting || layer.options.treeOptions.allow.selected);
                 updated = updated || (selected0 !== selectedAfter);
                 layer.options.treeOptions.selected = selectedAfter;
             }
@@ -277,11 +278,12 @@ window.Mapbender.MapModelBase = (function() {
         },
         /**
          * @param {Mapbender.Source} source
-         * @param {boolean} state
+         * @param {boolean} state: layer source will be set to visible if true
+         * @param {boolean} ignoreAllowSelectedSetting: if set to true the setting allowSelected will be ignored
          * engine-agnostic
          */
-        setSourceVisibility: function(source, state) {
-            this.controlLayer(source.getRootLayer(), state);
+        setSourceVisibility: function(source, state, ignoreAllowSelectedSetting) {
+            this.controlLayer(source.getRootLayer(), state, null, ignoreAllowSelectedSetting);
         },
         setSourceOpacity: function(source, opacity) {
             source.setOpacity(opacity);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.basesourceswitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.basesourceswitcher.js
@@ -117,13 +117,13 @@
             var i, self = this;
             this._highlight($menuItem, true);
             for (i = 0; i < sourcesOn.length; ++i) {
-                this.mbMap.model.setSourceVisibility(sourcesOn[i], true);
+                this.mbMap.model.setSourceVisibility(sourcesOn[i], true, true);
             }
             $others.each(function() {
                 self._highlight($(this), false);
             });
             for (i = 0; i < sourcesOff.length; ++i) {
-                this.mbMap.model.setSourceVisibility(sourcesOff[i], false);
+                this.mbMap.model.setSourceVisibility(sourcesOff[i], false, true);
             }
             this._hideMobile();
         },


### PR DESCRIPTION
If a WMS instance is configured like this

![grafik](https://github.com/mapbender/mapbender/assets/3438255/11169aa8-4c9b-4f96-910e-9658ba1d354f)

and this source is part of a BaseSourceSwitcher, it is expected to be toggled when switching between base sources. This did not work before this fix because the method responsible for activating layers did also check the "allow selected" checkbox. This checkbox should only be relevant to the layer tree but not for the base source switcher.