### PR TITLE
Prevent loop in case of non-existing Source Item in Method replaceIns…

### DIFF
--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -245,6 +245,9 @@ class Importer extends SourceLoader
         $titleMap = array();
         foreach ($instance->getLayers() as $oldInstanceLayer) {
             $sourceItem = $oldInstanceLayer->getSourceItem();
+            if (!$sourceItem) {
+                continue;
+            }
             if ($sourceItem->getName()) {
                 $nameMap += array($sourceItem->getName() => $oldInstanceLayer);
             }


### PR DESCRIPTION
…tanceLayers

This change just prevents calling a Method on NULL error in case of database inconsistencies which normally should not appear.