### PR TITLE
[LayerTree] Restore layertree configuration after source update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bugfixes:
 * [FeatureInfo][Mobile Template] Auto-activate did not work in mobile template; empty popups are now prevented when triggering the FeatureInfo via a button ([#1467](https://github.com/mapbender/mapbender/issues/1467), [PR#1471](https://github.com/mapbender/mapbender/pull/1471))
 * [Map element] Make base dpi configurable to circumvent discrepancies in Mapbender and WMS resolutions ([PR#1486](https://github.com/mapbender/mapbender/pull/1486))
 * [LayerTree] Correctly show folder state (opened/closed) when thematic layers are active ([PR#1478](https://github.com/mapbender/mapbender/pull/1478))
+* [LayerTree] Restore layertree configuration after source update ([PR#1497](https://github.com/mapbender/mapbender/pull/1497))
 * [Map element] Handle incorrect EPSG codes ([PR#1489](https://github.com/mapbender/mapbender/pull/1489))
 * [SearchRouter] Search failed due to cached csrf tokens in production environment ([PR#1475](https://github.com/mapbender/mapbender/pull/1475))
 * [SearchRouter] Highlighting was reset after hovering over another item ([PR#1470](https://github.com/mapbender/mapbender/pull/1470))

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -1098,7 +1098,7 @@ window.Mapbender.MapModelBase = (function() {
                     // Source not present in target settings => deactivate all layers
                     diff.sources.push({
                         id: fromSourceSettings.id,
-                        deactivate: fromSourceSettings.selectedIds.slice(),
+                        deactivate: fromSourceSettings.selectedLayers.slice(),
                         activate: []
                     });
                 }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -75,6 +75,7 @@ window.Mapbender.MapModelBase = (function() {
                 }
             } catch (e) {
                 console.error("Restoration of local storage source selection settings failed, ignoring");
+                throw e;
             }
         }
     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -197,12 +197,13 @@ window.Mapbender.Source = (function() {
          * @return {SourceSettingsDiff|null}
          */
         diffSettings: function(from, to) {
-            var toIds = to.selectedLayers.map(l => l.options.id);
-            var fromIds = from.selectedLayers.map(l => l.options.id);
-
             var diff = {
-                activate: toIds.filter(id => !fromIds.includes(id)),
-                deactivate: fromIds.filter(id => !toIds.includes(id)),
+                activate: to.selectedLayers.filter(function(layer) {
+                    return -1 === from.selectedLayers.findIndex(fromLayer => fromLayer.options.id === layer.options.id);
+                }),
+                deactivate: from.selectedLayers.filter(function(layer) {
+                    return -1 === to.selectedLayers.findIndex(toLayer => toLayer.options.id === layer.options.id);
+                })
             };
             if (to.opacity !== from.opacity) {
                 diff.opacity = to.opacity
@@ -226,11 +227,13 @@ window.Mapbender.Source = (function() {
             if (typeof (diff.opacity) !== 'undefined') {
                 settings.opacity = diff.opacity;
             }
-            settings.selectedLayers = settings.selectedLayers.filter(layer =>
-                ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id) === -1);
+            settings.selectedLayers = settings.selectedLayers.filter(function(layer) {
+                return -1 === ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id);
+            });
             settings.selectedLayers = settings.selectedLayers.concat((diff || {}).activate || []);
             return settings;
         },
+
         checkRecreateOnSrsSwitch: function(oldProj, newProj) {
             return this.recreateOnSrsSwitch;
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -197,13 +197,12 @@ window.Mapbender.Source = (function() {
          * @return {SourceSettingsDiff|null}
          */
         diffSettings: function(from, to) {
+            var toIds = to.selectedLayers.map(l => l.options.id);
+            var fromIds = from.selectedLayers.map(l => l.options.id);
+
             var diff = {
-                activate: to.selectedLayers.filter(function(layer) {
-                    return -1 === from.selectedLayers.findIndex(fromLayer => fromLayer.options.id === layer.options.id);
-                }),
-                deactivate: from.selectedLayers.filter(function(layer) {
-                    return -1 === to.selectedLayers.findIndex(toLayer => toLayer.options.id === layer.options.id);
-                })
+                activate: toIds.filter(id => !fromIds.includes(id)),
+                deactivate: fromIds.filter(id => !toIds.includes(id)),
             };
             if (to.opacity !== from.opacity) {
                 diff.opacity = to.opacity
@@ -227,13 +226,11 @@ window.Mapbender.Source = (function() {
             if (typeof (diff.opacity) !== 'undefined') {
                 settings.opacity = diff.opacity;
             }
-            settings.selectedLayers = settings.selectedLayers.filter(function(layer) {
-                return -1 === ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id);
-            });
+            settings.selectedLayers = settings.selectedLayers.filter(layer =>
+                ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id) === -1);
             settings.selectedLayers = settings.selectedLayers.concat((diff || {}).activate || []);
             return settings;
         },
-
         checkRecreateOnSrsSwitch: function(oldProj, newProj) {
             return this.recreateOnSrsSwitch;
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -199,10 +199,17 @@ window.Mapbender.Source = (function() {
         diffSettings: function(from, to) {
             var diff = {
                 activate: (to.selectedLayers || []).filter(function(layer) {
-                    return -1 === (from.selectedLayers || []).findIndex(fromLayer => fromLayer.options.id === layer.options.id);
+                    return (from.selectedLayers || []).findIndex(fromLayer =>
+                        fromLayer.options.id === layer.options.id ||
+                        fromLayer.options.name === layer.options.name
+                    ) === -1;
                 }),
+
                 deactivate: (from.selectedLayers || []).filter(function(layer) {
-                    return -1 === (to.selectedLayers || []).findIndex(toLayer => toLayer.options.id === layer.options.id);
+                    return (to.selectedLayers || []).findIndex(toLayer =>
+                        toLayer.options.id === layer.options.id ||
+                        toLayer.options.name === layer.options.name
+                    ) === -1;
                 })
             };
             if (to.opacity !== from.opacity) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -198,11 +198,11 @@ window.Mapbender.Source = (function() {
          */
         diffSettings: function(from, to) {
             var diff = {
-                activate: to.selectedLayers.filter(function(layer) {
-                    return -1 === from.selectedLayers.findIndex(fromLayer => fromLayer.options.id === layer.options.id);
+                activate: (to.selectedLayers || []).filter(function(layer) {
+                    return -1 === (from.selectedLayers || []).findIndex(fromLayer => fromLayer.options.id === layer.options.id);
                 }),
-                deactivate: from.selectedLayers.filter(function(layer) {
-                    return -1 === to.selectedLayers.findIndex(toLayer => toLayer.options.id === layer.options.id);
+                deactivate: (from.selectedLayers || []).filter(function(layer) {
+                    return -1 === (to.selectedLayers || []).findIndex(toLayer => toLayer.options.id === layer.options.id);
                 })
             };
             if (to.opacity !== from.opacity) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -8,7 +8,7 @@
 /**
  * @typedef {Object} SourceSettings
  * @property {Number} opacity
- * @property {Array<String>} selectedLayers
+ * @property {Array<{id: Number, name: String}>} selectedLayers
  */
 /**
  * @typedef {Object} SourceSettingsDiff
@@ -19,18 +19,19 @@
 
 window.Mapbender = Mapbender || {};
 
-window.Mapbender.LayerGroup = (function() {
+window.Mapbender.LayerGroup = (function () {
     function LayerGroup(title, parent) {
         this.title_ = title;
         this.parent = parent || null;
         this.children = [];
         this.siblings = [this];
     }
+
     Object.assign(LayerGroup.prototype, {
-        getTitle: function() {
+        getTitle: function () {
             return this.title_;
         },
-        getActive: function() {
+        getActive: function () {
             var active = this.getSelected();
             var parent = this.parent;
             while (parent && active) {
@@ -43,11 +44,11 @@ window.Mapbender.LayerGroup = (function() {
          * @return Boolean
          * @abstract
          */
-        getSelected: function() {
+        getSelected: function () {
             throw new Error("Invoked abstract LayerGroup.getSelected");
         },
-        removeChild: function(child) {
-            [this.children, this.siblings].forEach(function(list) {
+        removeChild: function (child) {
+            [this.children, this.siblings].forEach(function (list) {
                 var index = list.indexOf(child);
                 if (-1 !== index) {
                     list.splice(index, 1);
@@ -58,30 +59,31 @@ window.Mapbender.LayerGroup = (function() {
     return LayerGroup;
 })();
 
-window.Mapbender.Layerset = (function() {
+window.Mapbender.Layerset = (function () {
     function Layerset(title, id, selected) {
         Mapbender.LayerGroup.call(this, title, null);
         this.id = id;
         this.selected = selected;
     }
+
     Layerset.prototype = Object.create(Mapbender.LayerGroup.prototype);
     Object.assign(Layerset.prototype, {
         constructor: Layerset,
-        getId: function() {
+        getId: function () {
             return this.id;
         },
-        getSelected: function() {
+        getSelected: function () {
             return this.selected;
         },
-        setSelected: function(state) {
+        setSelected: function (state) {
             this.selected = !!state;
         },
-        getSettings: function() {
+        getSettings: function () {
             return {
                 selected: this.getSelected()
             };
         },
-        applySettings: function(settings) {
+        applySettings: function (settings) {
             var dirty = settings.selected !== this.selected;
             this.setSelected(settings.selected);
             return dirty;
@@ -90,7 +92,7 @@ window.Mapbender.Layerset = (function() {
     return Layerset;
 })();
 
-window.Mapbender.Source = (function() {
+window.Mapbender.Source = (function () {
     function Source(definition) {
         Mapbender.LayerGroup.call(this, definition.title, null);
         if (definition.id || definition.id === 0) {
@@ -100,18 +102,19 @@ window.Mapbender.Source = (function() {
         this.configuration = definition.configuration;
         this.wmsloader = definition.wmsloader;
         var sourceArg = this;
-        this.configuration.children = (this.configuration.children || []).map(function(childDef) {
+        this.configuration.children = (this.configuration.children || []).map(function (childDef) {
             return Mapbender.SourceLayer.factory(childDef, sourceArg, null)
         });
         this.children = this.configuration.children;
         this.configuredSettings_ = this.getSettings();
     }
+
     Source.typeMap = {};
     /**
      * @param {*} definition
      * @returns {Mapbender.Source}
      */
-    Source.factory = function(definition) {
+    Source.factory = function (definition) {
         var typeClass = Source.typeMap[definition.type];
         if (!typeClass) {
             typeClass = Source;
@@ -126,7 +129,7 @@ window.Mapbender.Source = (function() {
          * @param {Object} [mapOptions]
          * @return {Array<Object>}
          */
-        createNativeLayers: function(srsName, mapOptions) {
+        createNativeLayers: function (srsName, mapOptions) {
             console.error("Layer creation not implemented", this);
             throw new Error("Layer creation not implemented");
         },
@@ -135,11 +138,11 @@ window.Mapbender.Source = (function() {
          * @param {Object} [mapOptions]
          * @return {Array<Object>}
          */
-        initializeLayers: function(srsName, mapOptions) {
+        initializeLayers: function (srsName, mapOptions) {
             this.nativeLayers = this.createNativeLayers(srsName, mapOptions);
             return this.nativeLayers;
         },
-        getActive: function() {
+        getActive: function () {
             var upstream = Mapbender.LayerGroup.prototype.getActive.call(this);
             // NOTE: (only) WmsLoader sources don't have a layerset
             return upstream && (!this.layerset || this.layerset.getSelected());
@@ -151,30 +154,30 @@ window.Mapbender.Source = (function() {
         nativeLayers: [],
         recreateOnSrsSwitch: false,
         wmsloader: false,
-        destroyLayers: function(olMap) {
+        destroyLayers: function (olMap) {
             if (this.nativeLayers && this.nativeLayers.length) {
-                this.nativeLayers.map(function(olLayer) {
+                this.nativeLayers.map(function (olLayer) {
                     Mapbender.mapEngine.destroyLayer(olMap, olLayer);
                 });
             }
             this.nativeLayers = [];
         },
-        getNativeLayers: function() {
+        getNativeLayers: function () {
             return this.nativeLayers.slice();
         },
-        getSettings: function() {
+        getSettings: function () {
             return {
                 opacity: this.configuration.options.opacity
             };
         },
-        getConfiguredSettings: function() {
+        getConfiguredSettings: function () {
             return Object.assign({}, this.configuredSettings_);
         },
         /**
          * @param {SourceSettings} settings
          * @return {boolean}
          */
-        applySettings: function(settings) {
+        applySettings: function (settings) {
             var diff = this.diffSettings(this.getSettings(), settings);
             if (diff) {
                 this.applySettingsDiff(diff);
@@ -186,7 +189,7 @@ window.Mapbender.Source = (function() {
         /**
          * @param {SourceSettingsDiff} diff
          */
-        applySettingsDiff: function(diff) {
+        applySettingsDiff: function (diff) {
             if (diff && typeof (diff.opacity) !== 'undefined') {
                 this.setOpacity(diff.opacity);
             }
@@ -196,30 +199,46 @@ window.Mapbender.Source = (function() {
          * @param {SourceSettings} to
          * @return {SourceSettingsDiff|null}
          */
-        diffSettings: function(from, to) {
-            var diff = {
-                activate: (to.selectedLayers || []).filter(function(layer) {
-                    return (from.selectedLayers || []).findIndex(fromLayer =>
-                        fromLayer.options.id === layer.options.id ||
-                        fromLayer.options.name === layer.options.name
-                    ) === -1;
-                }),
+        diffSettings: function (from, to) {
+            // before v4, only the selectedIds were saved as an array.
+            // since v4, an object with id and name is saved are saved encapsulated as an array of objects to
+            // check for selectedIds for backwards compatibility
+            // @todo for v5: Remove check
+            const diff = to.hasOwnProperty('selectedIds') ?
+                {
+                    activate: to.selectedIds.filter(function (id) {
+                        return (from.selectedLayers || []).findIndex(fromLayer =>
+                            fromLayer.id === id
+                        ) === -1;
+                    }),
+                    deactivate: (from.selectedLayers || []).filter(function (layer) {
+                        return -1 === to.selectedIds.indexOf(layer.id);
+                    })
+                } :
+                {
+                    activate: (to.selectedLayers || []).filter(function (layer) {
+                        return (from.selectedLayers || []).findIndex(fromLayer =>
+                            fromLayer.id === layer.id ||
+                            fromLayer.name === layer.name
+                        ) === -1;
+                    }),
 
-                deactivate: (from.selectedLayers || []).filter(function(layer) {
-                    return (to.selectedLayers || []).findIndex(toLayer =>
-                        toLayer.options.id === layer.options.id ||
-                        toLayer.options.name === layer.options.name
-                    ) === -1;
-                })
-            };
+                    deactivate: (from.selectedLayers || []).filter(function (layer) {
+                        return (to.selectedLayers || []).findIndex(toLayer =>
+                            toLayer.id === layer.id ||
+                            toLayer.name === layer.name
+                        ) === -1;
+                    })
+                };
+
             if (to.opacity !== from.opacity) {
                 diff.opacity = to.opacity
             }
             if (!diff.activate.length) {
-                delete(diff.activate);
+                delete (diff.activate);
             }
             if (!diff.deactivate.length) {
-                delete(diff.deactivate);
+                delete (diff.deactivate);
             }
             // null if completely empty
             return Object.keys(diff).length && diff || null;
@@ -229,26 +248,26 @@ window.Mapbender.Source = (function() {
          * @param {SourceSettingsDiff} diff
          * @return {SourceSettings}
          */
-        mergeSettings: function(base, diff) {
+        mergeSettings: function (base, diff) {
             var settings = Object.assign({}, base);
             if (typeof (diff.opacity) !== 'undefined') {
                 settings.opacity = diff.opacity;
             }
-            settings.selectedLayers = settings.selectedLayers.filter(function(layer) {
+            settings.selectedLayers = settings.selectedLayers.filter(function (layer) {
                 return -1 === ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id);
             });
             settings.selectedLayers = settings.selectedLayers.concat((diff || {}).activate || []);
             return settings;
         },
 
-        checkRecreateOnSrsSwitch: function(oldProj, newProj) {
+        checkRecreateOnSrsSwitch: function (oldProj, newProj) {
             return this.recreateOnSrsSwitch;
         },
-        getNativeLayer: function(index) {
-            var layer =  this.nativeLayers[index || 0] || null;
+        getNativeLayer: function (index) {
+            var layer = this.nativeLayers[index || 0] || null;
             var c = this.nativeLayers.length;
             if (typeof index === 'undefined' && c !== 1) {
-                console.warn("Mapbender.Source.getNativeLayer called on a source with flexible layer count; currently "  + c + " native layers");
+                console.warn("Mapbender.Source.getNativeLayer called on a source with flexible layer count; currently " + c + " native layers");
             }
             return layer;
         },
@@ -256,9 +275,9 @@ window.Mapbender.Source = (function() {
          * @param {string} id
          * @return {SourceLayer}
          */
-        getLayerById: function(id) {
+        getLayerById: function (id) {
             var foundLayer = null;
-            Mapbender.Util.SourceTree.iterateLayers(this, false, function(sourceLayer) {
+            Mapbender.Util.SourceTree.iterateLayers(this, false, function (sourceLayer) {
                 if (sourceLayer.options.id === id) {
                     foundLayer = sourceLayer;
                     // abort iteration
@@ -267,10 +286,10 @@ window.Mapbender.Source = (function() {
             });
             return foundLayer;
         },
-        getRootLayer: function() {
+        getRootLayer: function () {
             return this.configuration.children[0];
         },
-        _reduceBboxMap: function(bboxMap, projCode) {
+        _reduceBboxMap: function (bboxMap, projCode) {
             if (bboxMap && Object.keys(bboxMap).length) {
                 if (projCode) {
                     if (bboxMap[projCode]) {
@@ -284,7 +303,7 @@ window.Mapbender.Source = (function() {
             }
             return null;
         },
-        getLayerBounds: function(layerId, projCode, inheritFromParent) {
+        getLayerBounds: function (layerId, projCode, inheritFromParent) {
             var layer;
             if (layerId) {
                 layer = this.getLayerById(layerId);
@@ -298,16 +317,16 @@ window.Mapbender.Source = (function() {
             }
             return layer.getBounds(projCode, inheritFromParent) || null;
         },
-        setOpacity: function(value) {
+        setOpacity: function (value) {
             this.configuration.options.opacity = value;
-            this.nativeLayers.map(function(layer) {
+            this.nativeLayers.map(function (layer) {
                 layer.setOpacity(value);
             });
         },
-        _bboxArrayToBounds: function(bboxArray, projCode) {
+        _bboxArrayToBounds: function (bboxArray, projCode) {
             return Mapbender.mapEngine.boundsFromArray(bboxArray);
         },
-        _getPrintBaseOptions: function() {
+        _getPrintBaseOptions: function () {
             return {
                 type: this.configuration.type,
                 sourceId: this.id,
@@ -317,7 +336,7 @@ window.Mapbender.Source = (function() {
         },
         // Custom toJSON for mbMap.getMapState()
         // Drops nativeLayers to avoid circular references
-        toJSON: function() {
+        toJSON: function () {
             return {
                 id: this.id,
                 title: this.title,
@@ -329,7 +348,7 @@ window.Mapbender.Source = (function() {
     return Source;
 }());
 
-window.Mapbender.SourceLayer = (function() {
+window.Mapbender.SourceLayer = (function () {
     function SourceLayer(definition, source, parent) {
         Mapbender.LayerGroup.call(this, ((definition || {}).options || {}).title || '', parent)
         this.options = definition.options || {};
@@ -345,11 +364,12 @@ window.Mapbender.SourceLayer = (function() {
         }
         this.siblings = [this];
     }
+
     SourceLayer.prototype = Object.create(Mapbender.LayerGroup.prototype);
     Object.assign(SourceLayer.prototype, {
         constructor: SourceLayer,
         // need custom toJSON for getMapState call
-        toJSON: function() {
+        toJSON: function () {
             // Skip the circular-ref inducing properties 'siblings', 'parent' and 'source'
             var r = {
                 options: this.options,
@@ -360,10 +380,10 @@ window.Mapbender.SourceLayer = (function() {
             }
             return r;
         },
-        getParent: function() {
+        getParent: function () {
             return this.parent;
         },
-        remove: function() {
+        remove: function () {
             var index = this.siblings.indexOf(this);
             if (index !== -1) {
                 this.siblings.splice(index, 1);
@@ -376,7 +396,7 @@ window.Mapbender.SourceLayer = (function() {
                 return null;
             }
         },
-        getBounds: function(projCode, inheritFromParent) {
+        getBounds: function (projCode, inheritFromParent) {
             var bboxMap = this.options.bbox;
             var srsOrder = [projCode].concat(Object.keys(bboxMap));
             for (var i = 0; i < srsOrder.length; ++i) {
@@ -393,7 +413,7 @@ window.Mapbender.SourceLayer = (function() {
             }
             return null;
         },
-        hasBounds: function() {
+        hasBounds: function () {
             var layer = this;
             do {
                 if (Object.keys(layer.options.bbox).length) {
@@ -405,7 +425,7 @@ window.Mapbender.SourceLayer = (function() {
         }
     });
     SourceLayer.typeMap = {};
-    SourceLayer.factory = function(definition, source, parent) {
+    SourceLayer.factory = function (definition, source, parent) {
         var typeClass = SourceLayer.typeMap[source.type];
         if (!typeClass) {
             typeClass = SourceLayer;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -8,7 +8,7 @@
 /**
  * @typedef {Object} SourceSettings
  * @property {Number} opacity
- * @property {Array<String>} selectedIds
+ * @property {Array<String>} selectedLayers
  */
 /**
  * @typedef {Object} SourceSettingsDiff
@@ -198,11 +198,11 @@ window.Mapbender.Source = (function() {
          */
         diffSettings: function(from, to) {
             var diff = {
-                activate: to.selectedIds.filter(function(id) {
-                    return -1 === from.selectedIds.indexOf(id);
+                activate: to.selectedLayers.filter(function(layer) {
+                    return -1 === from.selectedLayers.findIndex(fromLayer => fromLayer.options.id === layer.options.id);
                 }),
-                deactivate: from.selectedIds.filter(function(id) {
-                    return -1 === to.selectedIds.indexOf(id);
+                deactivate: from.selectedLayers.filter(function(layer) {
+                    return -1 === to.selectedLayers.findIndex(toLayer => toLayer.options.id === layer.options.id);
                 })
             };
             if (to.opacity !== from.opacity) {
@@ -227,12 +227,13 @@ window.Mapbender.Source = (function() {
             if (typeof (diff.opacity) !== 'undefined') {
                 settings.opacity = diff.opacity;
             }
-            settings.selectedIds = settings.selectedIds.filter(function(id) {
-                return -1 === ((diff || {}).deactivate || []).indexOf(id);
+            settings.selectedLayers = settings.selectedLayers.filter(function(layer) {
+                return -1 === ((diff || {}).deactivate || []).findIndex(diffLayer => diffLayer.options.id === layer.options.id);
             });
-            settings.selectedIds = settings.selectedIds.concat((diff || {}).activate || []);
+            settings.selectedLayers = settings.selectedLayers.concat((diff || {}).activate || []);
             return settings;
         },
+
         checkRecreateOnSrsSwitch: function(oldProj, newProj) {
             return this.recreateOnSrsSwitch;
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -13,8 +13,8 @@
 /**
  * @typedef {Object} SourceSettingsDiff
  * @property {Number} [opacity]
- * @property {Array<String>} [activate]
- * @property {Array<String>} [deactivate]
+ * @property {Array<Object>} [activate]
+ * @property {Array<Object>} [deactivate]
  */
 
 window.Mapbender = Mapbender || {};

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -107,15 +107,13 @@ window.Mapbender.WmsSource = (function() {
             const isDiffValid = diff && ((diff.activate || []).length || (diff.deactivate || []).length);
             if (!isDiffValid) return;
 
-            const notifyWarning = (layer, hits) => {
-                if (hits.length > 1) {
-                    const name = layer.getName();
-                    $.notify(`Layer '${name}': There seems to be a misconception in the underlying map service of this layer. The layer is at least twice defined`);
-                }
+            const notifyWarning = (layer) => {
+                const name = layer.getName();
+                $.notify(`Layer '${name}': There seems to be a misconception in the underlying map service of this layer. The layer is at least twice defined`);
             }
 
-            const filterAction = (layer, action, parents) => {
-                return action.filter(l => {
+            const findAction = (layer, action, parents) => {
+                return action.find(l => {
                     const foundById = l.options.id == layer.getId();
                     const foundByName = l.options.name == layer.getName();
                     if (!foundById && foundByName) {
@@ -127,17 +125,17 @@ window.Mapbender.WmsSource = (function() {
             };
 
             Mapbender.Util.SourceTree.iterateLayers(this, false, function(layer, index, parents) {
-                let activateHits = filterAction(layer, diff.activate || [], parents);
-                if (activateHits.length >= 1) {
-                    activateHits[0].found = true;
+                let activateHit = findAction(layer, diff.activate || [], parents);
+                if (activateHit) {
+                    activateHit.found = true;
                     layer.setSelected(true);
-                    notifyWarning(layer, activateHits);
+                    notifyWarning(layer);
                 }
-                let deactivateHits = filterAction(layer, diff.deactivate || [], parents);
-                if (deactivateHits.length >= 1) {
-                    deactivateHits[0].found = true;
+                let deactivateHit = findAction(layer, diff.deactivate || [], parents);
+                if (deactivateHit) {
+                    deactivateHit.found = true;
                     layer.setSelected(false);
-                    notifyWarning(layer, deactivateHits);
+                    notifyWarning(layer);
                 }
             });
 

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -91,11 +91,8 @@ window.Mapbender.WmsSource = (function() {
          */
         getSettings: function() {
             var selectedLayers = this.configuration.children[0].getSelectedList();
-            var selectedIds = selectedLayers.map(function(layer) {
-                return layer.getId();
-            });
             return Object.assign(Mapbender.Source.prototype.getSettings.call(this), {
-                selectedIds: selectedIds
+                selectedLayers: selectedLayers
             });
         },
         /**

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -102,10 +102,12 @@ window.Mapbender.WmsSource = (function() {
             Mapbender.Source.prototype.applySettingsDiff.call(this, diff);
             if (diff && ((diff.activate || []).length || (diff.deactivate || []).length)) {
                 Mapbender.Util.SourceTree.iterateLayers(this, false, function(layer) {
-                    if (-1 !== (diff.activate || []).indexOf(layer.getId())) {
+                    let activated_ids = (diff.activate || []).map(l=>l.options.id);
+                    let deactivated_ids = (diff.deactivate || []).map(l=>l.options.id);
+                    if (-1 !== (activated_ids).indexOf(layer.getId())) {
                         layer.setSelected(true);
                     }
-                    if (-1 !== (diff.deactivate || []).indexOf(layer.getId())) {
+                    if (-1 !== (deactivated_ids).indexOf(layer.getId())) {
                         layer.setSelected(false);
                     }
                 });

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -101,16 +101,29 @@ window.Mapbender.WmsSource = (function() {
         applySettingsDiff: function(diff) {
             Mapbender.Source.prototype.applySettingsDiff.call(this, diff);
             if (diff && ((diff.activate || []).length || (diff.deactivate || []).length)) {
+                let activated_ids = (diff.activate || []).map(l=>l.options.id);
+                let deactivated_ids = (diff.deactivate || []).map(l=>l.options.id);
+
                 Mapbender.Util.SourceTree.iterateLayers(this, false, function(layer) {
-                    let activated_ids = (diff.activate || []).map(l=>l.options.id);
-                    let deactivated_ids = (diff.deactivate || []).map(l=>l.options.id);
-                    if (-1 !== (activated_ids).indexOf(layer.getId())) {
+
+                    let index_activated = activated_ids.indexOf(layer.getId());
+                    if (-1 !== index_activated) {
+                        activated_ids.splice(index_activated,1);
                         layer.setSelected(true);
                     }
-                    if (-1 !== (deactivated_ids).indexOf(layer.getId())) {
+                    let index_deactivated = deactivated_ids.indexOf(layer.getId());
+                    if (-1 !== index_deactivated) {
+                        deactivated_ids.splice(index_deactivated,1);
                         layer.setSelected(false);
                     }
                 });
+
+                if (activated_ids.length > 0) {
+                    console.error("Invalid activate ids left",activated_ids);
+                }
+                if (deactivated_ids.length > 0) {
+                    console.error("Invalid deactivate ids left",deactivated_ids);
+                }
             }
         },
         getSelected: function() {

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -133,7 +133,7 @@ window.Mapbender.WmsSource = (function() {
                     layer.setSelected(true);
                     notifyWarning(layer, activateHits);
                 }
-                let deactivateHits = filterAction(layer, diff.deactivate || []);
+                let deactivateHits = filterAction(layer, diff.deactivate || [], parents);
                 if (deactivateHits.length >= 1) {
                     deactivateHits[0].found = true;
                     layer.setSelected(false);

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -1,26 +1,26 @@
-
 window.Mapbender = Mapbender || {};
-window.Mapbender.WmsSourceLayer = (function() {
+window.Mapbender.WmsSourceLayer = (function () {
     function WmsSourceLayer() {
         Mapbender.SourceLayer.apply(this, arguments);
     }
+
     Mapbender.SourceLayer.typeMap['wms'] = WmsSourceLayer;
     WmsSourceLayer.prototype = Object.create(Mapbender.SourceLayer.prototype);
     Object.assign(WmsSourceLayer.prototype, {
         constructor: WmsSourceLayer,
-        getId: function() {
+        getId: function () {
             return this.options.id;
         },
-        getName: function() {
+        getName: function () {
             return this.options.name;
         },
-        getSelected: function() {
+        getSelected: function () {
             return this.options.treeOptions.selected;
         },
-        setSelected: function(state) {
+        setSelected: function (state) {
             this.options.treeOptions.selected = !!state;
         },
-        getSelectedList: function() {
+        getSelectedList: function () {
             var selectedLayers = [];
             if (this.getSelected()) {
                 selectedLayers.push(this);
@@ -30,7 +30,7 @@ window.Mapbender.WmsSourceLayer = (function() {
             }
             return selectedLayers;
         },
-        isInScale: function(scale) {
+        isInScale: function (scale) {
             // NOTE: undefined / "open" limits are null, but it's safe to treat zero and null
             //       equivalently
             var min = this.options.minScale;
@@ -41,7 +41,7 @@ window.Mapbender.WmsSourceLayer = (function() {
                 return !(max && max < scale);
             }
         },
-        intersectsExtent: function(extent, srsName) {
+        intersectsExtent: function (extent, srsName) {
             var layerExtent = this.getBounds('EPSG:4326', false);
             if (layerExtent === null) {
                 // unlimited layer extent
@@ -58,7 +58,7 @@ window.Mapbender.WmsSourceLayer = (function() {
     });
     return WmsSourceLayer;
 }());
-window.Mapbender.WmsSource = (function() {
+window.Mapbender.WmsSource = (function () {
     // @todo: add containing Layerset object to constructor (currently post-instantiation-patched in application setup)
     function WmsSource(definition) {
         Mapbender.Source.apply(this, arguments);
@@ -66,13 +66,14 @@ window.Mapbender.WmsSource = (function() {
         if (definition.customParams) {
             $.extend(this.customParams, definition.customParams);
         }
-        (definition.configuration.options.dimensions || []).map(function(dimensionConfig) {
+        (definition.configuration.options.dimensions || []).map(function (dimensionConfig) {
             if (dimensionConfig.default) {
                 customParams[dimensionConfig.__name] = dimensionConfig.default;
             }
         });
         this.customParams = customParams;
     }
+
     WmsSource.prototype = Object.create(Mapbender.Source.prototype);
     WmsSource.prototype.constructor = WmsSource;
     Mapbender.Source.typeMap['wms'] = WmsSource;
@@ -86,14 +87,19 @@ window.Mapbender.WmsSource = (function() {
          * @param {Object} [mapOptions]
          * @return {Array<Object>}
          */
-        createNativeLayers: function(srsName, mapOptions) {
+        createNativeLayers: function (srsName, mapOptions) {
             return [Mapbender.mapEngine.createWmsLayer(this, mapOptions)];
         },
         /**
          * @return {SourceSettings}
          */
-        getSettings: function() {
-            var selectedLayers = this.configuration.children[0].getSelectedList();
+        getSettings: function () {
+            const selectedLayers = this.configuration.children[0].getSelectedList().map(function (layer) {
+                return {
+                    id: layer.getId(),
+                    name: layer.getName(),
+                };
+            });
             return Object.assign(Mapbender.Source.prototype.getSettings.call(this), {
                 selectedLayers: selectedLayers
             });
@@ -101,97 +107,59 @@ window.Mapbender.WmsSource = (function() {
         /**
          * @param {SourceSettingsDiff|null} diff
          */
-        applySettingsDiff: function(diff) {
+        applySettingsDiff: function (diff) {
             Mapbender.Source.prototype.applySettingsDiff.call(this, diff);
 
             const isDiffValid = diff && ((diff.activate || []).length || (diff.deactivate || []).length);
             if (!isDiffValid) return;
 
-            const findAction = (layer, action, parents) => {
-                let found = action.filter(l => {
-                    const foundById = l.options.id == layer.getId();
-                    const foundByName = l.options.name == layer.getName();
-                    if (!foundById && foundByName) {
-                        const name = parents.reverse().map(parent => parent.getName()).join("/")+"/"+layer.getName();
-                        console.warn(`Layer '${name}': Sources have been updated on the server, but are still detected by name. This message disappears on reselection of this source in the layer tree`);
-                    }
-                    return foundById || foundByName;
-                });
-                if (found.length == 0) {
-                    return null;
-                } else
-                if (found.length == 1) {
-                    return found[0];
-                } else {
-                    const name = parents.reverse().map(parent => parent.getName()).join("/")+"/"+layer.getName();
-                    $.notify(`Layer '${name}': There seems to be a misconception in the underlying map service of this layer. The layer is at least twice defined`);
-                    return found[0];
+            Mapbender.Util.SourceTree.iterateLayers(this, false, function (layer, index, parents) {
+                for (let index in (diff.activate || [])) {
+                    if (diff.activate[index].id === layer.getId()) layer.setSelected(true);
                 }
-
-
-            };
-
-            Mapbender.Util.SourceTree.iterateLayers(this, false, function(layer, index, parents) {
-                let activateHit = findAction(layer, diff.activate || [], parents);
-                if (activateHit) {
-                    activateHit.found = true;
-                    layer.setSelected(true);
+                for (let index in (diff.deactivate || [])) {
+                    if (diff.deactivate[index].id === layer.getId()) layer.setSelected(false);
                 }
-                let deactivateHit = findAction(layer, diff.deactivate || [], parents);
-                if (deactivateHit) {
-                    deactivateHit.found = true;
-                    layer.setSelected(false);
-                }
-            });
-
-            const checkInvalidActions = (action, actionName) => {
-                let foundActions = action.filter(l => !l.found);
-                if (foundActions.length > 0) {
-                    console.error(`Invalid ${actionName} ids left`, foundActions);
-                }
-            }
-
-            checkInvalidActions(diff.activate || [], 'activate');
-            checkInvalidActions(diff.deactivate || [], 'deactivate');
+            }.bind(this));
         },
 
-        getSelected: function() {
+        getSelected: function () {
             // delegate to root layer
             return this.configuration.children[0].getSelected();
         },
-        refresh: function() {
+        refresh: function () {
             var cacheBreakParams = {
                 _OLSALT: Math.random()
             };
             this.addParams(cacheBreakParams);
         },
-        addParams: function(params) {
+        addParams: function (params) {
             for (var i = 0; i < this.nativeLayers.length; ++i) {
                 Mapbender.mapEngine.applyWmsParams(this.nativeLayers[i], params);
             }
             var rtp = this._runtimeParams;
-            $.extend(this.customParams, _.omit(params, function(value, key) {
+            $.extend(this.customParams, _.omit(params, function (value, key) {
                 return -1 !== rtp.indexOf(('' + key).toUpperCase());
             }));
         },
-        removeParams: function(names) {
+        removeParams: function (names) {
             // setting a param to null effectively removes it from the generated URL
             // see https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Util.js#L514
             // see https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Layer/HTTPRequest.js#L197
             // see https://github.com/openlayers/openlayers/blob/v4.6.5/src/ol/uri.js#L16
-            var nullParams = _.object(names, names.map(function() {
+            var nullParams = _.object(names, names.map(function () {
                 return null;
             }));
             this.addParams(nullParams);
         },
-        toJSON: function() {
+        toJSON: function () {
             var s = Mapbender.Source.prototype.toJSON.apply(this, arguments);
             s.customParams = this.customParams;
             return s;
         },
-        updateEngine: function() {
+        updateEngine: function () {
             var layers = [], styles = [];
-            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function(layer) {
+            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function (layer) {
                 // Layer names can be emptyish, most commonly on root layers
                 // Suppress layers with empty names entirely
                 if (layer.options.name && layer.state.visibility) {
@@ -241,9 +209,9 @@ window.Mapbender.WmsSource = (function() {
         /**
          * @return {Array<WmsSourceLayer>}
          */
-        getFeatureInfoLayers: function() {
+        getFeatureInfoLayers: function () {
             var layers = [];
-            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function(layer) {
+            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function (layer) {
                 // Layer names can be emptyish, most commonly on root layers
                 // Suppress layers with empty names entirely
                 if (layer.options.name && layer.state.info) {
@@ -256,9 +224,9 @@ window.Mapbender.WmsSource = (function() {
          * Overview support hack: get names of all 'selected' leaf layers (c.f. instance backend),
          * disregarding 'allowed', disregarding 'state', not recalculating out of scale / out of bounds etc.
          */
-        getActivatedLeaves: function() {
+        getActivatedLeaves: function () {
             var layers = [];
-            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function(node, index, parents) {
+            Mapbender.Util.SourceTree.iterateSourceLeaves(this, false, function (node, index, parents) {
                 var selected = node.options.treeOptions.selected;
                 for (var pi = 0; selected && pi < parents.length; ++pi) {
                     selected = selected && parents[pi].options.treeOptions.selected;
@@ -269,11 +237,11 @@ window.Mapbender.WmsSource = (function() {
             });
             return layers;
         },
-        hasVisibleLayers: function(srsName) {
+        hasVisibleLayers: function (srsName) {
             var activatedLayers = this.getActivatedLeaves();
-            var nonEmptyLayerNames = activatedLayers.map(function(sourceLayer) {
+            var nonEmptyLayerNames = activatedLayers.map(function (sourceLayer) {
                 return sourceLayer.options.name;
-            }).filter(function(layerName) {
+            }).filter(function (layerName) {
                 return !!layerName;
             });
             return !!nonEmptyLayerNames.length;
@@ -284,7 +252,7 @@ window.Mapbender.WmsSource = (function() {
          *
          * @return Object<String, (String | (Array<String>))
          */
-        getGetMapRequestBaseParams: function() {
+        getGetMapRequestBaseParams: function () {
             var params = {
                 LAYERS: [],
                 STYLES: [],
@@ -304,7 +272,7 @@ window.Mapbender.WmsSource = (function() {
             }
             return params;
         },
-        _isBboxFlipped: function(srsName) {
+        _isBboxFlipped: function (srsName) {
             if (this.configuration.options.version === '1.3.0') {
                 return Mapbender.mapEngine.isProjectionAxisFlipped(srsName);
             } else {
@@ -317,7 +285,7 @@ window.Mapbender.WmsSource = (function() {
          * @param {String} srsName
          * @return {Array<Object>}
          */
-        getPrintConfigs: function(bounds, scale, srsName) {
+        getPrintConfigs: function (bounds, scale, srsName) {
             var baseUrl = Mapbender.mapEngine.getWmsBaseUrl(this.getNativeLayer(0), srsName, true);
             var extraParams = {
                 REQUEST: 'GetMap',          // required for tunnel resolution
@@ -326,13 +294,13 @@ window.Mapbender.WmsSource = (function() {
             };
             var dataOut = [];
             var leafInfoMap = Mapbender.Geo.SourceHandler.getExtendedLeafInfo(this, scale, bounds);
-            var resFromScale = function(scale) {
+            var resFromScale = function (scale) {
                 return (scale && Mapbender.Model.scaleToResolution(scale, undefined, srsName)) || null;
             };
             var commonOptions = Object.assign({}, this._getPrintBaseOptions(), {
                 changeAxis: this._isBboxFlipped(srsName)
             });
-            _.forEach(leafInfoMap, function(item) {
+            _.forEach(leafInfoMap, function (item) {
                 if (item.state.visibility) {
                     var replaceParams = Object.assign({}, extraParams, {
                         LAYERS: item.layer.options.name,
@@ -347,7 +315,7 @@ window.Mapbender.WmsSource = (function() {
                     }));
                 }
             });
-            return dataOut.sort(function(a, b) {
+            return dataOut.sort(function (a, b) {
                 return a.order - b.order;
             });
         }

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -83,11 +83,11 @@ window.Mapbender.WmtsTmsBaseSource = (function() {
          */
         getSettings: function() {
             var diff = Object.assign(Mapbender.Source.prototype.getSettings.call(this), {
-                selectedIds: []
+                selectedLayers: []
             });
             // Use a (single-item) layer id list
             if (this.getSelected()) {
-                diff.selectedIds.push(this.id);
+                diff.selectedLayers.push(this);
             }
             return diff;
         },


### PR DESCRIPTION
After a source update, the locally stored id's of wms layers won't be updated as well and therefore miss to restore the layertree. This branch provides a solution, matching the layer by name in case of missing id. 