### PR TITLE
login page no : as fom.server_name can be empty

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Login/box.html.twig
@@ -1,6 +1,6 @@
 {% extends 'MapbenderCoreBundle::index.html.twig' %}
 {%- set title = title | default(fom.server_name) -%}
-{%- set pagetitle = pagetitle | default(fom.server_name ~ ': ' ~ title) -%}
+{%- set pagetitle = pagetitle | default(fom.server_name ~ ' ' ~ title) -%}
 {% block mobilejs %}
   {%- set scaleFactor = scaleFactor | default(1) -%}
   {{ parent() }}


### PR DESCRIPTION
- login page no : as fom.server_name can be empty, then the tab will contain ": Login" as text
- Please merge to version 4