### PR TITLE
Fix search

### DIFF
--- a/src/Mapbender/CoreBundle/Component/SQLSearchEngine.php
+++ b/src/Mapbender/CoreBundle/Component/SQLSearchEngine.php
@@ -74,7 +74,7 @@ class SQLSearchEngine
 
         $qb->orderBy('t.' . $key, 'ASC');
 
-        $stmt = $qb->execute();
+        $stmt = $qb->executeQuery()->fetchAllAssociative();
         $dataOut = array();
         foreach ($stmt as $row) {
             if (!array_key_exists($key, $row)) {
@@ -134,7 +134,7 @@ class SQLSearchEngine
             $qb->andWhere($this->getBoundsExpression($qb, $geomColumn, $extent, $srs));
         }
 
-        $stmt = $qb->execute();
+        $stmt = $qb->executeQuery()->fetchAllAssociative();
         return $this->rowsToGeoJson($stmt);
     }
 


### PR DESCRIPTION
Replace deprecated QueryBuilder::execute() by executeQuery()

Error introduced after updating of doctrine DBAL