### PR TITLE
Feature/searchrouter exportcsv - add new option to export result list as csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Features:
 * PHP 8.2 is now fully supported.
 * [Coordinates Utility](https://github.com/mapbender/coordinates-utility) is now longer a separate repository but integrated as 
   a separate bundle in this repo.
+* [SearchRouter] New option exportcsv to download the result list as CSV ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))
 * [LayerTree] Restore layertree configuration after source update ([PR#1497](https://github.com/mapbender/mapbender/pull/1497))
+* [SearchRouter] Fix possiblility to enable/disable result option count ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 
 
 ## v3.3.5

--- a/src/Mapbender/CoreBundle/Element/SearchRouter.php
+++ b/src/Mapbender/CoreBundle/Element/SearchRouter.php
@@ -159,6 +159,7 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
         return array(
             'js' => array(
                 '@MapbenderCoreBundle/Resources/public/mapbender.element.searchRouter.js',
+                '@MapbenderCoreBundle/Resources/public/element/csv-export.js',
             ),
             'css' => array(
                 '@MapbenderCoreBundle/Resources/public/sass/element/search_router.scss',

--- a/src/Mapbender/CoreBundle/Element/SearchRouter.php
+++ b/src/Mapbender/CoreBundle/Element/SearchRouter.php
@@ -99,6 +99,7 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
             "results" => array(
                 "view" => "table",
                 "count" => "true",
+                "exportcsv" => "false",
                 "headers" => array(),
                 "callback" => array(
                     "event" => "click",
@@ -165,6 +166,7 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
             'trans' => array(
                 'mb.core.searchrouter.result_counter',
                 'mb.core.searchrouter.no_results',
+                'mb.core.searchrouter.exportcsv',
             ),
         );
     }

--- a/src/Mapbender/CoreBundle/Resources/public/element/csv-export.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/csv-export.js
@@ -1,0 +1,60 @@
+class CsvExport {
+    constructor(settings) {
+        this.settings = settings || {};
+    }
+
+    export(features, headers) {
+        let csvFile = '';
+
+        // header columns export in first row
+        csvFile += this.createRow(Object.values(headers));
+
+        for (let i = 0; i < features.length; ++i) {
+            const feature = features[i];
+            const row = [];
+            const props = Mapbender.mapEngine.getFeatureProperties(feature);
+            Object.keys(headers).map(function (header) {
+                row.push(props[header]);
+            });
+            csvFile += this.createRow(row);
+        }
+
+        this.downloadAsFile(csvFile, this.settings.filename || 'download.csv')
+    }
+
+    createRow(rowData) {
+        let finalVal = '';
+        for (let colIndex = 0; colIndex < rowData.length; colIndex++) {
+            let colValue = rowData[colIndex] === null ? '' : rowData[colIndex].toString();
+            if (rowData[colIndex] instanceof Date) {
+                colValue = rowData[colIndex].toLocaleString();
+            }
+
+            if (!colValue.length) {
+                colValue = 'NULL';
+            } else {
+                colValue = '"' + colValue + '"';
+            }
+
+            if (colIndex > 0)
+                finalVal += ',';
+            finalVal += colValue;
+        }
+        return finalVal + '\n';
+    };
+
+    downloadAsFile(fileContents, filename) {
+        const blob = new Blob([fileContents], {type: 'text/csv;charset=utf-8;'});
+        const link = document.createElement("a");
+        if (link.download !== undefined) { // feature detection
+            // Browsers that support HTML5 download attribute
+            const url = URL.createObjectURL(blob);
+            link.setAttribute("href", url);
+            link.setAttribute("download", filename);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
@@ -396,99 +396,41 @@
             feature.setStyle(this.featureStyles[style]);
         },
         _showResultState: function (results) {
-            var widget = this;
-            var element = widget.element;
-            var table = $('.search-results table', element);
-            var counter = $('.result-counter', element);
-            var exportcsv = $('.result-exportcsv', element);
+            var element = this.element;
+            const $table = $('.search-results table', element);
+            let $counter = $('.result-counter', element);
+            let $exportcsv = $('.result-exportcsv', element);
 
-            var currentRoute = widget.getCurrentRoute();
+            var currentRoute = this.getCurrentRoute();
 
-            if (currentRoute.results.exportcsv === true) {
-                exportcsv = $('<button/>', {'class': 'btn btn-sm btn-default result-exportcsv fa fas fa-download'})
-                    .prependTo($('.search-results', element));
+            if (!$counter.length && currentRoute.results.count === true) {
+                $counter = $('<div/>', {'class': 'result-counter'}).prependTo($('.search-results', element));
             }
-            if (0 === counter.length && currentRoute.results.count === true) {
-                counter = $('<div/>', {'class': 'result-counter'})
+
+            if (!$exportcsv.length && currentRoute.results.exportcsv === true) {
+                $exportcsv = $('<button/>', {'class': 'btn btn-sm btn-default result-exportcsv fa fas fa-download left'})
+                    .attr("title", Mapbender.trans('mb.core.searchrouter.exportcsv'))
                     .prependTo($('.search-results', element));
             }
 
             if (results.length > 0) {
-                counter.text(Mapbender.trans('mb.core.searchrouter.result_counter', {
+                $counter.text(Mapbender.trans('mb.core.searchrouter.result_counter', {
                     count: results.length
                 }));
 
-                exportcsv.attr( "title", Mapbender.trans('mb.core.searchrouter.exportcsv'));
-                exportcsv.button().click(function(){
-                    widget._exportCsv(results);
-
-                });
-
-                table.show();
+                $exportcsv.show().unbind().on('click', () => this._exportCsv(results));
+                $table.show();
             } else {
-                table.hide();
-                counter.text(Mapbender.trans('mb.core.searchrouter.no_results'));
+                $table.hide();
+                $exportcsv.hide();
+                $counter.text(Mapbender.trans('mb.core.searchrouter.no_results'));
             }
         },
-        /**
-         * Export results to CSV
-         */
         _exportCsv: function (features) {
-            var createRow = function (row) {
-                var finalVal = '';
-                for (var j = 0; j < row.length; j++) {
-                    var innerValue = row[j] === null ? '' : row[j].toString();
-                    if (row[j] instanceof Date) {
-                        innerValue = row[j].toLocaleString();
-                    };
-
-                    if (innerValue.length == 0){
-                        innerValue = 'NULL';
-                    }else{
-                        innerValue = '"' + innerValue + '"';
-                    }
-                    if (j > 0)
-                        finalVal += ',';
-                    finalVal += innerValue;
-                }
-                return finalVal + '\n';
-            };
-
-            var filename = 'download.csv';
-            var csvFile = '';
-
-            // header columns export in first row
-            var currentRoute = this.getCurrentRoute();
-            var headers = currentRoute.results.headers;
-            csvFile += createRow(Object.values(headers));
-
-            for (var i = 0; i < features.length; ++i) {
-                var feature = features[i];
-                var row = [];
-                var props = Mapbender.mapEngine.getFeatureProperties(feature);
-                Object.keys(headers).map(function (header) {
-                    var d = props[header];
-                    row.push(d);
-                });
-                csvFile += createRow(row);
+            if (!this.csvExport) {
+                this.csvExport = new CsvExport();
             }
-            // create csv file & download
-            var blob = new Blob([csvFile], { type: 'text/csv;charset=utf-8;' });
-            if (navigator.msSaveBlob) { // IE 10+
-                navigator.msSaveBlob(blob, filename);
-            } else {
-                var link = document.createElement("a");
-                if (link.download !== undefined) { // feature detection
-                    // Browsers that support HTML5 download attribute
-                    var url = URL.createObjectURL(blob);
-                    link.setAttribute("href", url);
-                    link.setAttribute("download", filename);
-                    link.style.visibility = 'hidden';
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
-                }
-            }
+            this.csvExport.export(features, this.getCurrentRoute().results.headers);
         },
         _createStyleMap: function (styles) {
             function _createSingleStyle(options) {

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yml
@@ -125,6 +125,7 @@ mb:
     searchrouter:
       no_results: 'Keine Ergebnisse gefunden.'
       result_counter: 'Ergebnisse: %count%'
+      exportcsv: 'Export der Trefferliste als CSV.'
       class:
         title: Suchen
         description: 'Ermöglicht die Konfiguration von individuellen Suchen'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yml
@@ -124,6 +124,7 @@ mb:
     searchrouter:
       no_results: 'No results found.'
       result_counter: 'Results: %count%'
+      exportcsv: 'Export results to CSV.'
       class:
         title: 'Search router'
         description: 'Configurable search routing element'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.es.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'No results'
       result_counter: 'Results: %count%'
+      exportcsv: 'Exporte los resultados a CSV.'
       class:
         title: 'Buscar ruteador'
         description: 'Búsqueda configurable del elemeteo de ruteo'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Aucun résultat.'
       result_counter: 'Résultats: %count%'
+      exportcsv: 'Exporter les résultats vers un fichier CSV.'
       class:
         title: 'Routeur de recherche'
         description: 'Élément de routeur de recherche configurable'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.it.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Nessun risultato trovato.'
       result_counter: 'Risultati: %count%'
+      exportcsv: 'Esportare i risultati in CSV.'
       class:
         title: 'Cerca router'
         description: 'Ricerca configurabile su elemento routing'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Geen resultaten gevonden.'
       result_counter: 'Resultaten: %count%'
+      exportcsv: 'Exporteer de resultaten naar CSV.'
       class:
         title: 'Zoek route'
         description: 'Configureer de zoek-route opdracht'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Sua pesquisa não encontrou resultados'
       result_counter: 'Resultados: %count%'
+      exportcsv: 'Exportar os resultados para CSV.'
       class:
         title: Procurar
         description: 'Possibilita a configuração de pesquisas individuais'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Не найдено результатов.'
       result_counter: 'Результаты: %count%'
+      exportcsv: 'Экспортировать результаты в CSV.'
       class:
         title: Поиск
         description: 'Настраиваемый элемент поиска '

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yml
@@ -67,6 +67,7 @@ mb:
     searchrouter:
       no_results: 'Sonuç bulunamadı'
       result_counter: 'Sonuçlar: %count%'
+      exportcsv: 'Sonuçları CSV'ye aktarma.'
       class:
         title: 'Arama yönlendiricisi'
         description: 'Yapılandırılabilir arama yönlendirme'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yml
@@ -79,6 +79,7 @@ mb:
     searchrouter:
       no_results: 'Не знайдено результатів.'
       result_counter: 'Результати: %count%'
+      exportcsv: 'Експортуйте результати в CSV.'
       class:
         title: 'Пошук маршрутизатора'
         description: 'Налаштовуваний елемент маршрутизації пошуку '


### PR DESCRIPTION
-> merge request to develop

- add new option to export the result list to csv (without geometry)
- csv ist for download as download.csv
- option exportcsv: true has to be added (defult for exportcsv is false)
- count: true definition was not validated. This is handled in the PR too
- csv content
  -  first row is header as defined for the table
  - then the values all in quotes "
  - if a values is empty ,NULL, exported in the csv -> is that ok? oder better ,,?

```
results:
  view: table
  count: false
  exportcsv: false
```
Example for the content of a download.csv
```

"Name","Gemeinde","Bundesland","Einwohner","Höhe"
"Bonn","Bonn","Nordrhein-Westfalen","109397","59"
"Bonndorf","Überlingen","Baden-Württemberg",NULL,"544"
```

This is how it looks in the application (in Version 4 the translation done)

![Bildschirmfoto vom 2023-10-20 14-23-20](https://github.com/mapbender/mapbender/assets/996298/1ee1be8e-8ce7-4bb9-9ccc-d463459e0257)
