### PR TITLE
Remove underscore dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes (for details on migration process see UPGRADING.md):
 * Twig updated to version 3.7. See UPGRADING.md for migration details 
 * Bootstrap updated to version 5.3. See https://getbootstrap.com/docs/4.0/migration/, https://getbootstrap.com/docs/5.0/migration/)
 * Removed deprecated automatic bundle inference. Assets now always have to be imported using a bundle qualifier (e.g. `@MyBundle/Resources/public/file.js`) ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
+* Removed underscore.js. Some functions are replaced by native JS functions, some are replaced by Mapbender.Util functions ([PR#1514](https://github.com/mapbender/mapbender/pull/1514))
 
 Features:
 * PHP 8.2 is now fully supported.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -74,7 +74,18 @@ The following methods have been renamed (only relevant if you overwrite or call 
 The following files have been renamed:
 - `mapbender.model.ol4.js` => `mapbender.model.js` 
 
+## Removed underscore.js
+The library was only used sparsely and was not worth the effort of keeping up to date. The following replacements can be used:
 
+- `_.assign`, `_.extend`: `Object.extend`
+- `_.debounce`: `Mapbender.Util.debounce`
+- `_.difference`: Write manully (one-liner)
+- `_.each`, `_.forEach`: `Array.prototype.forEach` or `JQuery.each`
+- `_.findWhere`: `Mapbender.Util.findFirst`
+- `_.mapObject`: Write manully (three-liner)
+- `_.object`: Write manully (three-liner)
+- `_.omit`, `_.filter`: `Mapbender.Util.filter`
+- `_.uniq`: `Mapbender.Util.array_unique`
 
 
 ## v3.3.x

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,6 @@
         "mapbender/mapbender-icons": "^1.3",
 
         "wheregroup/codemirror": "5.x",
-        "components/underscore": "1.x",
         "wheregroup/doctrine-dbal-shims": "^1",
         "wheregroup/assetic-filter-sassc": "^0.0",
         "wheregroup/sassc-binaries": "^0.0.1",

--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -188,7 +188,6 @@ class ApplicationAssetService
                 '@MapbenderCoreBundle/Resources/public/stubs.js',
                 '@MapbenderCoreBundle/Resources/public/util.js',
                 '@MapbenderCoreBundle/Resources/public/mapbender.trans.js',
-                '/components/underscore/underscore-min.js',
                 '/bundles/mapbendercore/regional/vendor/notify.0.3.2.min.js',
                 '@MapbenderCoreBundle/Resources/public/widgets/dropdown.js',
             ),

--- a/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
+++ b/src/Mapbender/CoreBundle/Component/Application/Template/IApplicationTemplateAssetDependencyInterface.php
@@ -17,7 +17,7 @@ interface IApplicationTemplateAssetDependencyInterface
      * 1) bundle-qualified paths starting with '@'; e.g:
      *    '@SpecialTemplateBundle/Resources/public/template/special-template.css'
      * 2) web-root-anchored paths starting with '/'; e.g:
-     *    '/components/underscore/underscore-min.js'
+     *    '/components/jquery/jquery.min.js'
      *
      * 'trans' entries are expected to name .json.twig files and must be
      * twig-compatible (e.g. Somebundle:[optional-subpath under Resources/views:]translations.json.twig

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -250,14 +250,14 @@ window.Mapbender.MapModelBase = (function() {
          * engine-agnostic
          */
         getSourceById: function(id) {
-            return _.findWhere(this.sourceTree, {id: '' + id}) || null;
+            return Mapbender.Util.findFirst(this.sourceTree, (value) => value.id === '' + id);
         },
         /**
          * @param {Number|String} id
          * @return {Mapbender.Layerset|null}
          */
         getLayersetById: function(id) {
-            return _.findWhere(Mapbender.layersets, {id: '' + id}) || null;
+            return Mapbender.Util.findFirst(Mapbender.layersets, (value) => value.id === '' + id);
         },
         /**
          * @param {Mapbender.Layerset} theme
@@ -1356,7 +1356,7 @@ window.Mapbender.MapModelBase = (function() {
             var updateHandler = function(evt, data) {
                 self._updateViewParamFragment(data.params);
             };
-            this.mbMap.element.on('mbmapviewchanged', _.debounce(updateHandler, 400));
+            this.mbMap.element.on('mbmapviewchanged', Mapbender.Util.debounce(updateHandler, 400));
             window.addEventListener('popstate', function() {
                 self._applyViewParamFragment();
             });
@@ -1386,7 +1386,7 @@ window.Mapbender.MapModelBase = (function() {
                 'mb.sourcenodeselectionchanged',
                 'mbmapsourcechanged'
             ];
-            this.mbMap.element.on(listened.join(' '), _.debounce(updateHandler, 1000));
+            this.mbMap.element.on(listened.join(' '), Mapbender.Util.debounce(updateHandler, 1000));
         },
         /**
          * @param {{left: Number, right: Number, top: Number, bottom: Number}} extent

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -41,7 +41,7 @@ Mapbender.ElementRegistry = (function($){
     ElementRegistry.prototype.listWidgets = function() {
         var data = {};
         $('.mb-element').each(function(i, el) {
-            _.assign(data, $(el).data());
+            Object.extend(data, $(el).data());
         });
         return data;
     };
@@ -161,7 +161,7 @@ Mapbender.ElementRegistry = (function($){
      */
     ElementRegistry.prototype.addTrackingByClass_ = function(bundle, node) {
         var classNames = ($(node).attr('class') || '').split(/\s+/);
-        var mbClasses = _.uniq(classNames.filter(function(c) {
+        var mbClasses = Mapbender.Util.array_unique(classNames.filter(function(c) {
             return !!c.match(/^mb-element-/);
         }));
         // record same promises bundle in class index for class-name based lookups

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -231,9 +231,8 @@
             var widget = this;
             var sources = widget._getSources();
             var html = $('<ul/>');
-            _.each(sources, function (source) {
-                html.append(widget._createSourceHtml(source));
-            });
+
+            sources.forEach((source) => html.append(widget._createSourceHtml(source)));
             // strip top-level dummy <ul>
             return $(' > *', html);
         },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.searchRouter.js
@@ -520,7 +520,7 @@
         },
         _getFormValues: function (form) {
             var values = {};
-            _.each($(':input', form), function (input) {
+            $(':input', form).each(function(index, input) {
                 var $input = $(input);
                 var name = $input.attr('name').replace(/^[^[]*\[/, '').replace(/[\]].*$/, '');
                 values[name] = $input.val();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -65,9 +65,11 @@ Mapbender.Geo.SourceHandler = {
      * @return {boolean}
      */
     updateLayerStates: function(source, scale, extent, srsName) {
-        var stateMap = _.mapObject(this.getExtendedLeafInfo(source, scale, extent, srsName), function(item) {
-            return item.state;
-        });
+        let stateMap = {}
+        const leafInfo = this.getExtendedLeafInfo(source, scale, extent, srsName);
+        for (const [key, item] of Object.entries(leafInfo)) {
+            stateMap[key] = item.state;
+        }
 
         var stateNames = ['outOfScale', 'outOfBounds', 'visibility', 'info'];
         var stateChanged = false;

--- a/src/Mapbender/CoreBundle/Resources/public/util.js
+++ b/src/Mapbender/CoreBundle/Resources/public/util.js
@@ -1,33 +1,33 @@
 window.Mapbender = Mapbender || {};
 
-Mapbender.error = function(errorObject,delayTimeout) {
+Mapbender.error = function (errorObject, delayTimeout) {
     var errorMessage = errorObject;
-    if(typeof errorObject != "string"){
+    if (typeof errorObject != "string") {
         errorMessage = JSON.stringify(errorObject);
     }
-    $.notify(errorMessage,{autoHideDelay: delayTimeout?delayTimeout:5000}, 'error');
-    console.error("Mapbender Error: ",errorObject);
+    $.notify(errorMessage, {autoHideDelay: delayTimeout ? delayTimeout : 5000}, 'error');
+    console.error("Mapbender Error: ", errorObject);
 };
 
-Mapbender.info = function(infoObject,delayTimeout) {
+Mapbender.info = function (infoObject, delayTimeout) {
     var message = infoObject;
-    if(typeof infoObject != "string"){
+    if (typeof infoObject != "string") {
         message = JSON.stringify(infoObject);
     }
-    $.notify(message,{autoHideDelay: delayTimeout?delayTimeout:5000,className: 'info'});
-    console.log("Mapbender Info: ",infoObject);
+    $.notify(message, {autoHideDelay: delayTimeout ? delayTimeout : 5000, className: 'info'});
+    console.log("Mapbender Info: ", infoObject);
 };
-Mapbender.confirm = function(message){
+Mapbender.confirm = function (message) {
     var res = confirm(message);
     return res;
 };
 
-Mapbender.checkTarget = function(widgetName, target, targetname) {
-    if(target === null || typeof (target) === 'undefined'
-            || new String(target).replace(/^\s+|\s+$/g, '') === ""
-            || $('#' + target).length === 0) {
+Mapbender.checkTarget = function (widgetName, target, targetname) {
+    if (target === null || typeof (target) === 'undefined'
+        || new String(target).replace(/^\s+|\s+$/g, '') === ""
+        || $('#' + target).length === 0) {
         Mapbender.error(widgetName + ': a target element ' + (targetname ? '"' + targetname + '"'
-                : '') + ' is not defined.');
+            : '') + ' is not defined.');
         return false;
     } else {
         return true;
@@ -36,9 +36,9 @@ Mapbender.checkTarget = function(widgetName, target, targetname) {
 
 Mapbender.Util = Mapbender.Util || {};
 
-Mapbender.Util.UUID = function(){
+Mapbender.Util.UUID = function () {
     var d = new Date().getTime();
-    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c){
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
         var r = (d + Math.random() * 16) % 16 | 0;
         d = Math.floor(d / 16);
         return (c == 'x' ? r : (r & 0x7 | 0x8)).toString(16);
@@ -46,16 +46,16 @@ Mapbender.Util.UUID = function(){
     return uuid;
 };
 /* deprecated */
-Mapbender.urlParam = function(key){
+Mapbender.urlParam = function (key) {
     window.console && console.warn(
-            'The function "Mapbender.urlParam" is deprecated, use instead it the "new Mapbender.Util.Url().getParameter(key)"');
+        'The function "Mapbender.urlParam" is deprecated, use instead it the "new Mapbender.Util.Url().getParameter(key)"');
     return new Mapbender.Util.Url(window.location.href).getParameter(key);
 };
 
 /* deprecated */
-Mapbender.UUID = function(){
+Mapbender.UUID = function () {
     window.console && console.warn(
-            'The function "Mapbender.UUID" is deprecated, use instead it the "Mapbender.Util.UUID"');
+        'The function "Mapbender.UUID" is deprecated, use instead it the "Mapbender.Util.UUID"');
     return Mapbender.Util.UUID();
 }
 
@@ -63,8 +63,8 @@ Mapbender.UUID = function(){
  * Creates an url object from a giving url string
  * @param {String} urlString
  */
-Mapbender.Util.Url = function(urlString) {
-    if(!urlString.replace(/^\s+|\s+$/g, ''))// trim
+Mapbender.Util.Url = function (urlString) {
+    if (!urlString.replace(/^\s+|\s+$/g, ''))// trim
         return;
     var self = this;
     var tmp = document.createElement("a");
@@ -112,15 +112,15 @@ Mapbender.Util.Url = function(urlString) {
      * Checks if a url object is valid.
      * @returns {Boolean} true if url valid
      */
-    this.isValid = function(){
-        return  !(!self.hostname || !self.protocol);// TODO ?
+    this.isValid = function () {
+        return !(!self.hostname || !self.protocol);// TODO ?
     };
     /**
      * Reconstruct url
      * @param {boolean} [withoutUser] to omit credentials (default false)
      * @returns {String}
      */
-    this.asString = function(withoutUser) {
+    this.asString = function (withoutUser) {
         var parts = [this.protocol, '//'];
         if (!withoutUser && this.username) {
             parts.push(encodeURIComponent(this.username), ':', encodeURIComponent(this.password || ''), '@');
@@ -153,9 +153,9 @@ Mapbender.Util.Url = function(urlString) {
      * @param {Boolean} [ignoreCase]
      * @returns {String|null}
      */
-    this.getParameter = function(name, ignoreCase) {
-        for(var key in self.parameters) {
-            if(key === name || (ignoreCase && key.toLowerCase() === name.toLowerCase())) {
+    this.getParameter = function (name, ignoreCase) {
+        for (var key in self.parameters) {
+            if (key === name || (ignoreCase && key.toLowerCase() === name.toLowerCase())) {
                 return self.parameters[key];
             }
         }
@@ -167,7 +167,7 @@ Mapbender.Util.Url = function(urlString) {
  * @param {String} x
  * @return {String}
  */
-Mapbender.Util.escapeRegex = function(x) {
+Mapbender.Util.escapeRegex = function (x) {
     // See https://stackoverflow.com/a/6969486
     return x.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 };
@@ -181,7 +181,7 @@ Mapbender.Util.escapeRegex = function(x) {
  * @param {boolean} [caseSensitive] default true
  * @return {String}
  */
-Mapbender.Util.removeUrlParams = function(url, names, caseSensitive) {
+Mapbender.Util.removeUrlParams = function (url, names, caseSensitive) {
     var ci_ = !caseSensitive && (typeof caseSensitive !== 'undefined');
     var qmAt = url.indexOf('?');
     if (qmAt === -1 || !names.length) {
@@ -218,7 +218,7 @@ Mapbender.Util.removeUrlParams = function(url, names, caseSensitive) {
  * @param {Object} params
  * @return {String}
  */
-Mapbender.Util.addUrlParams = function(url, params) {
+Mapbender.Util.addUrlParams = function (url, params) {
     var hashAt = url.indexOf('#');
     if (hashAt !== -1) {
         return Mapbender.Util.addUrlParams(url.substring(0, hashAt), params) + url.substring(hashAt);
@@ -243,7 +243,7 @@ Mapbender.Util.addUrlParams = function(url, params) {
  * @param {boolean} [caseSensitive] default true
  * @return {String}
  */
-Mapbender.Util.replaceUrlParams = function(url, params, caseSensitive) {
+Mapbender.Util.replaceUrlParams = function (url, params, caseSensitive) {
     var hashAt = url.indexOf('#');
     if (hashAt !== -1) {
         return Mapbender.Util.replaceUrlParams(url.substring(0, hashAt), params, caseSensitive) + url.substring(hashAt);
@@ -268,7 +268,7 @@ Mapbender.Util.replaceUrlParams = function(url, params, caseSensitive) {
  * @param {Object} b
  * @return {boolean}
  */
-Mapbender.Util.extentsIntersect = function(a, b) {
+Mapbender.Util.extentsIntersect = function (a, b) {
     /**
      * Rectangle intersection logic lifted from OpenLayers 2
      * minus all its behavioural tweak options we do not need.
@@ -293,11 +293,11 @@ Mapbender.Util.extentsIntersect = function(a, b) {
     return ((inBottom || inTop) && (inLeft || inRight));
 };
 
-Mapbender.Util.isInScale = function(scale, min_scale, max_scale){
+Mapbender.Util.isInScale = function (scale, min_scale, max_scale) {
     return (min_scale ? min_scale <= scale : true) && (max_scale ? max_scale >= scale : true);
 };
 
-Mapbender.Util.isSameSchemeAndHost = function(urlA, urlB) {
+Mapbender.Util.isSameSchemeAndHost = function (urlA, urlB) {
     var a = document.createElement('a');
     var b = document.createElement('a');
     a.href = urlA;
@@ -305,7 +305,7 @@ Mapbender.Util.isSameSchemeAndHost = function(urlA, urlB) {
     return a.host === b.host && a.protocol && b.protocol;
 };
 
-Mapbender.Util.removeProxy = function(url) {
+Mapbender.Util.removeProxy = function (url) {
     var proxyBase = Mapbender.configuration.application.urls.proxy + '?url=';
     if (url.indexOf(proxyBase) === 0) {
         return decodeURIComponent(url.substring(proxyBase.length));
@@ -313,7 +313,7 @@ Mapbender.Util.removeProxy = function(url) {
     return url;
 };
 
-Mapbender.Util.removeSignature = function(url) {
+Mapbender.Util.removeSignature = function (url) {
     var pos = url.indexOf("_signature");
     if (pos !== -1) {
         var url_new = url.substring(0, pos);
@@ -333,7 +333,7 @@ Mapbender.Util.removeSignature = function(url) {
  * @param {String} url
  * @returns {Promise<HTMLImageElement>}
  */
-Mapbender.Util.preloadImageAsset = function(url) {
+Mapbender.Util.preloadImageAsset = function (url) {
     var fullUrl;
     if (/^(\/)|([\w-]*:?\/\/)/.test(url)) {
         fullUrl = url;
@@ -344,10 +344,10 @@ Mapbender.Util.preloadImageAsset = function(url) {
 
     var deferred = $.Deferred();
     var image = new Image();
-    image.onload = function() {
+    image.onload = function () {
         deferred.resolveWith(null, [image]);
     };
-    image.onerror = function() {
+    image.onerror = function () {
         deferred.reject();
     };
     image.src = fullUrl;
@@ -363,7 +363,7 @@ Mapbender.Util.preloadImageAsset = function(url) {
  * @param {String} url
  * @return {Array<String>}
  */
-Mapbender.Util.splitUrlQueryParams = function(url) {
+Mapbender.Util.splitUrlQueryParams = function (url) {
     return (url || '')
         // Reduce to pure query string; becomes empty if no "?" in url
         .replace(/^[^?]*\??([^#]*).*$/, '$1')
@@ -372,7 +372,7 @@ Mapbender.Util.splitUrlQueryParams = function(url) {
         // Remove trailing &, if any
         .replace(/&$/, '')
         .split('&')
-    ;
+        ;
 };
 
 /**
@@ -385,7 +385,7 @@ Mapbender.Util.splitUrlQueryParams = function(url) {
  * @param {boolean} [plusToSpace] default true
  * @return {Object.<String, String>}
  */
-Mapbender.Util.getUrlQueryParams = function(url, plusToSpace) {
+Mapbender.Util.getUrlQueryParams = function (url, plusToSpace) {
     var assignments = Mapbender.Util.splitUrlQueryParams(url);
     var params = {};
     for (var i = 0; i < assignments.length; ++i) {
@@ -417,10 +417,10 @@ Mapbender.Util.getUrlQueryParams = function(url, plusToSpace) {
  * @param {String} name
  * @return {Object}
  */
-Mapbender.Util.unpackObjectParam = function(values, name) {
+Mapbender.Util.unpackObjectParam = function (values, name) {
     var params = {};
     var prefix = [name, '['].join('');
-    var fullNames = Object.keys(values).filter(function(name) {
+    var fullNames = Object.keys(values).filter(function (name) {
         return 0 === name.indexOf(prefix);
     });
     for (var i = 0; i < fullNames.length; ++i) {
@@ -451,6 +451,127 @@ Mapbender.Util.unpackObjectParam = function(values, name) {
     return params[name] || null;
 };
 
+/**
+ * Returns a copy of the given array containing only the unique values
+ * Equality check is type-safe (corresponding to ===), so "0" and 0 are separate values
+ * @param {*[]} array
+ * @returns {*[]}
+ */
+Mapbender.Util.array_unique = function (array) {
+    if (!Array.isArray(array)) return array;
+
+    let result = [];
+    array.forEach((value) => {
+        if (result.indexOf(value) === -1) {
+            result.push(value);
+        }
+    });
+    return result;
+}
+
+/**
+ * Returns a copy of the array containing only those elements where the predicate function returns a truthy value (e.g true, 1)
+ * @param {{}} obj
+ * @param {(value: *, key: string) => boolean} predicate
+* @returns {*[]}
+ */
+Mapbender.Util.object_filter = function (obj, predicate) {
+    let results = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (predicate(value, key)) results[key] = value;
+    }
+    return results;
+};
+
+/**
+ * Returns a copy of the array containing only those elements where the predicate function returns a truthy value (e.g true, 1)
+ * @param {*[]} array
+ * @param {(value: *, index: number) => boolean} predicate
+* @returns {*[]}
+ */
+Mapbender.Util.array_filter = function (array, predicate) {
+    let results = [];
+    array.forEach((value, index) => {
+        if (predicate(value, index)) results.push(value);
+    })
+    return results;
+};
+
+/**
+ * Returns a copy of the array or object containing only those elements, where the predicate function returns a truthy value (e.g true, 1)
+ * @param {{}|*[]} arrayOrObj
+ * @param {(value: *, indexOrKey: number|string) => boolean} predicate
+ * @returns {{}|*[]}
+ */
+Mapbender.Util.filter = function (arrayOrObj, predicate) {
+    if (Array.isArray(arrayOrObj)) return Mapbender.Util.array_filter(arrayOrObj, predicate);
+    if (typeof arrayOrObj === 'object') return Mapbender.Util.object_filter(arrayOrObj, predicate);
+    return arrayOrObj;
+};
+
+/**
+ * Returns the first item of the array or object where the predicate returns a truthy value (e.g. true, 1). Return null if
+ * the array or object is emo
+ * @param {{}|*[]} arrayOrObj
+ * @param {(value: *) => boolean} predicate
+ * @returns {*|null}
+ */
+Mapbender.Util.findFirst = function (arrayOrObj, predicate) {
+    const isArray = Array.isArray(arrayOrObj);
+    const array = isArray ? arrayOrObj : Object.entries(arrayOrObj);
+    let foundValue = null;
+
+    for (let i = 0; i < array.length && foundValue === null; i++) {
+        const item = isArray ? array[i] : array[i][1];
+        if (predicate(item)) {
+            foundValue = item;
+        }
+    }
+    return foundValue;
+}
+
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered. The function will be called after it stops being called for
+ * N milliseconds. If `immediate` is passed, trigger the function on the
+ * @param {function(): *} func
+ * @param {number} delayMs delay time [ms]
+ * @param {boolean} [immediate] if set to true, the method will trigger on the first call
+ * @returns {function(): *}
+ */
+Mapbender.Util.debounce = function (func, delayMs, immediate) {
+    let timeout, args, context, timestamp, result;
+
+    const later = function () {
+        const last = Date.now() - timestamp;
+
+        if (last < delayMs && last >= 0) {
+            timeout = setTimeout(later, delayMs - last);
+        } else {
+            timeout = null;
+            if (!immediate) {
+                result = func.apply(context, args);
+                context = args = null;
+            }
+        }
+    };
+
+    return function () {
+        context = this;
+        args = arguments;
+        timestamp = Date.now();
+        const callNow = immediate && !timeout;
+        if (!timeout) timeout = setTimeout(later, delayMs);
+        if (callNow) {
+            result = func.apply(context, args);
+            context = args = null;
+        }
+
+        return result;
+    };
+}
+
+
 Mapbender.ElementUtil = {
     /**
      * Checks the markup region containing the element for reasonable
@@ -462,14 +583,14 @@ Mapbender.ElementUtil = {
      * @param {jQuery|HTMLElement} element
      * @returns boolean
      */
-    checkDialogMode: function(element) {
+    checkDialogMode: function (element) {
         return !$(element).closest('.sideContent, .mobilePane').length;
     },
     /**
      * @param {jQuery|HTMLElement} element
      * @returns boolean
      */
-    checkResponsiveVisibility: function(element) {
+    checkResponsiveVisibility: function (element) {
         const $element = $(element);
         // Only check for responsive visibility if the element has one of the hide classes
         if (!$element.hasClass('hide-screentype-desktop') && !$element.hasClass('hide-screentype-mobile')) return true;

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
@@ -229,7 +229,9 @@
         }
 
         var self = this;
-        _.difference(Object.keys(this.options), this.staticOptions_).forEach(function(optionName) {
+        Object.keys(this.options).forEach(function(optionName) {
+            if (this.staticOptions_.indexOf(optionName) >= 0) return;
+
             var value = self.options[optionName];
             switch(optionName) {
                 case 'title':

--- a/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
@@ -421,7 +421,7 @@
                 var sourceName = source.configuration.title || (rootLayer && rootLayer.options.title) || '';
                 var leafInfo = Mapbender.Geo.SourceHandler.getExtendedLeafInfo(source, scale, this._getExportExtent());
                 var sourceLegendList = [];
-                _.forEach(leafInfo, function(activeLeaf) {
+                for(const activeLeaf of Object.values(leafInfo)) {
                     if (activeLeaf.state.visibility) {
                         for (var p = -1; p < activeLeaf.parents.length; ++p) {
                             var legendLayer = (p < 0) ? activeLeaf.layer : activeLeaf.parents[p];
@@ -450,7 +450,7 @@
                             }
                         }
                     }
-                });
+                }
                 if (sourceLegendList.length) {
                     // reverse source order
                     legends.unshift(sourceLegendList);
@@ -519,18 +519,18 @@
                 });
             }
             var mapDpi = (this.map.options || {}).dpi || 72;
-            _.assign(jobData, {
+            Object.assign(jobData, {
                 overview: overview,
                 mapDpi: mapDpi,
                 'extent_feature': extentFeature
             });
             if ($('input[name="printLegend"]', this.$form).prop('checked')) {
-                _.assign(jobData, {
+                Object.assign(jobData, {
                     legends: this._collectLegends()
                 });
             }
             if (this.digitizerData) {
-                _.assign(jobData, this.digitizerData);
+                Object.assign(jobData, this.digitizerData);
             }
             return jobData;
         },

--- a/src/Mapbender/WmsBundle/Resources/public/backend/dimensionshandler.js
+++ b/src/Mapbender/WmsBundle/Resources/public/backend/dimensionshandler.js
@@ -81,7 +81,7 @@ $(function () {
         $selects.each(function() {
             usedValues = usedValues.concat($(this).val());
         });
-        usedValues = _.uniq(usedValues);
+        usedValues = Mapbender.Util.array_unique(usedValues);
         $('option', $selects).each(function() {
             $(this).prop('disabled', (usedValues.indexOf(this.value) !== -1) && !$(this).is(':selected'));
         });

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -138,8 +138,8 @@ window.Mapbender.WmsSource = (function () {
                 Mapbender.mapEngine.applyWmsParams(this.nativeLayers[i], params);
             }
             var rtp = this._runtimeParams;
-            $.extend(this.customParams, _.omit(params, function (value, key) {
-                return -1 !== rtp.indexOf(('' + key).toUpperCase());
+            $.extend(this.customParams, Mapbender.Util.filter(params, function (value, key) {
+                return rtp.indexOf(('' + key).toUpperCase()) === -1;
             }));
         },
         removeParams: function (names) {
@@ -147,10 +147,11 @@ window.Mapbender.WmsSource = (function () {
             // see https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Util.js#L514
             // see https://github.com/openlayers/ol2/blob/release-2.13.1/lib/OpenLayers/Layer/HTTPRequest.js#L197
             // see https://github.com/openlayers/openlayers/blob/v4.6.5/src/ol/uri.js#L16
-            var nullParams = _.object(names, names.map(function () {
-                return null;
-            }));
-            this.addParams(nullParams);
+            let mapOfNamesToRemove = {}
+            names.forEach((name) => {
+                mapOfNamesToRemove[name] = null;
+            })
+            this.addParams(mapOfNamesToRemove);
         },
         toJSON: function () {
             var s = Mapbender.Source.prototype.toJSON.apply(this, arguments);
@@ -300,7 +301,7 @@ window.Mapbender.WmsSource = (function () {
             var commonOptions = Object.assign({}, this._getPrintBaseOptions(), {
                 changeAxis: this._isBboxFlipped(srsName)
             });
-            _.forEach(leafInfoMap, function (item) {
+            for(const item of Object.values(item)) {
                 if (item.state.visibility) {
                     var replaceParams = Object.assign({}, extraParams, {
                         LAYERS: item.layer.options.name,
@@ -314,7 +315,7 @@ window.Mapbender.WmsSource = (function () {
                         order: item.order
                     }));
                 }
-            });
+            }
             return dataOut.sort(function (a, b) {
                 return a.order - b.order;
             });


### PR DESCRIPTION
The library was only used sparsely and was not worth the effort of keeping up to date. The following replacements can be used:

- `_.assign`, `_.extend`: `Object.extend`
- `_.debounce`: `Mapbender.Util.debounce`
- `_.difference`: Write manully (one-liner)
- `_.each`, `_.forEach`: `Array.prototype.forEach` or `JQuery.each`
- `_.findWhere`: `Mapbender.Util.findFirst`
- `_.mapObject`: Write manully (three-liner)
- `_.object`: Write manully (three-liner)
- `_.omit`, `_.filter`: `Mapbender.Util.filter`
- `_.uniq`: `Mapbender.Util.array_unique`
