### PR TITLE
Draft. Allow customization of the icons available for selection in the button edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
   a separate bundle in this repo.
 * [SearchRouter] New option exportcsv to download the result list as CSV ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
+* [Button] Allow customization of the icons available for selection in the button edit form. Use parameter `mapbender.icons.custom` (Array with keys name, title and class). Also added parameters `mapbender.icons.disable_default` and `mapbender.icons.disable_default_fa` to disable default icons. ([PR#1513](https://github.com/mapbender/mapbender/pull/1513)) 
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Features:
   a separate bundle in this repo.
 * [SearchRouter] New option exportcsv to download the result list as CSV ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
-* [Button] Allow customization of the icons available for selection in the button edit form. Use parameter `mapbender.icons.custom` (Array with keys name, title and class). Also added parameters `mapbender.icons.disable_default` and `mapbender.icons.disable_default_fa` to disable default icons. ([PR#1513](https://github.com/mapbender/mapbender/pull/1513)) 
+* [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518)) 
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))

--- a/src/Mapbender/CoreBundle/Component/IconPackageMbIcons.php
+++ b/src/Mapbender/CoreBundle/Component/IconPackageMbIcons.php
@@ -13,9 +13,17 @@ use Mapbender\Utils\HtmlUtil;
  */
 class IconPackageMbIcons implements IconPackageInterface
 {
-    public function getChoices()
+    protected bool $showDefaultIcons = true;
+
+    public function __construct(bool $disableDefaultIcons)
     {
-        return array(
+        $this->showDefaultIcons = !$disableDefaultIcons;
+    }
+
+    public function getChoices(): array
+    {
+        if (!$this->showDefaultIcons) return [];
+        return [
             'Layer tree' => 'icon-layer-tree',
             'Feature Info' => 'icon-feature-info',
             'Area ruler' => 'icon-area-ruler',
@@ -24,14 +32,12 @@ class IconPackageMbIcons implements IconPackageInterface
             'Image Export' => 'icon-image-export',
             'Legend' => 'icon-legend',
             'About' => 'icon-about',
-        );
+        ];
     }
 
-    public function getStyleSheets()
+    public function getStyleSheets(): array
     {
-        return array(
-            'components/mapbender-icons/style.css',
-        );
+        return ['components/mapbender-icons/style.css'];
     }
 
     public function getIconMarkup($iconCode)
@@ -45,7 +51,7 @@ class IconPackageMbIcons implements IconPackageInterface
     {
         return \in_array($iconCode, $this->getChoices());
     }
-    
+
     public function getAliases()
     {
         return array();

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
@@ -20,3 +20,7 @@ parameters:
     mapbender.sitelinks: []
 
     mapbender.asset_overrides: ~
+    mapbender.icons.disable_default: false
+    mapbender.icons.disable_default_fa: false
+    mapbender.icons.custom: ~
+

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -293,9 +293,12 @@
             <argument type="service" id="mapbender.element_shim_factory" />
         </service>
         <service id="mapbender.icon_package_fa4" class="Mapbender\CoreBundle\Component\IconPackageFa4">
+            <argument>%mapbender.icons.disable_default_fa%</argument>
+            <argument>%mapbender.icons.custom%</argument>
             <tag name="mapbender.icon_package" priority="-1" />
         </service>
         <service id="mapbender.icon_package_mbicons" class="Mapbender\CoreBundle\Component\IconPackageMbIcons">
+            <argument>%mapbender.icons.disable_default%</argument>
             <tag name="mapbender.icon_package" priority="-2" />
         </service>
         <service id="mapbender.sqlite_connection_listener" class="%mapbender.sqlite_connection_listener.class%">


### PR DESCRIPTION
Added three parameters (that can be added to your parameters.yaml file):

**`mapbender.icons.disable_default`** (default: `false`):  
if set to true, the default icons from the mapbender namespace are disabled in the button edit form. These are Layer tree, Feature Info, Area ruler, Polygon, Line ruler, Image Export, Legend and About

**`mapbender.icons.disable_default_fa`** (default: `false`):  
if set to true, the default font awesome icons are disabled in the button edit form. These are all others currently available that are not in the mapbender namespace.

**`mapbender.icons.custom`** (default: `~`):  
allows adding more icons from FontAwesome (list available here: https://fontawesome.com/search?o=r&m=free)  
The parameter is an array ob objects containing three keys:
- `name`: Identifier for this icon, e.g. for usage in yaml-defined Applications
- `title`: Description of the icon as shown in the selection menu in the button edit form
- `class`: Full class name (including the "fa") of the icon. Copy from the bottom of the popup when clicking on the icon on the font awesome homepage

![grafik](https://github.com/mapbender/mapbender/assets/3438255/81962e4d-a152-44f8-a6c5-41aa6b2d5f56)

Example:

```yaml
mapbender.icons.disable_default: true
mapbender.icons.disable_default_fa: true
mapbender.icons.custom:
    - name: iconSnowflake
      title: Schneeflocke
      class: fa-solid fa-snowflake
    - name: iconHeartbeat
      title: Herzschlag
      class: fa-solid fa-heart-pulse
```


refs #1258