### PR TITLE
element ruler: change ruler to be able to create multiple geometries while measuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Features:
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
 * [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518))
 * [FeatureInfo] Tabs in the feature info window are now sorted in the order they appear in the layer tree ([PR#1534](https://github.com/mapbender/mapbender/pull/1534))
+* [Ruler] Allows to draw multiple geometries. Generates calculation for every single geometry. ([PR#1536](https://github.com/mapbender/mapbender/pull/1536))
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
@@ -81,8 +81,8 @@
                 style: this._getStyle.bind(this),
             });
             control.on('drawstart', function (event) {
-                self._reset();
-                source.clear();
+                self._resetAfterGeometryWasDrawn();
+                // AE auskommenteirt: source.clear();
                 /** @var {ol.Feature} */
                 var feature = event.feature;
                 var geometry = feature.getGeometry();
@@ -121,6 +121,7 @@
             this.help = $('<p/>').text(Mapbender.trans(this.options.help));
             this.total = $('<div/>').addClass('total-value').css({'font-weight': 'bold'});
             this.segments = $('<ul/>');
+            this.count = 0;
             this.segments.append()
             if (this.options.help) this.container.append(this.help);
             this.container.append(this.total);
@@ -191,11 +192,19 @@
         },
         _mapSrsChanged: function (event, srs) {
             if (this.control) {
-                this._reset();
+                this._resetAfterGeometryWasDrawn();
             }
         },
         _reset: function () {
+            // reset when dialog is closed
             $('>li', this.segments).remove();
+            $('>div', this.segments).remove();
+            this.total.text('');
+            this.count = 0;
+        },
+        _resetAfterGeometryWasDrawn: function () {
+            // reset after geometry was drawn
+            //$('>li', this.segments).remove();
             this.total.text('');
         },
         _handleModify: function (event) {
@@ -208,8 +217,10 @@
             }
         },
         _handlePartial: function (event) {
+            // calculates area while drawing areas
             if (this.options.type === 'area') {
-                this._handleFinal(event);
+                var measure = this._getMeasureFromEvent(event);
+                var measureElement = $('<li/>');
                 return;
             }
             var measure = this._getMeasureFromEvent(event);
@@ -225,7 +236,21 @@
         },
         _handleFinal: function (event) {
             var measure = this._getMeasureFromEvent(event);
+            var measureElement = $('<li/>');
+            measureElement.text('');
             this._updateTotal(measure, event);
+
+            this.object = $('<div/>').addClass('object-value').css({'font-weight': 'bold'});
+            this.count = this.count+1;
+
+            var $final = $('>li', this.segments).first();
+            //$final.show();
+
+            //finalObject = this.object.text(this.count+': '+ this.total.text());
+            finalObject = this.object.text(this.total.text());
+            this.segments.prepend(finalObject);
+            this.segments.prepend($('<br/>'));
+            this.total.text('');
         },
         _updateTotal: function (measure, event) {
             this.total.text(measure);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
@@ -244,7 +244,7 @@
             this.count = this.count+1;
 
             var $final = $('>li', this.segments).first();
-            //$final.show();
+            $final.remove();
 
             //finalObject = this.object.text(this.count+': '+ this.total.text());
             finalObject = this.object.text(this.total.text());


### PR DESCRIPTION
 Allows to draw multiple geometries. Generates calculation for every single geometry. 

Please check whether the layout is ok. Any ideas?

Ideas for future developments
- highlight geometry on mouse-over
- calculate total (length  or area of the geometries)
- allow to delete geometry from the list
- allow to modify geometries