### PR TITLE
Fix path to LDAP-userclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Bugfixes:
 * [SearchRouter] Additional search properties were ignored ([#1474](https://github.com/mapbender/mapbender/issues/1474), [PR#1476](https://github.com/mapbender/mapbender/pull/1476))
 * [Manager] Show message indicating too low max_input_vars value when editing instance layers ([PR#1491](https://github.com/mapbender/mapbender/pull/1491))
 * [BaseSourceSwitcher] Element behaved incorrectly when "allow selected" was not set in the WMS instance ([PR#1492](https://github.com/mapbender/mapbender/pull/1492))
+* [LDAP] Fix path to LDAP userclass in the currently used Mapbender LDAP-Bundle
 
 
 ## v3.3.4

--- a/src/FOM/UserBundle/Resources/config/services.xml
+++ b/src/FOM/UserBundle/Resources/config/services.xml
@@ -29,7 +29,7 @@
              doesn't explicitly encode a class name.
              NOTE: it's legal for the named class to not even exist. It just needs to be consistent with current
                    contents of the ACL DB structure -->
-        <parameter key="fom.ldap_user_identities_provider.user_class">Mapbender\LdapIntegrationBundle\Entity\LdapUser</parameter>
+        <parameter key="fom.ldap_user_identities_provider.user_class">Mapbender\LDAPBundle\Security\User\LDAPUser</parameter>
         <!-- internal; automatically replaced with value extracted from 'security' extension config
              see ForwardUserEntityClassPass -->
         <parameter key="fom.user_entity">null</parameter>


### PR DESCRIPTION
- Fixes the path to the user class of the currently used MapbenderLDAPBundle.
- Allows to secure an application with an LDAP-User again. 