### PR TITLE
New console command `mapbender:normalize-translations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 * Added splash screen for all applications ([PR#1522](https://github.com/mapbender/mapbender/pull/1522))
 * [Coordinates Utility](https://github.com/mapbender/coordinates-utility) is now longer a separate repository but integrated as 
   a separate bundle in this repo.
+* New console command `mapbender:normalize-translations` to quickly find and complement missing translations ([PR#1538](https://github.com/mapbender/mapbender/pull/1538))
 * [SearchRouter] New option exportcsv to download the result list as CSV ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
 * [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518))

--- a/src/FOM/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/FOM/CoreBundle/Resources/translations/messages.de.yaml
@@ -3,10 +3,10 @@ fom:
     components:
       popup:
         delete_user_group:
-          title: Entfernen bestätigen
-          content: Wollen Sie die Gruppe %userGroup% wirklich entfernen?
+          title: 'Entfernen bestätigen'
+          content: 'Wollen Sie die Gruppe %userGroup% wirklich entfernen?'
           btn:
             cancel: Abbrechen
             ok: Speichern
     fields:
-      no_user_group_defined: Kein/e Benutzer/Gruppe ist definiert.
+      no_user_group_defined: 'Kein/e Benutzer/Gruppe ist definiert.'

--- a/src/FOM/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/FOM/CoreBundle/Resources/translations/messages.en.yaml
@@ -3,10 +3,10 @@ fom:
     components:
       popup:
         delete_user_group:
-          title: Confirm delete
-          content: Really delete %userGroup%?
+          title: 'Confirm delete'
+          content: 'Really delete %userGroup%?'
           btn:
             cancel: Cancel
             ok: OK
     fields:
-      no_user_group_defined: No user or group defined.
+      no_user_group_defined: 'No user or group defined.'

--- a/src/FOM/ManagerBundle/Resources/translations/messages.de.yaml
+++ b/src/FOM/ManagerBundle/Resources/translations/messages.de.yaml
@@ -1,8 +1,8 @@
 fom:
   core:
     manager:
-      logged_as: Angemeldet als
-      you_account: Ihr Konto
+      logged_as: 'Angemeldet als'
+      you_account: 'Ihr Konto'
       btn:
         logout: Abmelden
         login: Anmelden

--- a/src/FOM/ManagerBundle/Resources/translations/messages.en.yaml
+++ b/src/FOM/ManagerBundle/Resources/translations/messages.en.yaml
@@ -1,8 +1,8 @@
 fom:
   core:
     manager:
-      logged_as: Logged in as
-      you_account: Your Account
+      logged_as: 'Logged in as'
+      you_account: 'Your Account'
       btn:
         logout: Logout
         login: Login

--- a/src/FOM/UserBundle/Resources/translations/messages.de.yaml
+++ b/src/FOM/UserBundle/Resources/translations/messages.de.yaml
@@ -1,141 +1,141 @@
 fom:
   acl:
     group_label:
-      anonymous: Anonyme Nutzer
-      authenticated: Alle angemeldeten Nutzer
+      anonymous: 'Anonyme Nutzer'
+      authenticated: 'Alle angemeldeten Nutzer'
   user:
     registration:
-      email_body_html: <p>Hallo %user_username%,</p><p>Sie haben sich kürzlich registriert. Um die Registrierung abzuschließen, klicken Sie bitte <a href="%url%">hier</a>.</p>
+      email_body_html: '<p>Hallo %user_username%,</p><p>Sie haben sich kürzlich registriert. Um die Registrierung abzuschließen, klicken Sie bitte <a href="%url%">hier</a>.</p>'
       done:
         title: Registrierung
-        congratulations: Herzlichen Glückwunsch!
-        account_activated: Ihr Account wurde erfolgreich aktiviert und ist einsatzbereit!
-        back_to_login: Zurück zum Login
+        congratulations: 'Herzlichen Glückwunsch!'
+        account_activated: 'Ihr Account wurde erfolgreich aktiviert und ist einsatzbereit!'
+        back_to_login: 'Zurück zum Login'
       form:
         title: Registrierung
-        choose_password: Passwort auswählen
-        confirm_password: Passwort bestätigen
+        choose_password: 'Passwort auswählen'
+        confirm_password: 'Passwort bestätigen'
         email: E-Mail
-        back_to_login: Zurück zum Login
+        back_to_login: 'Zurück zum Login'
         register: Registrieren
-      email_subject: Ihre Registrierung
+      email_subject: 'Ihre Registrierung'
       send:
         title: Registrierung
-        account_created: Ihr Account wurde erstellt. Eine E-Mail mit Ihrem Freischaltungs-Code und -Link ist Ihnen mit Ihrer bereitgestellten Adresse gesendet worden.
-        back_to_login: Zurück zum Login
-      email_body_text: Hallo %user_username%, Sie haben sich kürzlich registriert. Um die Registrierung abzuschließen, rufen Sie bitte folgenden Link in Ihrem Browser auf %url%.
+        account_created: 'Ihr Account wurde erstellt. Eine E-Mail mit Ihrem Freischaltungs-Code und -Link ist Ihnen mit Ihrer bereitgestellten Adresse gesendet worden.'
+        back_to_login: 'Zurück zum Login'
+      email_body_text: 'Hallo %user_username%, Sie haben sich kürzlich registriert. Um die Registrierung abzuschließen, rufen Sie bitte folgenden Link in Ihrem Browser auf %url%.'
     group:
       index:
         groups: Gruppen
-        add_new_group: Neue Gruppe hinzufügen
+        add_new_group: 'Neue Gruppe hinzufügen'
         title: Titel
         description: Beschreibung
-        edit_group: Gruppe bearbeiten
-        delete_group: Gruppe löschen
-        no_groups_available: Keine Gruppen verfügbar
+        edit_group: 'Gruppe bearbeiten'
+        delete_group: 'Gruppe löschen'
+        no_groups_available: 'Keine Gruppen verfügbar'
       form:
-        edit_group: Gruppe bearbeiten
-        new_group: Neue Gruppe
+        edit_group: 'Gruppe bearbeiten'
+        new_group: 'Neue Gruppe'
       container:
         base_data: Basisdaten
         users: Benutzer
-        users_of_selected: Benutzer von %users_count% selektiert
-        no_user_exists: Benutzer existiert nicht
+        users_of_selected: 'Benutzer von %users_count% selektiert'
+        no_user_exists: 'Benutzer existiert nicht'
     login:
       error_tockenexp:
-        title: Passwort zurücksetzen
+        title: 'Passwort zurücksetzen'
         sorry: Sorry!
-        registration_token_expired: Ihr Registrierungs-Token ist abgelaufen. Leider müssen Sie ein neues Token anfordern.
-        request_new_token: Neues Token anfordern
-        back_to_login: Zurück zur Anmeldung
+        registration_token_expired: 'Ihr Registrierungs-Token ist abgelaufen. Leider müssen Sie ein neues Token anfordern.'
+        request_new_token: 'Neues Token anfordern'
+        back_to_login: 'Zurück zur Anmeldung'
       login:
         title: Anmeldung
         username: Benutzer
         password: Passwort
         register: Register
-        forgot_password: Passwort vergessen
+        forgot_password: 'Passwort vergessen'
         login: Anmelden
       error_notocken:
-        password_reset: Passwort zurücksetzen
+        password_reset: 'Passwort zurücksetzen'
         sorry: Sorry!
-        no_such_tocken: Token nicht gefunden. Wenn Sie denken, dass dies ein Fehler ist, bitte kontaktieren Sie Ihren Administrator.
-        contact: Kontakt Administrator
-        back_to_login: Zurück zur Anmeldung
+        no_such_tocken: 'Token nicht gefunden. Wenn Sie denken, dass dies ein Fehler ist, bitte kontaktieren Sie Ihren Administrator.'
+        contact: 'Kontakt Administrator'
+        back_to_login: 'Zurück zur Anmeldung'
     user:
       index:
         title: Benutzer
-        add_new_user: Neuen Benutzer hinzufügen
+        add_new_user: 'Neuen Benutzer hinzufügen'
         name: Name
         email: E-Mail
         groups: Gruppen
-        edit_user: Benutzer bearbeiten
-        contact_user: Kontaktieren Sie den Benutzer per E-Mail
-        edit_group: Gruppe bearbeiten
-        delete_user: Benutzer löschen
-        no_users_available: Kein Benutzer verfügbar.
+        edit_user: 'Benutzer bearbeiten'
+        contact_user: 'Kontaktieren Sie den Benutzer per E-Mail'
+        edit_group: 'Gruppe bearbeiten'
+        delete_user: 'Benutzer löschen'
+        no_users_available: 'Kein Benutzer verfügbar.'
       form:
-        edit_user: Benutzer bearbeiten
-        new_user: Neuer Benutzer
+        edit_user: 'Benutzer bearbeiten'
+        new_user: 'Neuer Benutzer'
       container:
         base_data: Basisdaten
         profile: Profil
         groups: Gruppen
         security: Sicherheit
-        choose_password: Passwort auswählen
-        confirm_password: Passwort bestätigen
+        choose_password: 'Passwort auswählen'
+        confirm_password: 'Passwort bestätigen'
         name: Name
-        users_of_selected: Gruppen von %users_count% selektiert
-        no_groups_defined: Keine Gruppen definiert
+        users_of_selected: 'Gruppen von %users_count% selektiert'
+        no_groups_defined: 'Keine Gruppen definiert'
         username: Benutzername
         description: Beschreibung
         activated: aktiviert
     acl:
       index:
-        access_control_lists: Globale Zugriffssteuerungsliste (ACL)
+        access_control_lists: 'Globale Zugriffssteuerungsliste (ACL)'
         name: Name
         class: Klasse
         edit: Bearbeiten
-      required: Die erforderlichen Felder sind mit dunkler Beschriftung markiert, optionale Felder haben eine hellere Beschriftung.
+      required: 'Die erforderlichen Felder sind mit dunkler Beschriftung markiert, optionale Felder haben eine hellere Beschriftung.'
       edit:
-        edit_class_acl: ACL-Klasse bearbeiten von %name%
+        edit_class_acl: 'ACL-Klasse bearbeiten von %name%'
       groups_users:
         name: Name
-        no_goups_users: Keine Gruppen/Benutzer definiert.
+        no_goups_users: 'Keine Gruppen/Benutzer definiert.'
     password:
-      email_body_html: <p>Hallo %user_username%,</p><p>Sie haben ein neues Mapbender Passwort angefordert. <p>Klicken Sie bitte <a href="%url%">hier</a>, um Ihr Passwort zu ändern.</p>
+      email_body_html: '<p>Hallo %user_username%,</p><p>Sie haben ein neues Mapbender Passwort angefordert. <p>Klicken Sie bitte <a href="%url%">hier</a>, um Ihr Passwort zu ändern.</p>'
       done:
-        password_reset: Passwort zurücksetzen
-        congratulations: Herzlichen Glückwunsch!
-        password_been_reset: Ihr Passwort wurde erfolgreich zurückgesetzt.
-        back_to_login: Zurück zur Anmeldung
+        password_reset: 'Passwort zurücksetzen'
+        congratulations: 'Herzlichen Glückwunsch!'
+        password_been_reset: 'Ihr Passwort wurde erfolgreich zurückgesetzt.'
+        back_to_login: 'Zurück zur Anmeldung'
       reset:
-        title: Passwort zurücksetzen
-        btn: Passwort zurücksetzen
+        title: 'Passwort zurücksetzen'
+        btn: 'Passwort zurücksetzen'
       form:
-        message: Zum Zurücksetzen des Passworts geben Sie bitte Ihren Benutzernamen oder Ihre E-Mail Adresse an.
-        title: Passwort vergessen
-        username_email: Benutzername oder E-Mail
-        back_to_login: Zurück zum Login
-        require_password: Passwort anfordern
-      email_subject: Passwort vergessen
+        message: 'Zum Zurücksetzen des Passworts geben Sie bitte Ihren Benutzernamen oder Ihre E-Mail Adresse an.'
+        title: 'Passwort vergessen'
+        username_email: 'Benutzername oder E-Mail'
+        back_to_login: 'Zurück zum Login'
+        require_password: 'Passwort anfordern'
+      email_subject: 'Passwort vergessen'
       send:
-        title: Passwort zurücksetzen
-        email_been_sent: Eine E-Mail mit Ihrem zurückgesetzten Code und Link ist Ihnen zu Ihrer bereitgestellten Adresse gesendet worden.
-        back_to_login: Zurück zur Anmeldung
-      email_body_text: Hallo %user_username%, Sie haben ein neues Passwort angefordert. Rufen Sie in Ihrem Browser folgenden Link auf "%url%"
+        title: 'Passwort zurücksetzen'
+        email_been_sent: 'Eine E-Mail mit Ihrem zurückgesetzten Code und Link ist Ihnen zu Ihrer bereitgestellten Adresse gesendet worden.'
+        back_to_login: 'Zurück zur Anmeldung'
+      email_body_text: 'Hallo %user_username%, Sie haben ein neues Passwort angefordert. Rufen Sie in Ihrem Browser folgenden Link auf "%url%"'
     userbundle:
       user_control: Benutzerverwaltung
       users: Benutzer
-      new_user: Neuer Benutzer
+      new_user: 'Neuer Benutzer'
       groups: Gruppen
-      new_group: Neue Gruppe
+      new_group: 'Neue Gruppe'
       classes:
-        acls: Berechtigungen ACLs
+        acls: 'Berechtigungen ACLs'
         users: Benutzer
         groups: Gruppen
       roles:
-        super_admin: Kann alles verwalten (super admin)
-        user_admin: Kann Benutzer und Gruppen verwalten
+        super_admin: 'Kann alles verwalten (super admin)'
+        user_admin: 'Kann Benutzer und Gruppen verwalten'
 IS_AUTHENTICATED_ANONYMOUSLY: IS_AUTHENTICATED_ANONYMOUSLY
 form:
   profile:

--- a/src/FOM/UserBundle/Resources/translations/messages.en.yaml
+++ b/src/FOM/UserBundle/Resources/translations/messages.en.yaml
@@ -1,154 +1,154 @@
 fom:
   acl:
     group_label:
-      anonymous: Anonymous users
-      authenticated: All authenticated users
+      anonymous: 'Anonymous users'
+      authenticated: 'All authenticated users'
   user:
     registration:
-      email_body_html: <p>Hello %user_username%,</p><p>You have just recently registered to the Mapbender3 instance. To conclude your registration, please, click please <a href="%url%">here</a>.</p>
+      email_body_html: '<p>Hello %user_username%,</p><p>You have just recently registered to the Mapbender3 instance. To conclude your registration, please, click please <a href="%url%">here</a>.</p>'
       done:
         title: Registration
         congratulations: Congratulations!
-        account_activated: You're account has been successfully activated and is ready for use.
-        back_to_login: Back to login
+        account_activated: 'You''re account has been successfully activated and is ready for use.'
+        back_to_login: 'Back to login'
       form:
         title: Registration
-        choose_password: Choose password
-        confirm_password: Confirm password
+        choose_password: 'Choose password'
+        confirm_password: 'Confirm password'
         email: Email
-        back_to_login: Back to login
+        back_to_login: 'Back to login'
         register: Register
-      email_subject: Your registration
+      email_subject: 'Your registration'
       send:
         title: Registration
         account_created: |-
           Your account has been created. An email with your activation code
                       and link has been sent to the address you provided.
-        back_to_login: Back to login
-      email_body_text: Hello %user_username%, You have just recently registered to the Mapbender3 instance. To conclude your registration, please, call in your browser the link %url%.
+        back_to_login: 'Back to login'
+      email_body_text: 'Hello %user_username%, You have just recently registered to the Mapbender3 instance. To conclude your registration, please, call in your browser the link %url%.'
     group:
       index:
         groups: Groups
-        add_new_group: Add new group
+        add_new_group: 'Add new group'
         title: Title
         description: Description
-        edit_group: Edit group
-        delete_group: Delete group
-        no_groups_available: No groups available.
+        edit_group: 'Edit group'
+        delete_group: 'Delete group'
+        no_groups_available: 'No groups available.'
       form:
-        edit_group: Edit Group
-        new_group: New Group
+        edit_group: 'Edit Group'
+        new_group: 'New Group'
       container:
-        base_data: Base data
+        base_data: 'Base data'
         users: Users
-        users_of_selected: users of %users_count% selected
-        no_user_exists: No user exists.
+        users_of_selected: 'users of %users_count% selected'
+        no_user_exists: 'No user exists.'
     login:
       error_tockenexp:
-        title: Password Reset
+        title: 'Password Reset'
         sorry: Sorry!
-        registration_token_expired: Your registration token has expired. Unfortunately, you will have to request a new token.
-        request_new_token: Request new token
-        back_to_login: Back to login
+        registration_token_expired: 'Your registration token has expired. Unfortunately, you will have to request a new token.'
+        request_new_token: 'Request new token'
+        back_to_login: 'Back to login'
       login:
         title: Login
-        username: User name
+        username: 'User name'
         password: Password
         register: Register
-        forgot_password: Forgot password
+        forgot_password: 'Forgot password'
         login: Login
       error_notocken:
-        password_reset: Password reset
+        password_reset: 'Password reset'
         sorry: Sorry!
-        no_such_tocken: No such token can be found. If you think this is an error, please contact the site administrator.
-        contact: Contact administrator
-        back_to_login: Back to login
+        no_such_tocken: 'No such token can be found. If you think this is an error, please contact the site administrator.'
+        contact: 'Contact administrator'
+        back_to_login: 'Back to login'
     user:
       index:
         title: Users
-        add_new_user: Add new user
+        add_new_user: 'Add new user'
         name: Name
         email: E-Mail
         groups: Groups
-        edit_user: Edit user
-        contact_user: Contact user via e-mail
-        edit_group: Edit group
-        delete_user: Delete user
-        no_users_available: No users available.
+        edit_user: 'Edit user'
+        contact_user: 'Contact user via e-mail'
+        edit_group: 'Edit group'
+        delete_user: 'Delete user'
+        no_users_available: 'No users available.'
       form:
-        edit_user: Edit User
-        new_user: New User
+        edit_user: 'Edit User'
+        new_user: 'New User'
       container:
-        base_data: Base data
+        base_data: 'Base data'
         profile: Profile
         groups: Groups
         security: Security
-        choose_password: Choose password
-        confirm_password: Confirm password
+        choose_password: 'Choose password'
+        confirm_password: 'Confirm password'
         name: Name
-        users_of_selected: groups of %users_count% selected
-        no_groups_defined: No groups defined
-        username: User name
+        users_of_selected: 'groups of %users_count% selected'
+        no_groups_defined: 'No groups defined'
+        username: 'User name'
         description: Description
         activated: activated
     acl:
       index:
-        access_control_lists: Global Access Control Lists
+        access_control_lists: 'Global Access Control Lists'
         name: Name
         class: Class
         edit: Edit
-      required: Required fields are marked with dark labels, while optional fields have lighter labels.
+      required: 'Required fields are marked with dark labels, while optional fields have lighter labels.'
       edit:
-        edit_class_acl: Edit Class ACL for %name%
+        edit_class_acl: 'Edit Class ACL for %name%'
       groups_users:
         name: Name
-        no_goups_users: No groups and users defined.
+        no_goups_users: 'No groups and users defined.'
     password:
-      email_body_html: <p>Hello %user_username%,</p><p>You have requested a new password for your Mapbender3 account. Please click <a href="%url%"> here to change it.</p>
+      email_body_html: '<p>Hello %user_username%,</p><p>You have requested a new password for your Mapbender3 account. Please click <a href="%url%"> here to change it.</p>'
       done:
-        password_reset: Password reset
+        password_reset: 'Password reset'
         congratulations: Congratulations!
-        password_been_reset: You're password has been successfully reset.
-        back_to_login: Back to login
+        password_been_reset: 'You''re password has been successfully reset.'
+        back_to_login: 'Back to login'
       reset:
-        title: Reset password
-        btn: Reset password
+        title: 'Reset password'
+        btn: 'Reset password'
       form:
-        message: To reset your password please provide your username or your e-mail address.
-        title: Forgot password
-        username_email: User name or Email
-        back_to_login: Back to login
-        require_password: Require password
-      email_subject: Forgot password
+        message: 'To reset your password please provide your username or your e-mail address.'
+        title: 'Forgot password'
+        username_email: 'User name or Email'
+        back_to_login: 'Back to login'
+        require_password: 'Require password'
+      email_subject: 'Forgot password'
       send:
-        title: Password Reset
-        email_been_sent: An email with your reset code and link has been sent to the address you provided.
-        back_to_login: Back to login
+        title: 'Password Reset'
+        email_been_sent: 'An email with your reset code and link has been sent to the address you provided.'
+        back_to_login: 'Back to login'
       email_body_text: 'Hello %user_username%, You have requested a new password for your Mapbender3 account. Please follow this link to change it: "%url%".'
     userbundle:
-      user_control: User control
+      user_control: 'User control'
       users: Users
-      new_user: New user
+      new_user: 'New user'
       groups: Groups
-      new_group: New group
+      new_group: 'New group'
       classes:
         acls: ACLs
         users: Users
         groups: groups
       roles:
-        super_admin: Can administrate everything (super admin)
-        user_admin: Can administrate users and groups
+        super_admin: 'Can administrate everything (super admin)'
+        user_admin: 'Can administrate users and groups'
 IS_AUTHENTICATED_ANONYMOUSLY: IS_AUTHENTICATED_ANONYMOUSLY
 form:
   profile:
     basic:
-      firstname: First name
-      lastName: Last name
+      firstname: 'First name'
+      lastName: 'Last name'
       notes: Notes
       phone: Phone
       organizationName: Organization
       organizationRole: Position
       street: Street
-      zipCode: Zip code
+      zipCode: 'Zip code'
       city: City
       country: Country

--- a/src/Mapbender/CoreBundle/Command/TranslationCommand.php
+++ b/src/Mapbender/CoreBundle/Command/TranslationCommand.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Mapbender\CoreBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class TranslationCommand extends Command
+{
+    protected static $defaultName = 'mapbender:normalize-translations';
+
+    public function __construct(private KernelInterface $kernel)
+    {
+        parent::__construct();
+    }
+
+    const ARGUMENT_LANGUAGE = "language";
+    const OPTION_SOURCE_LANGUAGE = "source-language";
+    const OPTION_PRINT_MISSING_KEYS = "print-missing-keys";
+    const OPTION_ADD_MISSING_KEYS = "add-missing-keys";
+    const OPTION_MISSING_KEY_PREFIX = "missing-key-prefix";
+
+    private InputInterface $input;
+    private OutputInterface $output;
+
+    private int $keysMissingCounter = 0;
+
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Normalize YAML order of translation files and mark missing translations.')
+            ->setHelp('This command normalizes YAML order of translation files and adds missing translations.')
+            ->addArgument(self::ARGUMENT_LANGUAGE, mode: InputArgument::REQUIRED, description: 'the language code (e.g. de) that should be processed')
+            ->addOption(self::OPTION_SOURCE_LANGUAGE, mode: InputOption::VALUE_OPTIONAL, description: 'the source language (e.g. en) that is seen as default. It is assumed all keys are present in the source language', default: 'en')
+            ->addOption(self::OPTION_ADD_MISSING_KEYS, 'a', description: 'if set to true, entries not present in the target language will be added (marked with a prefix)')
+            ->addOption(self::OPTION_MISSING_KEY_PREFIX, mode: InputOption::VALUE_OPTIONAL, description: 'the prefix to mark keys that were automatically added and are yet to translate', default: 'TRANSLATE: ')
+            ->addOption(self::OPTION_PRINT_MISSING_KEYS, 'p', description: 'if set to true, entries not present in the target language will be logged to the console.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        $sourceLanguage = $input->getOption(self::OPTION_SOURCE_LANGUAGE);
+        $targetLanguage = $input->getArgument(self::ARGUMENT_LANGUAGE);
+
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if (!str_starts_with($bundle->getNamespace(), 'Mapbender') && !str_starts_with($bundle->getNamespace(), 'FOM')) continue;
+
+            $translationFolder = $bundle->getPath() . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'translations';
+            if (!is_dir($translationFolder)) continue;
+            $sourceFile = $this->getTranslationFile($translationFolder, $sourceLanguage);
+            if ($sourceFile === null) {
+                $output->writeln("No translation file found for bundle " . $bundle->getNamespace() . " and source language " . $sourceLanguage . "; skipping");
+                continue;
+            }
+
+            $targetFile = $this->getTranslationFile($translationFolder, $targetLanguage);
+            if ($targetFile === null) {
+                $output->writeln("No translation file found for bundle " . $bundle->getNamespace() . " and target language " . $targetLanguage . "; skipping");
+                continue;
+            }
+
+            $output->writeln("Processing translation for " . $bundle->getNamespace() . "  …");
+            $this->normalizeYamlOrder($sourceFile, $targetFile);
+            $successMessage = 'Translations keys normalized for bundle ' . $bundle->getNamespace() . '. ';
+            $successMessage .= match ($this->keysMissingCounter) {
+                0 => "No keys were",
+                1 => "1 key was",
+                default => $this->keysMissingCounter . " keys were"
+            };
+            $successMessage .= $input->getOption(self::OPTION_ADD_MISSING_KEYS) ? " added." : " missing.";
+            $output->writeln($successMessage . "\n");
+            $this->keysMissingCounter = 0;
+        }
+        return Command::SUCCESS;
+    }
+
+    private function getTranslationFile(string $translationFolder, mixed $sourceLanguage): string|null
+    {
+        $sourceFile = $translationFolder . DIRECTORY_SEPARATOR . "messages+intl-icu." . $sourceLanguage . ".yaml";
+        if (!is_file($sourceFile)) {
+            $sourceFile = $translationFolder . DIRECTORY_SEPARATOR . "messages." . $sourceLanguage . ".yaml";
+        }
+        if (!is_file($sourceFile)) {
+            $sourceFile = $translationFolder . DIRECTORY_SEPARATOR . "messages+intl-icu." . $sourceLanguage . ".yml";
+        }
+        if (!is_file($sourceFile)) {
+            $sourceFile = $translationFolder . DIRECTORY_SEPARATOR . "messages." . $sourceLanguage . ".yml";
+        }
+        return is_file($sourceFile) ? $sourceFile : null;
+    }
+
+    private function normalizeYamlOrder(string $sourceFile, string $targetFile): void
+    {
+        $messagesSource = $this->parseYamlFile($sourceFile);
+        $messagesTarget = $this->parseYamlFile($targetFile);
+
+        $newMessages = $this->recursiveNormalizeOrder($messagesSource, $messagesTarget);
+
+        $this->writeYamlFile($sourceFile, $messagesSource);
+        $this->writeYamlFile($targetFile, $newMessages);
+    }
+
+    private function recursiveNormalizeOrder(array $source, array $target, array $path = []): array
+    {
+        $newTarget = [];
+        foreach ($source as $key => $value) {
+            if (is_array($value)) {
+                $targetValue = array_key_exists($key, $target) ? $target[$key] : [];
+                $newTarget[$key] = $this->recursiveNormalizeOrder($value, $targetValue, [...$path, $key]);
+                if (!empty($target[$key])) unset($target[$key]);
+            } elseif (array_key_exists($key, $target)) {
+                $newTarget[$key] = $target[$key];
+                unset($target[$key]);
+            } else {
+                $this->keysMissingCounter++;
+
+                if ($this->input->getOption(self::OPTION_ADD_MISSING_KEYS)) {
+                    $newTarget[$key] = $this->input->getOption(self::OPTION_MISSING_KEY_PREFIX) . $value;
+                } elseif ($this->input->getOption(self::OPTION_PRINT_MISSING_KEYS)) {
+                    $fullKeyName = implode('.', $path) . (empty($path) ? '' : '.') . $key;
+                    $this->output->writeln('<comment>Translation key "' . $fullKeyName . '" is missing in target translation file</comment>');
+                }
+            }
+        }
+        foreach ($target as $key => $value) {
+            $fullKeyName = implode('.', $path) . (empty($path) ? '' : '.') . $key;
+            $this->output->writeln('<comment>Found unexpected key "' . $fullKeyName . '" in translated file not present in original</comment>');
+            $newTarget[$key] = $value;
+        }
+        return $newTarget;
+    }
+
+    private function parseYamlFile(string $filePath): array
+    {
+        try {
+            $messages = Yaml::parse(file_get_contents($filePath), Yaml::PARSE_DATETIME);
+        } catch (ParseException $e) {
+            throw new InvalidResourceException(sprintf('The file "%s" does not contain valid YAML: ', $filePath) . $e->getMessage(), 0, $e);
+        }
+
+        if (null !== $messages && !\is_array($messages)) {
+            throw new InvalidResourceException(sprintf('Unable to load file "%s".', $filePath));
+        }
+
+        return $messages ?: [];
+    }
+
+    private function writeYamlFile(string $filePath, array $contents): void
+    {
+        $yamlFlags = Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK;
+        file_put_contents($filePath, Yaml::dump($contents, 10, indent: 2, flags: $yamlFlags));
+    }
+
+
+}

--- a/src/Mapbender/CoreBundle/Resources/config/commands.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/commands.xml
@@ -63,5 +63,10 @@
             <argument type="service" id="doctrine" />
             <argument>%kernel.project_dir%</argument>
         </service>
+        <service id="Mapbender\CoreBundle\Command\TranslationCommand"
+                 class="Mapbender\CoreBundle\Command\TranslationCommand">
+            <tag name="console.command" command="mapbender:normalize-translations" />
+            <argument type="service" id="Symfony\Component\HttpKernel\KernelInterface" />
+        </service>
     </services>
 </container>

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -89,7 +89,6 @@ mb:
       admin:
         configurations: Konfigurationen
         title: Titel
-        title.help: 'Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird'
         placeholder: Platzhalter
         placeholder.help: 'Text, der im Suchfeld angezeigt wird, wenn dieses leer ist. Wird der Platzhalter nicht gesetzt, wird der Titel verwendet.'
         query_url: 'Query URL'
@@ -127,6 +126,7 @@ mb:
         result_icon_url.help: 'URL zu einer Bilddatei, die als Marker für Punktgeometrien verwendet wird. Kann relativ oder absolut sein. Der Standard-Pin liegt unter <code>/bundles/mapbendercore/image/pin_red.png</code>.'
         result_icon_offset: 'Icon Versatz'
         result_icon_offset.help: 'Positionskorrektur des Icons als kommagetrennter x und y-Versatz, z.B. <code>-6,-32</code> für den Standard-Pin'
+        title.help: 'Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird'
       errors:
         invalid_query_format: 'Das angegebene Query Format enthält keine Platzhalter. Hilfetext beachten!'
         invalid_epsg_code: 'Der eingegebene Text ist kein gültiger EPSG-Code. Geben Sie den Code im Format EPSG:1234 ein'
@@ -259,10 +259,10 @@ mb:
         metadata: Metadaten
         legend: Legende
         kmlexport: 'KML Export'
-        dimensions: Dimensions
         dimension_onoff: 'An/Aus Dimension'
         dimension: Dimension
         sourcevisibility_onoff: 'Dienste anzeigen/ausblenden'
+        dimensions: Dimensions
       class:
         title: Ebenenbaum
         description: 'Baum der Karten-Ebenen'
@@ -583,8 +583,8 @@ mb:
         label: 'Beschriftung anzeigen'
     searchrouterroute:
       admin:
-        title: Titel
         configuration: Konfiguration
+        title: Titel
     instanceset:
       admin:
         title: Titel

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -89,6 +89,7 @@ mb:
       admin:
         configurations: Konfigurationen
         title: Titel
+        title.help: 'Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird'
         placeholder: Platzhalter
         placeholder.help: 'Text, der im Suchfeld angezeigt wird, wenn dieses leer ist. Wird der Platzhalter nicht gesetzt, wird der Titel verwendet.'
         query_url: 'Query URL'
@@ -126,7 +127,6 @@ mb:
         result_icon_url.help: 'URL zu einer Bilddatei, die als Marker für Punktgeometrien verwendet wird. Kann relativ oder absolut sein. Der Standard-Pin liegt unter <code>/bundles/mapbendercore/image/pin_red.png</code>.'
         result_icon_offset: 'Icon Versatz'
         result_icon_offset.help: 'Positionskorrektur des Icons als kommagetrennter x und y-Versatz, z.B. <code>-6,-32</code> für den Standard-Pin'
-        title.help: 'Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird'
       errors:
         invalid_query_format: 'Das angegebene Query Format enthält keine Platzhalter. Hilfetext beachten!'
         invalid_epsg_code: 'Der eingegebene Text ist kein gültiger EPSG-Code. Geben Sie den Code im Format EPSG:1234 ein'
@@ -262,7 +262,6 @@ mb:
         dimension_onoff: 'An/Aus Dimension'
         dimension: Dimension
         sourcevisibility_onoff: 'Dienste anzeigen/ausblenden'
-        dimensions: Dimensions
       class:
         title: Ebenenbaum
         description: 'Baum der Karten-Ebenen'
@@ -583,8 +582,8 @@ mb:
         label: 'Beschriftung anzeigen'
     searchrouterroute:
       admin:
-        configuration: Konfiguration
         title: Titel
+        configuration: Konfiguration
     instanceset:
       admin:
         title: Titel

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -31,30 +31,30 @@ mb:
       typed:
         singular: '%type%-Instanz'
       reusable:
-        singular: Freie Instanz
-        plural: Freie Instanzen
+        singular: 'Freie Instanz'
+        plural: 'Freie Instanzen'
       bound:
-        singular: Private Instanz
-        plural: Private Instanzen
+        singular: 'Private Instanz'
+        plural: 'Private Instanzen'
     security: Sicherheit
   form:
-    choice_required: Auswahl erforderlich
-    choice_optional: Nichts ausgewählt
-    unnamed_entry: Unbenannter Eintrag
+    choice_required: 'Auswahl erforderlich'
+    choice_optional: 'Nichts ausgewählt'
+    unnamed_entry: 'Unbenannter Eintrag'
   states:
     active: aktiv
     inactive: inaktiv
   core:
     featureinfo:
       error:
-        nolayer: Informationsebene existiert nicht.
-        unknownoption: Unbekannte Option %key% für %namespace%.%widgetname%.
-        noresult: kein Ergebnis
+        nolayer: 'Informationsebene existiert nicht.'
+        unknownoption: 'Unbekannte Option %key% für %namespace%.%widgetname%.'
+        noresult: 'kein Ergebnis'
       class:
         title: Information
         description: Information
       admin:
-        maxcount: Max. Anzahl
+        maxcount: 'Max. Anzahl'
         height: Höhe
         width: Breite
         displaytype: Anzeigetyp
@@ -64,11 +64,11 @@ mb:
       content:
         versionprefix: Version
         learnmore: 'Lernen Sie Mapbender kennen '
-        linktitle: Besuchen Sie die offizielle Mapbender Webseite.
+        linktitle: 'Besuchen Sie die offizielle Mapbender Webseite.'
         website: '- zur Webseite'
       class:
         title: Über-Mapbender-Dialog
-        description: Der Über-Mapbender-Dialog zeigt Informationen zu Mapbender an.
+        description: 'Der Über-Mapbender-Dialog zeigt Informationen zu Mapbender an.'
       tag:
         help: Hilfe
         info: Info
@@ -79,65 +79,65 @@ mb:
       input:
         searchterm: Suchbegriff
         search: Suchen
-        clear: Eingabe löschen
+        clear: 'Eingabe löschen'
       class:
-        title: Einfache Suche
-        description: Einfeldsuche über JSON-Daten (z.B. Solr)
+        title: 'Einfache Suche'
+        description: 'Einfeldsuche über JSON-Daten (z.B. Solr)'
       error:
         geometry:
-          missing: Der ausgewählte Eintrag enthält keine Geometrie.
+          missing: 'Der ausgewählte Eintrag enthält keine Geometrie.'
       admin:
         configurations: Konfigurationen
         title: Titel
-        title.help: Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird
+        title.help: 'Text, der im Dropdown zur Auswahl der Konfigurationen angezeigt wird'
         placeholder: Platzhalter
-        placeholder.help: Text, der im Suchfeld angezeigt wird, wenn dieses leer ist. Wird der Platzhalter nicht gesetzt, wird der Titel verwendet.
-        query_url: Query URL
-        query_url.help: Solr bzw. Nominatim URL, an die der eingegebene Suchbegriff gesendet wird (z.B. <code>https://nominatim.openstreetmap.org/search.php?format=geojson</code>).
-        query_key: Query URL-Parameter
-        query_key.help: Der URL Parameter, der mit dem eingebenen Suchbegriff befüllt wird (z.B. <code>q</code>)
-        query_ws_replace: Query Whitespace Ersetzung
-        query_ws_replace.help: Falls angegeben, werden Leerzeichen und Zeilenumbrüche in der Suchanfrage hierdurch ersetzt, z.B. <code>+</code> oder <code>%20</code>
-        query_format: Query Key Format
-        query_format.help: Format für PHPs <a href="https://www.php.net/manual/en/function.sprintf.php" target="_blank">sprintf</a>-Funktion, mit dem der Suchbegriff formatiert wird, z.B. <code>%s</code> (Standard) wenn der Suchbegriff als Zeichenkette interpretiert werden soll, <code>%d</code> wenn die Suche eine Zahl erwartet
+        placeholder.help: 'Text, der im Suchfeld angezeigt wird, wenn dieses leer ist. Wird der Platzhalter nicht gesetzt, wird der Titel verwendet.'
+        query_url: 'Query URL'
+        query_url.help: 'Solr bzw. Nominatim URL, an die der eingegebene Suchbegriff gesendet wird (z.B. <code>https://nominatim.openstreetmap.org/search.php?format=geojson</code>).'
+        query_key: 'Query URL-Parameter'
+        query_key.help: 'Der URL Parameter, der mit dem eingebenen Suchbegriff befüllt wird (z.B. <code>q</code>)'
+        query_ws_replace: 'Query Whitespace Ersetzung'
+        query_ws_replace.help: 'Falls angegeben, werden Leerzeichen und Zeilenumbrüche in der Suchanfrage hierdurch ersetzt, z.B. <code>+</code> oder <code>%20</code>'
+        query_format: 'Query Key Format'
+        query_format.help: 'Format für PHPs <a href="https://www.php.net/manual/en/function.sprintf.php" target="_blank">sprintf</a>-Funktion, mit dem der Suchbegriff formatiert wird, z.B. <code>%s</code> (Standard) wenn der Suchbegriff als Zeichenkette interpretiert werden soll, <code>%d</code> wenn die Suche eine Zahl erwartet'
         token_regex: 'Tokenizer: Split Regex'
         token_regex.help: 'Mit dem Tokenizer ist es möglich, Suchbegriffe zu verändern, bevor sie an die Such-URL gesendet werden. Der Split Regex sollte alle Zeichen matchen, die ein neues Token (i.d.R. neues Wort) einleiten. Standard: <code> </code> (Leerzeichen)'
         token_regex_in: 'Tokenizer: Such-Regex'
-        token_regex_in.help: Innerhalb jedes Tokens (siehe Split Regex) wird nach diesem regulären Ausdruck gesucht und mit dem Wert aus "Ersetzungs-Regex" ersetzt.
+        token_regex_in.help: 'Innerhalb jedes Tokens (siehe Split Regex) wird nach diesem regulären Ausdruck gesucht und mit dem Wert aus "Ersetzungs-Regex" ersetzt.'
         token_regex_out: 'Tokenizer: Ersetzungs-Regex'
-        token_regex_out.help: Innerhalb jedes Tokens (siehe Split Regex) wird der regulären Ausdruck aus "Such-Regex" mit diesem Wert ersetzt. Gefundene Gruppen werden mit <code>$</code> durchnummeriert referenziert. Beispielsweise würde <code>$1*</code> an jedes Suchwort ein Stern ergänzen.
-        collection_path: Pfad zu den Ergebnissen
-        collection_path.help: Pfad zu der Liste an Ergebnissen innerhalb der Antwort der Such-URL. Jede Hierarchie-Ebene ist durch einen Punkt getrennt, z.B. <code>response.docs</code> (Solr-Standard), <code>features</code> (GeoJSON)
-        label_attribute: Attribut für Beschriftung
-        label_attribute.help: Pfad (innerhalb eines einzelnen Ergebnisses) zu dem Attribut, das als Beschriftung angezeigt werden soll, z.B. <code>label</code>. Alternativ kann ein String-Template angegeben werden, z.B. <code>Stadt ${properties.address.city} - ${properties.address.road}</code>
-        geom_attribute: Attribut für Geometrie
-        geom_attribute.help: Pfad (innerhalb eines einzelnen Ergebnisses) zu dem Attribut, in dem die Geometrie verfügbar ist, z.B. <code>geom</code>, <code>geometry</code> (GeoJSON)
+        token_regex_out.help: 'Innerhalb jedes Tokens (siehe Split Regex) wird der regulären Ausdruck aus "Such-Regex" mit diesem Wert ersetzt. Gefundene Gruppen werden mit <code>$</code> durchnummeriert referenziert. Beispielsweise würde <code>$1*</code> an jedes Suchwort ein Stern ergänzen.'
+        collection_path: 'Pfad zu den Ergebnissen'
+        collection_path.help: 'Pfad zu der Liste an Ergebnissen innerhalb der Antwort der Such-URL. Jede Hierarchie-Ebene ist durch einen Punkt getrennt, z.B. <code>response.docs</code> (Solr-Standard), <code>features</code> (GeoJSON)'
+        label_attribute: 'Attribut für Beschriftung'
+        label_attribute.help: 'Pfad (innerhalb eines einzelnen Ergebnisses) zu dem Attribut, das als Beschriftung angezeigt werden soll, z.B. <code>label</code>. Alternativ kann ein String-Template angegeben werden, z.B. <code>Stadt ${properties.address.city} - ${properties.address.road}</code>'
+        geom_attribute: 'Attribut für Geometrie'
+        geom_attribute.help: 'Pfad (innerhalb eines einzelnen Ergebnisses) zu dem Attribut, in dem die Geometrie verfügbar ist, z.B. <code>geom</code>, <code>geometry</code> (GeoJSON)'
         geom_format: Geometrie-Format
-        geom_format.help: Format, in dem die Geometrie verfügbar ist, entweder <a href="https://de.wikipedia.org/wiki/Simple_Feature_Access#Well-known_Text" target="_blank">Well Known Text</a> oder <a href="https://geojson.org/" target="_blank">GeoJSON</a>
+        geom_format.help: 'Format, in dem die Geometrie verfügbar ist, entweder <a href="https://de.wikipedia.org/wiki/Simple_Feature_Access#Well-known_Text" target="_blank">Well Known Text</a> oder <a href="https://geojson.org/" target="_blank">GeoJSON</a>'
         sourceSrs: Quell-SRS
-        sourceSrs.help: <a href="https://epsg.io/" target="_blank">EPSG-Code</a> der in der Such-URL verwendeten Projektion, inklusive des Präfixes <code>EPSG:</code>, z.B. <code>EPSG:25832</code>. Falls nicht angegeben, wird angenommen, dass die Ergebnisse in der Standard-Kartenprojektion vorliegen.
-        delay: Such-Verzögerung [ms]
+        sourceSrs.help: '<a href="https://epsg.io/" target="_blank">EPSG-Code</a> der in der Such-URL verwendeten Projektion, inklusive des Präfixes <code>EPSG:</code>, z.B. <code>EPSG:25832</code>. Falls nicht angegeben, wird angenommen, dass die Ergebnisse in der Standard-Kartenprojektion vorliegen.'
+        delay: 'Such-Verzögerung [ms]'
         delay.help: 'Zeit in Millisekunden, die nach der letzten Tasteneingabe gewartet wird, bis die Suche automatisch ausgeführt wird. Standard: 300ms'
-        result_buffer: Ergebnis-Puffer [Karteneinheiten]
-        result_buffer.help: Bestimmt indirekt die Zoomstufe, die nach Auswählen eines Ergebnisses erscheint. Um die Geometrie herum ist mindestens der ausgewählte Bereich sichtbar. Die Einheit Karteneinheiten variiert je nach Projektion, meist sind es Meter. Eine Kombination zu Maßstab (min/max) ist grundsätzlich möglich, kann aber zu unerwünschten Ergebnissen führen.
-        result_minscale: minimaler Maßstab [Nenner]
+        result_buffer: 'Ergebnis-Puffer [Karteneinheiten]'
+        result_buffer.help: 'Bestimmt indirekt die Zoomstufe, die nach Auswählen eines Ergebnisses erscheint. Um die Geometrie herum ist mindestens der ausgewählte Bereich sichtbar. Die Einheit Karteneinheiten variiert je nach Projektion, meist sind es Meter. Eine Kombination zu Maßstab (min/max) ist grundsätzlich möglich, kann aber zu unerwünschten Ergebnissen führen.'
+        result_minscale: 'minimaler Maßstab [Nenner]'
         result_minscale.help: 'Alternative Angabe der Zoomstufe. Je nach Größe der Zielgeometrie wird ein Maßstab zwischen <code>min</code> und <code>max</code> eingestellt. Bei einem Maßstab <code>1 : 1000</code> muss nur <code>1000</code> eingegeben werden. Für einen festen Maßstab genügt die Eingabe des minimalen Maßstabs.'
-        result_maxscale: maximaler Maßstab [Nenner]
-        result_icon_url: Icon URL
-        result_icon_url.help: URL zu einer Bilddatei, die als Marker für Punktgeometrien verwendet wird. Kann relativ oder absolut sein. Der Standard-Pin liegt unter <code>/bundles/mapbendercore/image/pin_red.png</code>.
-        result_icon_offset: Icon Versatz
-        result_icon_offset.help: Positionskorrektur des Icons als kommagetrennter x und y-Versatz, z.B. <code>-6,-32</code> für den Standard-Pin
+        result_maxscale: 'maximaler Maßstab [Nenner]'
+        result_icon_url: 'Icon URL'
+        result_icon_url.help: 'URL zu einer Bilddatei, die als Marker für Punktgeometrien verwendet wird. Kann relativ oder absolut sein. Der Standard-Pin liegt unter <code>/bundles/mapbendercore/image/pin_red.png</code>.'
+        result_icon_offset: 'Icon Versatz'
+        result_icon_offset.help: 'Positionskorrektur des Icons als kommagetrennter x und y-Versatz, z.B. <code>-6,-32</code> für den Standard-Pin'
       errors:
-        invalid_query_format: Das angegebene Query Format enthält keine Platzhalter. Hilfetext beachten!
-        invalid_epsg_code: Der eingegebene Text ist kein gültiger EPSG-Code. Geben Sie den Code im Format EPSG:1234 ein
-        no_configuration_added: Bitte fügen Sie mindestens eine Konfiguration hinzu
+        invalid_query_format: 'Das angegebene Query Format enthält keine Platzhalter. Hilfetext beachten!'
+        invalid_epsg_code: 'Der eingegebene Text ist kein gültiger EPSG-Code. Geben Sie den Code im Format EPSG:1234 ein'
+        no_configuration_added: 'Bitte fügen Sie mindestens eine Konfiguration hinzu'
     searchrouter:
-      no_results: Keine Ergebnisse gefunden.
+      no_results: 'Keine Ergebnisse gefunden.'
       result_counter: 'Ergebnisse: %count%'
-      exportcsv: Export der Trefferliste als CSV.
+      exportcsv: 'Export der Trefferliste als CSV.'
       class:
         title: Suchen
-        description: Ermöglicht die Konfiguration von individuellen Suchen
+        description: 'Ermöglicht die Konfiguration von individuellen Suchen'
       tag:
         search: Suchen
         router: Router
@@ -146,29 +146,29 @@ mb:
         height: Höhe
         routes: Routen
     poi:
-      sharepoi: Treffpunkt vereinbaren
+      sharepoi: 'Treffpunkt vereinbaren'
       text:
-        snippet: Sie können den folgenden Link in einer E-Mail verschicken. Der Link öffnet die Anwendung und zeigt den Treffpunkt an.
+        snippet: 'Sie können den folgenden Link in einer E-Mail verschicken. Der Link öffnet die Anwendung und zeigt den Treffpunkt an.'
       popup:
         btn:
           position: Positionierung
       class:
-        title: MeetingPoint (POI)
-        description: Element über das eine Treffpunkt generiert und verschickt werden kann.
+        title: 'MeetingPoint (POI)'
+        description: 'Element über das eine Treffpunkt generiert und verschickt werden kann.'
       label:
-        text: Bearbeiten Sie den Text
+        text: 'Bearbeiten Sie den Text'
       admin:
         body: Text
         gps: GPS
-        placeholder: Bitte schauen Sie sich diesen POI an
+        placeholder: 'Bitte schauen Sie sich diesen POI an'
     basesourceswitcher:
       error:
-        sourcenotavailable: Der Dienst mit der ID %id% ist nicht vorhanden.
+        sourcenotavailable: 'Der Dienst mit der ID %id% ist nicht vorhanden.'
       class:
-        title: Hintergrund wechseln
-        Description: Hintergrundkarten können definiert werden. In der Anwendung kann zwischen diesen gewechselt werden.
+        title: 'Hintergrund wechseln'
+        Description: 'Hintergrundkarten können definiert werden. In der Anwendung kann zwischen diesen gewechselt werden.'
       form:
-        mesage: Keine Hintergrund Definitionen vorhanden.
+        mesage: 'Keine Hintergrund Definitionen vorhanden.'
         instancesets: Instancesets
       admin:
         tooltip: Tooltip
@@ -177,7 +177,7 @@ mb:
     legend:
       class:
         title: Legende
-        description: Zeigt die Legende zu den aktiven Themen der Karte an.
+        description: 'Zeigt die Legende zu den aktiven Themen der Karte an.'
     ruler:
       create_error: 'Messen: Der Geometrietyp muss eine Linie oder eine Fläche sein.'
       class:
@@ -187,13 +187,13 @@ mb:
         line: Linie
         area: Fläche
         measure: Messen
-      help: Doppelklicken zum Beenden
+      help: 'Doppelklicken zum Beenden'
       admin:
         type: Geometrie
         help: Hilfetext
-        help_help: Der Standardwert <code>mb.core.ruler.help</code> bedeutet "Doppelklicken zum Beenden" in der Sprache des Nutzers
-        stroke_width_while_drawing: Linienstärke während des Zeichnens
-        only_for_area: nur relevant, wenn <i>Fläche</i> als Geometrie ausgewählt ist
+        help_help: 'Der Standardwert <code>mb.core.ruler.help</code> bedeutet "Doppelklicken zum Beenden" in der Sprache des Nutzers'
+        stroke_width_while_drawing: 'Linienstärke während des Zeichnens'
+        only_for_area: 'nur relevant, wenn <i>Fläche</i> als Geometrie ausgewählt ist'
         style: Stil
     printclient:
       label:
@@ -201,36 +201,36 @@ mb:
         quality: Qualität
         scale: Maßstab
         rotation: Drehung
-        legend: Legende drucken
+        legend: 'Legende drucken'
       class:
         title: Druck
-        description: Druck Dialog
+        description: 'Druck Dialog'
       btn:
-        deactivate: Druckrahmen deaktivieren
-        activate: Druckrahmen aktivieren
+        deactivate: 'Druckrahmen deaktivieren'
+        activate: 'Druckrahmen aktivieren'
     overview:
-      nolayer: Die Übersicht enthält keine Ebene.
+      nolayer: 'Die Übersicht enthält keine Ebene.'
       class:
-        title: Übersicht (overview)
-        description: Zeigt eine kleine Übersichtskarte (overview) an.
+        title: 'Übersicht (overview)'
+        description: 'Zeigt eine kleine Übersichtskarte (overview) an.'
       tag:
         overview: Übersicht
-        map: Karte (overview)
+        map: 'Karte (overview)'
       admin:
-        visibility.closed_initially: Initial geschlossen
-        visibility.open_initially: Initial offen
-        visibility.open_permanent: Dauerhaft offen
+        visibility.closed_initially: 'Initial geschlossen'
+        visibility.open_initially: 'Initial offen'
+        visibility.open_permanent: 'Dauerhaft offen'
         layerset: Layerset
     metadata:
       popup:
         title: Metadaten
     gpsposition:
       error:
-        notsupported: Der Geolocation Dienst wird von Ihrem Browser nicht unterstützt.
-        nosignal: Es ist nicht möglich Ihre Position zu bestimmen.
+        notsupported: 'Der Geolocation Dienst wird von Ihrem Browser nicht unterstützt.'
+        nosignal: 'Es ist nicht möglich Ihre Position zu bestimmen.'
       class:
         title: GPS-Position
-        description: Übergibt einen Button um die GPS-Position anzuzeigen.
+        description: 'Übergibt einen Button um die GPS-Position anzuzeigen.'
       tag:
         gpsposition: GPS-Position
         gps: GPS
@@ -239,49 +239,49 @@ mb:
       admin:
         average: Durchschnitt
         follow: Folge
-        centeronfirstposition: Zentriere auf die erste Position
-        zoomtoaccuracyonfirstposition: Zoom auf Genauigkeit der ersten Position
+        centeronfirstposition: 'Zentriere auf die erste Position'
+        zoomtoaccuracyonfirstposition: 'Zoom auf Genauigkeit der ersten Position'
     layertree:
       const:
-        outofscale: Ebene außerhalb des Maßstabs
-        outofbounds: Ebene außerhalb der BoundingBox
-        parentinvisible: Eltern Ebene nicht sichtbar
+        outofscale: 'Ebene außerhalb des Maßstabs'
+        outofbounds: 'Ebene außerhalb der BoundingBox'
+        parentinvisible: 'Eltern Ebene nicht sichtbar'
       tooltip:
         sublayers_openclose: öffnen/schließen
-        removelayer: Ebene entfernen
+        removelayer: 'Ebene entfernen'
         menu:
           close: Schließen
       label:
-        visibility_onoff: Sichtbarkeit an/aus
-        featureinfo_onoff: Information an/aus
+        visibility_onoff: 'Sichtbarkeit an/aus'
+        featureinfo_onoff: 'Information an/aus'
         opacity: Deckkraft
-        zoomtolayer: Zoom auf Ebene
+        zoomtolayer: 'Zoom auf Ebene'
         metadata: Metadaten
         legend: Legende
-        kmlexport: KML Export
+        kmlexport: 'KML Export'
         dimensions: Dimensions
-        dimension_onoff: An/Aus Dimension
+        dimension_onoff: 'An/Aus Dimension'
         dimension: Dimension
-        sourcevisibility_onoff: Dienste anzeigen/ausblenden
+        sourcevisibility_onoff: 'Dienste anzeigen/ausblenden'
       class:
         title: Ebenenbaum
-        description: Baum der Karten-Ebenen
+        description: 'Baum der Karten-Ebenen'
       admin:
-        layerremove: Ebene entfernen
+        layerremove: 'Ebene entfernen'
         opacity: Deckkraft
-        zoomtolayer: Auf Ebene zoomen
+        zoomtolayer: 'Auf Ebene zoomen'
         metadata: Metadaten
         dimension: Abmessung
     zoombar:
-      zoombybox: Ausschnitt aufziehen
-      zoombyworld: Zoom auf gesamte Ausdehnung
-      zoom_home: Zurück zum Anfang
+      zoombybox: 'Ausschnitt aufziehen'
+      zoombyworld: 'Zoom auf gesamte Ausdehnung'
+      zoom_home: 'Zurück zum Anfang'
       zoomHomeRestoresLayers: '"Zurück zum Anfang" setzt Dienstezustände zurück'
       zoomin: Hineinzoomen
       zoomout: Herauszoomen
       class:
         title: Navigationswerkzeug
-        description: Das Navigationswerkzeug bietet Zoomen und Verschieben an, ähnlich wie bei OpenLayers.
+        description: 'Das Navigationswerkzeug bietet Zoomen und Verschieben an, ähnlich wie bei OpenLayers.'
       tag:
         zoom: Zoom
         pan: Verschieben
@@ -291,22 +291,22 @@ mb:
       admin:
         components: Komponenten
         rotation: Drehen
-        zoommax: Zoom auf maximale Ausdehnung
-        zoominout: Rein- und Rauszoomen
+        zoommax: 'Zoom auf maximale Ausdehnung'
+        zoominout: 'Rein- und Rauszoomen'
         zoomslider: Zoom-Schieberegler
     activityindicator:
       class:
         title: Aktivitätsanzeige
-        description: Zeigt HTTP-Aktivität an.
+        description: 'Zeigt HTTP-Aktivität an.'
       tag:
         activity: Aktivität
         indicator: Indikator
       admin:
         tooltip: Tooltip
-        activityclass: CSS-Klasse Aktivität generell
-        ajaxactivityclass: CSS-Klasse bei Hintergrundaktivität
-        ajaxactivityclass_help: CSS-Klasse, die gesetzt wird, wenn eine Aktion im Hintergrund ausgeführt wird, z.B. wenn eine Suche durchgeführt wird
-        tileactivityclass: CSS-Klasse bei Laden der Karte
+        activityclass: 'CSS-Klasse Aktivität generell'
+        ajaxactivityclass: 'CSS-Klasse bei Hintergrundaktivität'
+        ajaxactivityclass_help: 'CSS-Klasse, die gesetzt wird, wenn eine Aktion im Hintergrund ausgeführt wird, z.B. wenn eine Suche durchgeführt wird'
+        tileactivityclass: 'CSS-Klasse bei Laden der Karte'
     button:
       class:
         title: Button
@@ -319,20 +319,20 @@ mb:
         deactivate: Deaktivieren
     controlbutton:
       class:
-        description: Steuert ein anderes Element
+        description: 'Steuert ein anderes Element'
       admin:
         group: Gruppe
         target: Ziel
     linkbutton:
       class:
         title: Link
-        description: Link zu externer URL
+        description: 'Link zu externer URL'
       admin:
         click: Ziel-URL
     coordinatesdisplay:
       class:
         title: Koordinatenanzeige
-        description: Die Koordinatenanzeige zeigt die Mausposition in den Kartenkoordinaten an.
+        description: 'Die Koordinatenanzeige zeigt die Mausposition in den Kartenkoordinaten an.'
       tag:
         coordinates: Koordinaten
         display: Anzeige
@@ -341,7 +341,7 @@ mb:
     copyright:
       class:
         title: Copyright
-        description: Zeigt Nutzungsbedingungen an.
+        description: 'Zeigt Nutzungsbedingungen an.'
       tag:
         copyright: Copyright
         dialog: Dialog
@@ -350,46 +350,46 @@ mb:
     map:
       class:
         title: Karte
-        description: Hauptkarte basiernd auf OpenLayers
+        description: 'Hauptkarte basiernd auf OpenLayers'
       tag:
         map: Karte
         mapquery: MapQuery
         openlayers: OpenLayers
-      srsnotfound: SRS Eigenschaften für %srslist% wurden nicht gefunden.
+      srsnotfound: 'SRS Eigenschaften für %srslist% wurden nicht gefunden.'
       admin:
-        fixedZoomSteps: Feste Maßstabsstufen
+        fixedZoomSteps: 'Feste Maßstabsstufen'
         layersets: Layersets
         tilesize: Kachelgröße
         SRS: SRS
-        scales: Maßstäbe (komma-separiert)
-        othersrs: Andere SRS
+        scales: 'Maßstäbe (komma-separiert)'
+        othersrs: 'Andere SRS'
         srs: SRS
     scalebar:
       class:
         title: Maßstabsleiste
-        description: Maßstabsleiste, die den aktuellen Maßstab anzeigt.
+        description: 'Maßstabsleiste, die den aktuellen Maßstab anzeigt.'
       tag:
         scale: Maßstab
         bar: Leiste
       admin:
-        maxwidth: Maximale Breite
+        maxwidth: 'Maximale Breite'
         units: Einheit
     scaledisplay:
       label: Maßstab
       scale_prefix: Präfix
-      scale_prefix.help: Bezeichnung, die vor der Maßstabsangabe steht. Der Standard <code>mb.core.scaledisplay.label</code> wird als <code>Maßstab</code> in der Sprache des Benutzers gerendert.
-      unit_prefix: Maßstab abkürzen
-      unit_prefix.help: Falls aktiviert, werden Maßstabszahlen über 1.000 nicht ausgeschrieben, sondern mit nachgestelltem <code>K</code> oder <code>M</code> versehen.
+      scale_prefix.help: 'Bezeichnung, die vor der Maßstabsangabe steht. Der Standard <code>mb.core.scaledisplay.label</code> wird als <code>Maßstab</code> in der Sprache des Benutzers gerendert.'
+      unit_prefix: 'Maßstab abkürzen'
+      unit_prefix.help: 'Falls aktiviert, werden Maßstabszahlen über 1.000 nicht ausgeschrieben, sondern mit nachgestelltem <code>K</code> oder <code>M</code> versehen.'
       class:
         title: Maßstabsanzeige
-        description: Der aktuelle Maßstab wird angezeigt.
+        description: 'Der aktuelle Maßstab wird angezeigt.'
       tag:
         scale: Maßstab
         display: Anzeige
     scaleselector:
       class:
         title: Maßstabsauswahl
-        description: Auswahlbox mit verfügbaren Maßstäben zum Wechseln des Maßstabs. Zeigt den aktuellen Maßstab an.
+        description: 'Auswahlbox mit verfügbaren Maßstäben zum Wechseln des Maßstabs. Zeigt den aktuellen Maßstab an.'
       tag:
         scale: Maßstab
         selector: Auswahl
@@ -397,8 +397,8 @@ mb:
         tooltip: Tooltip
     srsselector:
       class:
-        title: SRS Auswahl
-        description: Nach der Auswahl eines räumlichen Referenzsystems (SRS) ändert sich das SRS in der Karte.
+        title: 'SRS Auswahl'
+        description: 'Nach der Auswahl eines räumlichen Referenzsystems (SRS) ändert sich das SRS in der Karte.'
       tag:
         srs: SRS
         selector: Auswahl
@@ -407,107 +407,107 @@ mb:
         tooltip: Tooltip
     ShareUrl:
       class:
-        title: URL teilen
-        description: Teilt die aktuelle Kartenansicht über eine URL
-      copied_to_clipboard: URL in Zwischenablage kopiert
+        title: 'URL teilen'
+        description: 'Teilt die aktuelle Kartenansicht über eine URL'
+      copied_to_clipboard: 'URL in Zwischenablage kopiert'
     viewManager:
       class:
         title: Ansichtsverwaltung
-        description: Speichert Kartenzustände zum späteren Abruf
-      saveAsPublic: Als öffentlichen Eintrag speichern
+        description: 'Speichert Kartenzustände zum späteren Abruf'
+      saveAsPublic: 'Als öffentlichen Eintrag speichern'
       recordStatus:
-        public: Öffentlicher Eintrag
-        private: Privater Eintrag
-      confirmDelete: Eintrag wirklich löschen?
-      no_data: Keine Daten
+        public: 'Öffentlicher Eintrag'
+        private: 'Privater Eintrag'
+      confirmDelete: 'Eintrag wirklich löschen?'
+      no_data: 'Keine Daten'
       title: Titel
       date: Datum
-      enter_title: Titel eingeben
+      enter_title: 'Titel eingeben'
       apply: Abrufen
       replace: Überschreiben
-      details: Details anzeigen
+      details: 'Details anzeigen'
       admin:
-        access.none: Nicht anzeigen
-        access.ro: Nur lesen
-        access.rw: Speichern erlauben
-        access.rwd: Speichern und löschen erlauben
-        publicEntries: Öffentliche Liste
-        privateEntries: Private Liste anzeigen
+        access.none: 'Nicht anzeigen'
+        access.ro: 'Nur lesen'
+        access.rw: 'Speichern erlauben'
+        access.rwd: 'Speichern und löschen erlauben'
+        publicEntries: 'Öffentliche Liste'
+        privateEntries: 'Private Liste anzeigen'
         adminDeleteHint: 'Hinweis: Administratoren dürfen öffentliche Einträge immer löschen'
-        allowAnonymousSave: Anonyme Besucher dürfen speichern
-        showDate: Datum anzeigen
+        allowAnonymousSave: 'Anonyme Besucher dürfen speichern'
+        showDate: 'Datum anzeigen'
     coordinatesutility:
       class:
         title: Koordinaten-Werkzeug
-        description: Koordinaten-Transformation. Navigation zu Koordinaten auf der Karte.
+        description: 'Koordinaten-Transformation. Navigation zu Koordinaten auf der Karte.'
       widget:
         error:
-          noSrs: Kein SRS ist definiert
-          invalidCoordinates: Ungültige Koordinaten
+          noSrs: 'Kein SRS ist definiert'
+          invalidCoordinates: 'Ungültige Koordinaten'
       view:
         srs:
           title: Koordinatensystem
           tooltip: Koordinatensystem
         transformedCoordinates:
-          tooltip: Transformierte Koordinaten
+          tooltip: 'Transformierte Koordinaten'
         copytoclipboard:
-          tooltip: Koordinaten in die Zwischenablage kopieren
+          tooltip: 'Koordinaten in die Zwischenablage kopieren'
         originCoordinates:
-          title: Koordinaten im Anzeige-Koordinatensystem der Karte
-          tooltip: nicht editierbar
+          title: 'Koordinaten im Anzeige-Koordinatensystem der Karte'
+          tooltip: 'nicht editierbar'
         button:
           search: Koordinatensuche
-          centermap: Karte zentrieren
+          centermap: 'Karte zentrieren'
       backend:
-        addMapSrsList: Koordinatensysteme von der Karte hinzufügen
+        addMapSrsList: 'Koordinatensysteme von der Karte hinzufügen'
       admin:
         srslist: SRS-Liste
         zoomlevel: Zoomstufe
     admin:
       poi:
         label:
-          usemailto: Versenden per Mail - Mailclient öffnen
+          usemailto: 'Versenden per Mail - Mailclient öffnen'
       legend:
         label:
-          hideemptylayers: Ebenen ohne Objekte ausblenden
-          generatelegendurl: Legenden-URL generieren
-          showsourcetitle: Titel der Datenquelle anzeigen
-          showlayertitle: Titel der Ebene anzeigen
-          showgroupedlayertitle: Titel der gruppierten Ebene anzeigen
+          hideemptylayers: 'Ebenen ohne Objekte ausblenden'
+          generatelegendurl: 'Legenden-URL generieren'
+          showsourcetitle: 'Titel der Datenquelle anzeigen'
+          showlayertitle: 'Titel der Ebene anzeigen'
+          showgroupedlayertitle: 'Titel der gruppierten Ebene anzeigen'
       featureinfo:
         label:
-          deactivateonclose: Beim Schließen deaktivieren
-          onlyvalid: Nur valide zeigen
+          deactivateonclose: 'Beim Schließen deaktivieren'
+          onlyvalid: 'Nur valide zeigen'
           highlighting_group: Highlighting
-          highlighting: Highlighting aktiv
+          highlighting: 'Highlighting aktiv'
           default_group: Standard
           hover_group: Hover
           fillColor: Füllfarbe
           strokeColor: Strichfarbe
-          opacity_pct: Deckkraft (%)
-          stroke_width_px: Linienstärke (Pixel)
+          opacity_pct: 'Deckkraft (%)'
+          stroke_width_px: 'Linienstärke (Pixel)'
           fontColor: Schriftfarbe
           fontSize: Schriftgröße
       printclient:
         label:
           rotatable: Drehbar
-          legend: Legende drucken
-          legend_default_behaviour: Legenden Checkbox aktiv
-          required_fields_first: Pflichtfelder ganz oben anzeigen
+          legend: 'Legende drucken'
+          legend_default_behaviour: 'Legenden Checkbox aktiv'
+          required_fields_first: 'Pflichtfelder ganz oben anzeigen'
       layertree:
         label:
-          showbasesources: BaseSources anzeigen
+          showbasesources: 'BaseSources anzeigen'
           showlayerremove: '"Layer entfernen" anzeigen'
-          usetheme: Thematischer Layer
+          usetheme: 'Thematischer Layer'
           themes: Themen
           theme:
-            opened: Thema geöffnet/geschlossen
-            activate: Aktivieren von Layers hinzufügen/entfernen
-            useTheme: Thema anzeigen
+            opened: 'Thema geöffnet/geschlossen'
+            activate: 'Aktivieren von Layers hinzufügen/entfernen'
+            useTheme: 'Thema anzeigen'
             label: Themenname
-          hidenottoggleable: Nicht aufklappbare Ordner ausblenden
-          hideselect: Visibility bei Ordnern ausblenden
-          hideinfo: Info ausblenden
+          hidenottoggleable: 'Nicht aufklappbare Ordner ausblenden'
+          hideselect: 'Visibility bei Ordnern ausblenden'
+          hideinfo: 'Info ausblenden'
           menu: Menü
       template:
         sidepane:
@@ -518,7 +518,7 @@ mb:
               accordion: Akkordeon
               unstyled: Unformatiert
       button:
-        show_label: Beschriftung anzeigen
+        show_label: 'Beschriftung anzeigen'
         label: Beschriftung
       layerset:
         label:
@@ -527,14 +527,14 @@ mb:
     htmlelement:
       class:
         title: HTML
-        description: HTML hinzufügen
+        description: 'HTML hinzufügen'
       admin:
         content: Inhalt
         classes: Klassen
     entity:
       app:
         screenshotfile:
-          error: Die Datei ist zu groß. Die maximal zulässige Größe beträgt %limit% bytes.
+          error: 'Die Datei ist zu groß. Die maximal zulässige Größe beträgt %limit% bytes.'
     sketch:
       geometrytype:
         point: Punkt
@@ -547,40 +547,40 @@ mb:
         radius: Radius
       geometry:
         action:
-          remove: Entfernen der Geometrie
-          edit: Editieren der Geometrie
-          zoom: Zoom auf die Geometrie
-          stop_drawing: Zeichnen abbrechen
+          remove: 'Entfernen der Geometrie'
+          edit: 'Editieren der Geometrie'
+          zoom: 'Zoom auf die Geometrie'
+          stop_drawing: 'Zeichnen abbrechen'
       class:
         title: Skizzen
         description: Zeichenwerkzeug
       admin:
-        deactivate_on_close: Beim Schließen deaktivieren
+        deactivate_on_close: 'Beim Schließen deaktivieren'
         colors: Farben
-        allow_custom_color: Farbanpassung erlauben
+        allow_custom_color: 'Farbanpassung erlauben'
         geometrytypes: Geometrie-Typen
     redlining:
       class:
         title: Skizzen
     resetView:
       class:
-        title: Ansicht zurücksetzen
-        description: Stellt den ursprünglichen Kartenausschnitt und Diensteeinstellungen wieder her
+        title: 'Ansicht zurücksetzen'
+        description: 'Stellt den ursprünglichen Kartenausschnitt und Diensteeinstellungen wieder her'
       admin:
-        resetDynamicSources: Hinzugeladene Quellen entfernen
+        resetDynamicSources: 'Hinzugeladene Quellen entfernen'
     applicationSwitcher:
       class:
-        title: Anwendung wechseln
-        description: Wechselt unter Beibehaltung der aktuellen Kartenposition zu einer anderen Anwendung
+        title: 'Anwendung wechseln'
+        description: 'Wechselt unter Beibehaltung der aktuellen Kartenposition zu einer anderen Anwendung'
       admin:
-        open_in_new_tab: In neuem Tab öffnen
+        open_in_new_tab: 'In neuem Tab öffnen'
     coordinesdisplay:
       admin:
-        numdigits: Anzahl der Nachkommastellen
-        empty: Leere Anzeige
+        numdigits: 'Anzahl der Nachkommastellen'
+        empty: 'Leere Anzeige'
         prefix: Präfix
         separator: Trennzeichen
-        label: Beschriftung anzeigen
+        label: 'Beschriftung anzeigen'
     searchrouterroute:
       admin:
         title: Titel
@@ -599,15 +599,15 @@ mb:
       mb:
         about: Information
         layer_tree: Ebenenbaum
-        feature_info: Feature Info
-        area_ruler: Fläche messen
+        feature_info: 'Feature Info'
+        area_ruler: 'Fläche messen'
         polygon: Polygon
-        line_ruler: Strecke messen
+        line_ruler: 'Strecke messen'
         image_export: Bildexport
         legend: Legende
       fa:
         about: Gruppe
-        info: Information (invertiert)
+        info: 'Information (invertiert)'
         pin: Marker
         home: Startseite
         legend: Liste
@@ -624,15 +624,15 @@ mb:
         copyright: Copyright
         share: Teilen
         forward: Weiterleiten
-        refresh: Neu laden
+        refresh: 'Neu laden'
         earth: Erdkugel
         map: Karte
-        pin_alt: Stecknadel (Alternative)
+        pin_alt: 'Stecknadel (Alternative)'
         help: Hilfe
   template:
-    toolbar_menu_tooltip: Menü öffnen
+    toolbar_menu_tooltip: 'Menü öffnen'
     region:
-      toolbar: Obere Werkzeugleiste
+      toolbar: 'Obere Werkzeugleiste'
       footer: Fußzeile
       sidepane: Sidepane
       content: Kartenbereich
@@ -641,18 +641,18 @@ mb:
     backgroundThemes: Hintergrundthemen
     baseMaps: Karten
     aerialView: Luftbilder
-    noBackground: kein Hintergrund
-    poi: Bitte werfen Sie einen Blick auf diesen POI
-    search: Ort suchen
-    about: Über Mapbender
+    noBackground: 'kein Hintergrund'
+    poi: 'Bitte werfen Sie einen Blick auf diesen POI'
+    search: 'Ort suchen'
+    about: 'Über Mapbender'
   wms:
     wmsloader:
       repo:
         instancelayerform:
           label:
             title: Titel
-Bad credentials.: Authentifizierung fehlgeschlagen.
-User account is locked.: Benutzerkonto ist gesperrt.
-User account is disabled.: Benutzerkonto ist deaktiviert.
-User account has expired.: Benutzerkonto ist abgelaufen.
-User credentials have expired.: Anmeldedaten sind abgelaufen.
+'Bad credentials.': 'Authentifizierung fehlgeschlagen.'
+'User account is locked.': 'Benutzerkonto ist gesperrt.'
+'User account is disabled.': 'Benutzerkonto ist deaktiviert.'
+'User account has expired.': 'Benutzerkonto ist abgelaufen.'
+'User credentials have expired.': 'Anmeldedaten sind abgelaufen.'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -89,6 +89,7 @@ mb:
       admin:
         configurations: Configurations
         title: Title
+        title.help: 'Text shown in the configurations dropdown'
         placeholder: Placeholder
         placeholder.help: 'Text to display when the search field is empty. If a placeholder is not defined, the content of the title is used instead.'
         query_url: 'Query URL'
@@ -581,7 +582,7 @@ mb:
         label: 'Show label'
     searchrouterroute:
       admin:
-        'title''': Title
+        title: Title
         configuration: Configuration
     instanceset:
       admin:
@@ -649,3 +650,8 @@ mb:
         instancelayerform:
           label:
             title: Title
+'Bad credentials.': 'Bad credentials.'
+'User account is locked.': 'User account is locked.'
+'User account is disabled.': 'User account is disabled.'
+'User account has expired.': 'User account has expired.'
+'User credentials have expired.': 'User credentials have expired.'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -23,52 +23,52 @@ mb:
       singular: Source
       plural: Sources
     layerset:
-      singular: Layer set
-      plural: Layer sets
+      singular: 'Layer set'
+      plural: 'Layer sets'
     sourceinstance:
       singular: Instance
       plural: Instances
       typed:
         singular: '%type% instance'
       reusable:
-        singular: Shared instance
-        plural: Shared instances
+        singular: 'Shared instance'
+        plural: 'Shared instances'
       bound:
-        singular: Bound instance
-        plural: Bound instances
+        singular: 'Bound instance'
+        plural: 'Bound instances'
     security: Security
   form:
-    choice_required: Choose one
+    choice_required: 'Choose one'
     choice_optional: None
-    unnamed_entry: Unnamed Entry
+    unnamed_entry: 'Unnamed Entry'
   states:
     active: active
     inactive: inactive
   core:
     featureinfo:
       error:
-        nolayer: No feature info layer exists.
-        unknownoption: Unknown or unhandled option %key% for %namespace%.%widgetname%.
-        noresult: no result
+        nolayer: 'No feature info layer exists.'
+        unknownoption: 'Unknown or unhandled option %key% for %namespace%.%widgetname%.'
+        noresult: 'no result'
       class:
         title: FeatureInfo
         description: FeatureInfo
       admin:
-        maxcount: Max count
+        maxcount: 'Max count'
         height: Height
         width: Width
-        displaytype: Display type
+        displaytype: 'Display type'
         tabs: Tabs
         accordion: Accordion
     aboutdialog:
       content:
         versionprefix: v.
-        learnmore: learn more about Mapbender
-        linktitle: Visit our official Mapbender website
+        learnmore: 'learn more about Mapbender'
+        linktitle: 'Visit our official Mapbender website'
         website: website
       class:
-        title: About dialog
-        description: Shows an about dialog
+        title: 'About dialog'
+        description: 'Shows an about dialog'
       tag:
         help: help
         info: info
@@ -77,66 +77,66 @@ mb:
         tooltip: About
     simplesearch:
       input:
-        searchterm: Search term
+        searchterm: 'Search term'
         search: Search
         clear: Clear
       class:
-        title: Simple Search
-        description: Single field search on JSON sources (e.g. Solr)
+        title: 'Simple Search'
+        description: 'Single field search on JSON sources (e.g. Solr)'
       error:
         geometry:
-          missing: The selected entry does not contain a geometry.
+          missing: 'The selected entry does not contain a geometry.'
       admin:
         configurations: Configurations
         title: Title
         placeholder: Placeholder
-        placeholder.help: Text to display when the search field is empty. If a placeholder is not defined, the content of the title is used instead.
-        query_url: Query URL
-        query_url.help: Solr or Nominatim URL for the search (e.g. <code>https://nominatim.openstreetmap.org/search.php?format=geojson</code>)
-        query_key: Query URL parameter key
-        query_key.help: The query parameter key to append (e.g. <code>q</code>)
-        query_ws_replace: Query Whitespace replacement pattern
-        query_ws_replace.help: If set, spaces and line breaks in the search query will be replaced hereby, e.g. <code>+</code> or <code>%20</code>
-        query_format: Query key format
-        query_format.help: Format for PHP's <a href="https://www.php.net/manual/en/function.sprintf.php" target="_blank">sprintf</a>-function. The search term will be interpreted using this format. E.g. <code>%s</code> (default) if a string is expected, <code>%d</code> if an integer is expected
+        placeholder.help: 'Text to display when the search field is empty. If a placeholder is not defined, the content of the title is used instead.'
+        query_url: 'Query URL'
+        query_url.help: 'Solr or Nominatim URL for the search (e.g. <code>https://nominatim.openstreetmap.org/search.php?format=geojson</code>)'
+        query_key: 'Query URL parameter key'
+        query_key.help: 'The query parameter key to append (e.g. <code>q</code>)'
+        query_ws_replace: 'Query Whitespace replacement pattern'
+        query_ws_replace.help: 'If set, spaces and line breaks in the search query will be replaced hereby, e.g. <code>+</code> or <code>%20</code>'
+        query_format: 'Query key format'
+        query_format.help: 'Format for PHP''s <a href="https://www.php.net/manual/en/function.sprintf.php" target="_blank">sprintf</a>-function. The search term will be interpreted using this format. E.g. <code>%s</code> (default) if a string is expected, <code>%d</code> if an integer is expected'
         token_regex: 'Tokenizer: Split Regex'
         token_regex.help: 'The tokenizer allows to modify search terms before they are sent to the search url. The split regex should match all characters that separate tokens (usually words). Default: <code> </code> (space)'
         token_regex_in: 'Tokenizer: Search Regex'
-        token_regex_in.help: Within each token (see Split Regex) this regular expression will be searched and replaced by the value of "Replacement Regex".
+        token_regex_in.help: 'Within each token (see Split Regex) this regular expression will be searched and replaced by the value of "Replacement Regex".'
         token_regex_out: 'Tokenizer: Replacement Regex'
-        token_regex_out.help: Within each token (see Split Regex) the regular expression from "Search Regex" will be searched and replaced by this value. Found groups will be referenced by a <code>$</code> and ascending numbes. E.g. <code>$1*</code> will append an asterisk to each search word.
-        collection_path: Results Path
-        collection_path.help: Path pointing to the array of results within the search url's response. Hierarchy levels are separated by dots. E.g. <code>response.docs</code> (Solr Standard), <code>features</code> (GeoJSON)
-        label_attribute: Label Attribute
-        label_attribute.help: Path (within a single result) to the attribute which will be used as label, e.g. <code>label</code>. Alternatively, a string template can be entered, e.g. <code>City ${properties.address.city} - ${properties.address.road}</code>
-        geom_attribute: Geometry Attribute
-        geom_attribute.help: Path (within a single result) to the attribute which provides the geometry, e.g. <code>geom</code>, <code>geometry</code> (GeoJSON)
-        geom_format: Geometry Format
-        geom_format.help: Provided geometry format, either <a href="https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry" target="_blank">Well Known Text</a> oder <a href="https://geojson.org/" target="_blank">GeoJSON</a>
-        sourceSrs: Source SRS
-        sourceSrs.help: <a href="https://epsg.io/" target="_blank">EPSG code</a> of the projection used in the search url, including the prefix <code>EPSG:</code>, e.g. <code>EPSG:25832</code>. If unset, the results are assumed to be in the default map projection.
-        delay: Search Delay [ms]
+        token_regex_out.help: 'Within each token (see Split Regex) the regular expression from "Search Regex" will be searched and replaced by this value. Found groups will be referenced by a <code>$</code> and ascending numbes. E.g. <code>$1*</code> will append an asterisk to each search word.'
+        collection_path: 'Results Path'
+        collection_path.help: 'Path pointing to the array of results within the search url''s response. Hierarchy levels are separated by dots. E.g. <code>response.docs</code> (Solr Standard), <code>features</code> (GeoJSON)'
+        label_attribute: 'Label Attribute'
+        label_attribute.help: 'Path (within a single result) to the attribute which will be used as label, e.g. <code>label</code>. Alternatively, a string template can be entered, e.g. <code>City ${properties.address.city} - ${properties.address.road}</code>'
+        geom_attribute: 'Geometry Attribute'
+        geom_attribute.help: 'Path (within a single result) to the attribute which provides the geometry, e.g. <code>geom</code>, <code>geometry</code> (GeoJSON)'
+        geom_format: 'Geometry Format'
+        geom_format.help: 'Provided geometry format, either <a href="https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry" target="_blank">Well Known Text</a> oder <a href="https://geojson.org/" target="_blank">GeoJSON</a>'
+        sourceSrs: 'Source SRS'
+        sourceSrs.help: '<a href="https://epsg.io/" target="_blank">EPSG code</a> of the projection used in the search url, including the prefix <code>EPSG:</code>, e.g. <code>EPSG:25832</code>. If unset, the results are assumed to be in the default map projection.'
+        delay: 'Search Delay [ms]'
         delay.help: 'The automatic search will trigger that many milliseconds after the last key input. Default: 300ms'
-        result_buffer: Result Buffer [map units]
-        result_buffer.help: Indirectly determines the zoom level that appears after selecting a result. At least the selected area is visible around the geometry. The unit map units vary depending on the projection, in most cases it equals metres. A combination with the scale (min/max) parameters is possible, but can lead to undesired results.
-        result_minscale: Minimum Scale [Denominator]
+        result_buffer: 'Result Buffer [map units]'
+        result_buffer.help: 'Indirectly determines the zoom level that appears after selecting a result. At least the selected area is visible around the geometry. The unit map units vary depending on the projection, in most cases it equals metres. A combination with the scale (min/max) parameters is possible, but can lead to undesired results.'
+        result_minscale: 'Minimum Scale [Denominator]'
         result_minscale.help: 'Alternative to specifying the zoom level. Depending on the bounds of the target geometry, a scale between <code>min</code> and <code>max</code> is set. With a scale <code>1 : 1000</code>, only <code>1000</code> must be entered. For a fixed scale, it is sufficient to enter the minimum scale.'
-        result_maxscale: Maximum Scale [Denominator]
-        result_icon_url: Icon URL
-        result_icon_url.help: URL to an image file that will be used as marker for Point geometries. Can be relative or absolute. For the standard pin use <code>/bundles/mapbendercore/image/pin_red.png</code>.
-        result_icon_offset: Icon Offset
-        result_icon_offset.help: Position correction for the icon as comma-separated x and y offset, e.g. <code>-6,-32</code> for the standard pin
+        result_maxscale: 'Maximum Scale [Denominator]'
+        result_icon_url: 'Icon URL'
+        result_icon_url.help: 'URL to an image file that will be used as marker for Point geometries. Can be relative or absolute. For the standard pin use <code>/bundles/mapbendercore/image/pin_red.png</code>.'
+        result_icon_offset: 'Icon Offset'
+        result_icon_offset.help: 'Position correction for the icon as comma-separated x and y offset, e.g. <code>-6,-32</code> for the standard pin'
       errors:
-        invalid_query_format: The specified query format does not contain placeholders. Read the help text!
-        invalid_epsg_code: The text entered is not a valid EPSG code. Enter the code in the format EPSG:1234
-        no_configuration_added: Please add at least one configuration
+        invalid_query_format: 'The specified query format does not contain placeholders. Read the help text!'
+        invalid_epsg_code: 'The text entered is not a valid EPSG code. Enter the code in the format EPSG:1234'
+        no_configuration_added: 'Please add at least one configuration'
     searchrouter:
-      no_results: No results found.
+      no_results: 'No results found.'
       result_counter: 'Results: %count%'
-      exportcsv: Export results to CSV.
+      exportcsv: 'Export results to CSV.'
       class:
-        title: Search router
-        description: Configurable search routing element
+        title: 'Search router'
+        description: 'Configurable search routing element'
       tag:
         search: search
         router: router
@@ -145,29 +145,29 @@ mb:
         height: Height
         routes: Routes
     poi:
-      sharepoi: Share POI
+      sharepoi: 'Share POI'
       text:
-        snippet: You can use the following snippet in an email to send the POI
+        snippet: 'You can use the following snippet in an email to send the POI'
       popup:
         btn:
           position: Positioning
       class:
         title: POI
-        description: Create a POI for sharing
+        description: 'Create a POI for sharing'
       label:
         text: Text
       admin:
         body: Body
         gps: GPS
-        placeholder: Please take a look at this POI
+        placeholder: 'Please take a look at this POI'
     basesourceswitcher:
       error:
-        sourcenotavailable: A source with id %id% is not available.
+        sourcenotavailable: 'A source with id %id% is not available.'
       class:
-        title: Base source switcher
-        Description: Change the map's background sources.
+        title: 'Base source switcher'
+        Description: 'Change the map''s background sources.'
       form:
-        mesage: No basesource set is defined.
+        mesage: 'No basesource set is defined.'
         instancesets: Instancesets
       admin:
         tooltip: Tooltip
@@ -176,23 +176,23 @@ mb:
     legend:
       class:
         title: Legend
-        description: The legend shows the legend of the map's layers
+        description: 'The legend shows the legend of the map''s layers'
     ruler:
       create_error: 'Ruler: Type must be line or area.'
       class:
-        title: Line/Area Ruler
-        description: Ruler to draw a line/area and display length/area in a dialog
+        title: 'Line/Area Ruler'
+        description: 'Ruler to draw a line/area and display length/area in a dialog'
       tag:
         line: line
         area: area
         measure: measure
-      help: Double-click to end drawing
+      help: 'Double-click to end drawing'
       admin:
         type: Geometry
         help: Helptext
-        help_help: The default value <code>mb.core.ruler.help</code> translates to "Double-click to end drawing" in the user's language
-        stroke_width_while_drawing: Line width while drawing
-        only_for_area: only relevant if geometry is set to <i>Area</i>
+        help_help: 'The default value <code>mb.core.ruler.help</code> translates to "Double-click to end drawing" in the user''s language'
+        stroke_width_while_drawing: 'Line width while drawing'
+        only_for_area: 'only relevant if geometry is set to <i>Area</i>'
         style: Style
     printclient:
       label:
@@ -200,86 +200,86 @@ mb:
         quality: Quality
         scale: Scale
         rotation: Rotation
-        legend: Print legend
+        legend: 'Print legend'
       class:
-        title: Print client
-        description: Renders a Print dialog
+        title: 'Print client'
+        description: 'Renders a Print dialog'
       btn:
-        deactivate: Deactivate Print Frame
-        activate: Activate Print Frame
+        deactivate: 'Deactivate Print Frame'
+        activate: 'Activate Print Frame'
     overview:
-      nolayer: The overview element has no layer.
+      nolayer: 'The overview element has no layer.'
       class:
         title: Overview
-        description: Renders a small overview map
+        description: 'Renders a small overview map'
       tag:
         overview: overview
         map: map
       admin:
-        visibility.closed_initially: Initially closed
-        visibility.open_initially: Initially open
-        visibility.open_permanent: Permanently open
+        visibility.closed_initially: 'Initially closed'
+        visibility.open_initially: 'Initially open'
+        visibility.open_permanent: 'Permanently open'
         layerset: Layerset
     metadata:
       popup:
         title: Metadata
     gpsposition:
       error:
-        notsupported: Geolocation services are not supported by your browser.
-        nosignal: Currently it's not possible to locate your position.
+        notsupported: 'Geolocation services are not supported by your browser.'
+        nosignal: 'Currently it''s not possible to locate your position.'
       class:
-        title: GPS Position
-        description: Renders a button to show the GPS Position
+        title: 'GPS Position'
+        description: 'Renders a button to show the GPS Position'
       tag:
-        gpsposition: GPS Position
+        gpsposition: 'GPS Position'
         gps: GPS
         position: position
         button: button
       admin:
         average: Average
         follow: Follow
-        centeronfirstposition: Center on first position
-        zoomtoaccuracyonfirstposition: Zoom to accuracy on first position
+        centeronfirstposition: 'Center on first position'
+        zoomtoaccuracyonfirstposition: 'Zoom to accuracy on first position'
     layertree:
       const:
-        outofscale: Layer out of scale
-        outofbounds: Layer out of bounds
-        parentinvisible: Parent layer invisible
+        outofscale: 'Layer out of scale'
+        outofbounds: 'Layer out of bounds'
+        parentinvisible: 'Parent layer invisible'
       tooltip:
-        sublayers_openclose: Sublayers open/close
-        removelayer: Remove layer
+        sublayers_openclose: 'Sublayers open/close'
+        removelayer: 'Remove layer'
         menu:
           close: Close
       label:
-        visibility_onoff: Visibility on/off
-        featureinfo_onoff: Featureinfo on/off
+        visibility_onoff: 'Visibility on/off'
+        featureinfo_onoff: 'Featureinfo on/off'
         opacity: Opacity
-        zoomtolayer: Zoom to layer
+        zoomtolayer: 'Zoom to layer'
         metadata: Metadata
         legend: Legend
-        kmlexport: KML export
-        dimension_onoff: On/Off Dimension
+        kmlexport: 'KML export'
+        dimension_onoff: 'On/Off Dimension'
         dimension: Dimension
-        sourcevisibility_onoff: Show sources
+        sourcevisibility_onoff: 'Show sources'
       class:
-        title: Layer tree
-        description: Tree of map's layers
+        title: 'Layer tree'
+        description: 'Tree of map''s layers'
       admin:
-        layerremove: Remove layer
+        layerremove: 'Remove layer'
         opacity: Opacity
-        zoomtolayer: Zoom to layer
+        zoomtolayer: 'Zoom to layer'
         metadata: Metadata
         dimension: Dimension
     zoombar:
-      zoombybox: Zoom by box
-      zoombyworld: Zoom by world
-      zoom_home: Back to start
+      zoombybox: 'Zoom by box'
+      zoombyworld: 'Zoom by world'
+      zoom_home: 'Back to start'
       zoomHomeRestoresLayers: '"Back to start" also resets layer settings'
-      zoomin: Zoom in
-      zoomout: Zoom out
+      zoomin: 'Zoom in'
+      zoomout: 'Zoom out'
       class:
-        title: Navigation toolbar
-        description: The Navigation Toolbar element provides a floating control to pan and zoom, similar to the OpenLayers PanZoomBar control. This element though is easier to use when custom styling is needed.
+        title: 'Navigation toolbar'
+        description: 'The Navigation Toolbar element provides a floating control to pan and zoom, similar to the OpenLayers PanZoomBar control. This element though is easier to use when custom styling is needed.'
       tag:
         zoom: zoom
         pan: pan
@@ -289,22 +289,22 @@ mb:
       admin:
         components: Components
         rotation: Rotation
-        zoommax: Zoom to maximum extent
-        zoominout: Zoom in and out
-        zoomslider: Zoom slider
+        zoommax: 'Zoom to maximum extent'
+        zoominout: 'Zoom in and out'
+        zoomslider: 'Zoom slider'
     activityindicator:
       class:
-        title: Activity indicator
-        description: Shows HTTP activity
+        title: 'Activity indicator'
+        description: 'Shows HTTP activity'
       tag:
         activity: activity
         indicator: indicator
       admin:
         tooltip: Tooltip
-        activityclass: CSS-Class General Activity
-        ajaxactivityclass: CSS-Class Background Activity
-        ajaxactivityclass_help: CSS-Class that is set while an action is active in the background (like a search being performed)
-        tileactivityclass: CSS-Class Map Loading
+        activityclass: 'CSS-Class General Activity'
+        ajaxactivityclass: 'CSS-Class Background Activity'
+        ajaxactivityclass_help: 'CSS-Class that is set while an action is active in the background (like a search being performed)'
+        tileactivityclass: 'CSS-Class Map Loading'
     button:
       class:
         title: Button
@@ -317,20 +317,20 @@ mb:
         deactivate: Deactivate
     controlbutton:
       class:
-        description: Controls another element
+        description: 'Controls another element'
       admin:
         group: Group
         target: Target
     linkbutton:
       class:
         title: Link
-        description: Link to external URL
+        description: 'Link to external URL'
       admin:
-        click: Target URL
+        click: 'Target URL'
     coordinatesdisplay:
       class:
-        title: Coordinates display
-        description: The coordinates display shows your mouse position in map coordinates.
+        title: 'Coordinates display'
+        description: 'The coordinates display shows your mouse position in map coordinates.'
       tag:
         coordinates: coordinates
         display: display
@@ -339,7 +339,7 @@ mb:
     copyright:
       class:
         title: Copyright
-        description: Shows terms of use
+        description: 'Shows terms of use'
       tag:
         copyright: Copyright
         dialog: dialog
@@ -348,46 +348,46 @@ mb:
     map:
       class:
         title: Map
-        description: OpenLayers based map
+        description: 'OpenLayers based map'
       tag:
         map: map
         mapquery: MapQuery
         openlayers: OpenLayers
-      srsnotfound: SRS properties for %srslist% are not found
+      srsnotfound: 'SRS properties for %srslist% are not found'
       admin:
-        fixedZoomSteps: Fixed zoom steps
+        fixedZoomSteps: 'Fixed zoom steps'
         layersets: Layersets
-        tilesize: Tile size
+        tilesize: 'Tile size'
         SRS: SRS
-        scales: Scales (comma-separated)
-        othersrs: Other SRS
+        scales: 'Scales (comma-separated)'
+        othersrs: 'Other SRS'
         srs: SRS
     scalebar:
       class:
-        title: Scale bar
-        description: The scalebar displays a small line indicator representing the current map scale.
+        title: 'Scale bar'
+        description: 'The scalebar displays a small line indicator representing the current map scale.'
       tag:
         scale: scale
         bar: bar
       admin:
-        maxwidth: Maximum width
+        maxwidth: 'Maximum width'
         units: Unit
     scaledisplay:
       label: Scale
       scale_prefix: Prefix
-      scale_prefix.help: Description shown before the actual scale. The standard <code>mb.core.scaledisplay.label</code> is rendered as <code>Scale</code> in the user's language.
-      unit_prefix: Shorten scale
-      unit_prefix.help: If checked, scale numbers higher than 1,000 will be shortened with a postpositioned <code>K</code> or <code>M</code>.
+      scale_prefix.help: 'Description shown before the actual scale. The standard <code>mb.core.scaledisplay.label</code> is rendered as <code>Scale</code> in the user''s language.'
+      unit_prefix: 'Shorten scale'
+      unit_prefix.help: 'If checked, scale numbers higher than 1,000 will be shortened with a postpositioned <code>K</code> or <code>M</code>.'
       class:
-        title: Scale display
-        description: Displays the current map scale
+        title: 'Scale display'
+        description: 'Displays the current map scale'
       tag:
         scale: scale
         display: display
     scaleselector:
       class:
-        title: Scale selector
-        description: Displays and changes a map scale
+        title: 'Scale selector'
+        description: 'Displays and changes a map scale'
       tag:
         scale: scale
         selector: selector
@@ -395,117 +395,117 @@ mb:
         tooltip: Tooltip
     srsselector:
       class:
-        title: SRS selector
-        description: The spatial reference system selector changes the map's spatial reference system
+        title: 'SRS selector'
+        description: 'The spatial reference system selector changes the map''s spatial reference system'
       tag:
         srs: SRS
         selector: selector
       admin:
-        srsselector: SRS selector
+        srsselector: 'SRS selector'
         tooltip: Tooltip
     ShareUrl:
       class:
-        title: Share URL
-        description: Share current map view via url
-      copied_to_clipboard: URL copied to clipboard
+        title: 'Share URL'
+        description: 'Share current map view via url'
+      copied_to_clipboard: 'URL copied to clipboard'
     viewManager:
       class:
-        title: View manager
-        description: Saves map states for later restoration
-      saveAsPublic: Save as public
+        title: 'View manager'
+        description: 'Saves map states for later restoration'
+      saveAsPublic: 'Save as public'
       recordStatus:
-        public: Public entry
-        private: Private entry
-      confirmDelete: Confirm deletion
-      no_data: No data
+        public: 'Public entry'
+        private: 'Private entry'
+      confirmDelete: 'Confirm deletion'
+      no_data: 'No data'
       title: Title
       date: Date
-      enter_title: Enter title
+      enter_title: 'Enter title'
       apply: Apply
       replace: Replace
-      details: Show details
+      details: 'Show details'
       admin:
-        access.none: Do not show
-        access.ro: Read only
-        access.rw: Allow saving
-        access.rwd: Allow saving and deletion
-        publicEntries: Public list
-        privateEntries: Show private list
+        access.none: 'Do not show'
+        access.ro: 'Read only'
+        access.rw: 'Allow saving'
+        access.rwd: 'Allow saving and deletion'
+        publicEntries: 'Public list'
+        privateEntries: 'Show private list'
         adminDeleteHint: 'Note: the administrator can always delete public entries'
-        allowAnonymousSave: Allow saving to anonymous users
-        showDate: Show date
+        allowAnonymousSave: 'Allow saving to anonymous users'
+        showDate: 'Show date'
     coordinatesutility:
       class:
-        title: Coordinates utility
-        description: Transform coordinates in different SRS. Navigate to coordinates on the map.
+        title: 'Coordinates utility'
+        description: 'Transform coordinates in different SRS. Navigate to coordinates on the map.'
       widget:
         error:
-          noSrs: No SRS is defined
-          invalidCoordinates: Invalid coordinates
+          noSrs: 'No SRS is defined'
+          invalidCoordinates: 'Invalid coordinates'
       view:
         srs:
-          title: Coordinate system
-          tooltip: Coordinate system
+          title: 'Coordinate system'
+          tooltip: 'Coordinate system'
         transformedCoordinates:
-          tooltip: Transformed coordinates
+          tooltip: 'Transformed coordinates'
         copytoclipboard:
-          tooltip: Copy to clipboard
+          tooltip: 'Copy to clipboard'
         originCoordinates:
-          title: Coordinate in map reference system
-          tooltip: read only
+          title: 'Coordinate in map reference system'
+          tooltip: 'read only'
         button:
-          search: Coordinate search
-          centermap: Center map
+          search: 'Coordinate search'
+          centermap: 'Center map'
       backend:
-        addMapSrsList: Add map's srs list
+        addMapSrsList: 'Add map''s srs list'
       admin:
-        srslist: SRS List
-        zoomlevel: Zoom level
+        srslist: 'SRS List'
+        zoomlevel: 'Zoom level'
     admin:
       poi:
         label:
-          usemailto: Use Mailto
+          usemailto: 'Use Mailto'
       legend:
         label:
-          hideemptylayers: Hide empty layers
-          generatelegendurl: Generate legend url
-          showsourcetitle: Show source title
-          showlayertitle: Show layer title
-          showgroupedlayertitle: Show grouped layer title
+          hideemptylayers: 'Hide empty layers'
+          generatelegendurl: 'Generate legend url'
+          showsourcetitle: 'Show source title'
+          showlayertitle: 'Show layer title'
+          showgroupedlayertitle: 'Show grouped layer title'
       featureinfo:
         label:
-          deactivateonclose: Deactivate on close
-          onlyvalid: Only valid
+          deactivateonclose: 'Deactivate on close'
+          onlyvalid: 'Only valid'
           highlighting_group: Highlighting
-          highlighting: Highlighting enabled
+          highlighting: 'Highlighting enabled'
           default_group: Default
-          hover_group: On hover
-          fillColor: Fill color
-          strokeColor: Stroke color
-          opacity_pct: Opacity (%)
-          stroke_width_px: Stroke width (pixels)
-          fontColor: Font color
-          fontSize: Font size
+          hover_group: 'On hover'
+          fillColor: 'Fill color'
+          strokeColor: 'Stroke color'
+          opacity_pct: 'Opacity (%)'
+          stroke_width_px: 'Stroke width (pixels)'
+          fontColor: 'Font color'
+          fontSize: 'Font size'
       printclient:
         label:
           rotatable: Rotatable
-          legend: Print legend
-          legend_default_behaviour: Legend checkbox active
-          required_fields_first: Display required fields first
+          legend: 'Print legend'
+          legend_default_behaviour: 'Legend checkbox active'
+          required_fields_first: 'Display required fields first'
       layertree:
         label:
-          showbasesources: Show base sources
-          showlayerremove: Show layer remove
-          usetheme: Thematic layer
+          showbasesources: 'Show base sources'
+          showlayerremove: 'Show layer remove'
+          usetheme: 'Thematic layer'
           themes: Themes
           theme:
             opened: opened
-            activate: Enabling Layer Add / Remove
-            useTheme: Theme show
-            label: theme name
-          hidenottoggleable: Hide not toggleable
-          hideselect: Hide visibility by folders
-          hideinfo: Hide info
+            activate: 'Enabling Layer Add / Remove'
+            useTheme: 'Theme show'
+            label: 'theme name'
+          hidenottoggleable: 'Hide not toggleable'
+          hideselect: 'Hide visibility by folders'
+          hideinfo: 'Hide info'
           menu: Menu
       template:
         sidepane:
@@ -516,7 +516,7 @@ mb:
               accordion: Accordion
               unstyled: Unstyled
       button:
-        show_label: Show label
+        show_label: 'Show label'
         label: Label
       layerset:
         label:
@@ -525,7 +525,7 @@ mb:
     htmlelement:
       class:
         title: HTML
-        description: Add some HTML
+        description: 'Add some HTML'
       admin:
         content: Content
         classes: Classes
@@ -545,43 +545,43 @@ mb:
         radius: Radius
       geometry:
         action:
-          remove: Remove geometry
-          edit: Edit geometry
-          zoom: Zoom to geometry
-          stop_drawing: Stop drawing
+          remove: 'Remove geometry'
+          edit: 'Edit geometry'
+          zoom: 'Zoom to geometry'
+          stop_drawing: 'Stop drawing'
       class:
         title: Sketches
-        description: Drawing tool
+        description: 'Drawing tool'
       admin:
-        deactivate_on_close: Deactivate on close
+        deactivate_on_close: 'Deactivate on close'
         colors: Colors
-        allow_custom_color: Allow custom color
-        geometrytypes: Geometry types
+        allow_custom_color: 'Allow custom color'
+        geometrytypes: 'Geometry types'
     redlining:
       class:
         title: Sketches
     resetView:
       class:
-        title: Reset view
-        description: Restores initial map view and source settings
+        title: 'Reset view'
+        description: 'Restores initial map view and source settings'
       admin:
-        resetDynamicSources: Remove dynamically loaded sources
+        resetDynamicSources: 'Remove dynamically loaded sources'
     applicationSwitcher:
       class:
-        title: Application switcher
-        description: Switches to another application while maintaining current map position
+        title: 'Application switcher'
+        description: 'Switches to another application while maintaining current map position'
       admin:
-        open_in_new_tab: Open in new tab
+        open_in_new_tab: 'Open in new tab'
     coordinesdisplay:
       admin:
-        numdigits: Number of decimal places
+        numdigits: 'Number of decimal places'
         empty: Empty
         prefix: Prefix
         separator: Separator
-        label: Show label
+        label: 'Show label'
     searchrouterroute:
       admin:
-        title': Title
+        'title''': Title
         configuration: Configuration
     instanceset:
       admin:
@@ -596,16 +596,16 @@ mb:
     icon:
       mb:
         about: Information
-        layer_tree: Layer tree
-        feature_info: Feature Info
-        area_ruler: Area ruler
+        layer_tree: 'Layer tree'
+        feature_info: 'Feature Info'
+        area_ruler: 'Area ruler'
         polygon: Polygon
-        line_ruler: Line ruler
-        image_export: Image Export
+        line_ruler: 'Line ruler'
+        image_export: 'Image Export'
         legend: Legend
       fa:
         about: Group
-        info: Information (inverted)
+        info: 'Information (inverted)'
         pin: Marker
         home: Home
         legend: List
@@ -625,24 +625,24 @@ mb:
         refresh: Refresh
         earth: Earth
         map: Map
-        pin_alt: Pin (Alternative)
+        pin_alt: 'Pin (Alternative)'
         help: Help
   template:
-    toolbar_menu_tooltip: Toggle menu
+    toolbar_menu_tooltip: 'Toggle menu'
     region:
-      toolbar: Top toolbar
+      toolbar: 'Top toolbar'
       footer: Footer
       sidepane: Sidepane
-      content: Map area
+      content: 'Map area'
   demoapps:
     themes: Themes
-    backgroundThemes: Background themes
-    baseMaps: Base maps
-    aerialView: Aerial view
-    noBackground: No background
-    poi: Please take a look at this POI
-    search: Search location
-    about: About Mapbender
+    backgroundThemes: 'Background themes'
+    baseMaps: 'Base maps'
+    aerialView: 'Aerial view'
+    noBackground: 'No background'
+    poi: 'Please take a look at this POI'
+    search: 'Search location'
+    about: 'About Mapbender'
   wms:
     wmsloader:
       repo:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -68,13 +68,12 @@ mb:
       convert_to_reusable: 'In freie Instanz umwandeln'
       convert_to_bound: 'In private Instanz umwandeln'
       converted_to_bound: 'Eine private Kopie der freien Instanz wurde der Anwendung hinzugefügt'
+      reusable_assigned_to_application: 'Die freie Instanz wurde der Anwendung hinzugefügt'
       create_reusable: 'Freie Instanz erzeugen'
       created_reusable: 'Neue freie Instanz erzeugt'
-      reusable_assigned_to_application: 'Die freie Instanz wurde der Anwendung hinzugefügt'
     application:
       persistentView: 'Kartenzustand merken'
       splashscreen: 'Ladescreen anzeigen'
-      splashscreen_autohide: 'Ladescreen automatisch ausblenden'
     admin:
       sources: Datenquellen
       csrf_token_invalid: 'CSRF-Token ungültig.'
@@ -100,11 +99,11 @@ mb:
           }
       map:
         max_extent: 'Max. Karten­ausdehnung'
+        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
         start_extent: 'Initiale Karten­ausdehnung'
+        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
         base_dpi: 'Standard-Auflösung [dpi]'
         base_dpi.help: 'Die Auflösung passt sich auf Basis dieses Wertes an die Auflösung des verwendeten Gerätes an.'
-        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
-        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
       element:
         title: Titel
         type: Typ

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -1,33 +1,33 @@
 mb:
   application:
     create:
-      success: Ihre Anwendung wurde erstellt.
+      success: 'Ihre Anwendung wurde erstellt.'
       failure:
-        create.directory: Anwendungsverzeichnis kann nicht erstellt werden.
+        create.directory: 'Anwendungsverzeichnis kann nicht erstellt werden.'
     save:
-      success: Ihre Anwendung wurde gespeichert.
+      success: 'Ihre Anwendung wurde gespeichert.'
       failure:
-        general: Beim Speichern Ihrer Anwendung ist ein Fehler aufgetreten.
-        create.directory: Ihre Anwendung wurde aktualisiert, aber das Anwendungsverzeichnis konnte nicht erstellt werden.
+        general: 'Beim Speichern Ihrer Anwendung ist ein Fehler aufgetreten.'
+        create.directory: 'Ihre Anwendung wurde aktualisiert, aber das Anwendungsverzeichnis konnte nicht erstellt werden.'
     remove:
-      success: Ihre Anwendung wurde gelöscht.
+      success: 'Ihre Anwendung wurde gelöscht.'
       failure:
-        general: Ihre Anwendung konnte nicht gelöscht werden.
+        general: 'Ihre Anwendung konnte nicht gelöscht werden.'
   layerset:
     create:
-      success: Ihr Layerset wurde erstellt.
+      success: 'Ihr Layerset wurde erstellt.'
     remove:
-      success: Ihr Layerset wurde gelöscht.
-      failure: Ihr Layerset kann nicht gelöscht werden.
+      success: 'Ihr Layerset wurde gelöscht.'
+      failure: 'Ihr Layerset kann nicht gelöscht werden.'
   source:
     instance:
       create:
-        success: Eine neue Instanz wurde erstellt. Bitte passen Sie diese an.
+        success: 'Eine neue Instanz wurde erstellt. Bitte passen Sie diese an.'
   manager:
     automatic: Automatisch
-    autoActivate: Automatisch aktivieren
-    autoOpen: Automatisch öffnen
-    confirm_form_discard: Änderungen verwerfen?
+    autoActivate: 'Automatisch aktivieren'
+    autoOpen: 'Automatisch öffnen'
+    confirm_form_discard: 'Änderungen verwerfen?'
     popup_height: Dialog-Höhe
     popup_width: Dialog-Breite
     screentype:
@@ -43,16 +43,16 @@ mb:
           left: Links
           right: Rechts
           center: Zentriert
-      generate_button_menu: Schaltflächen zu Menü zusammenfassen
+      generate_button_menu: 'Schaltflächen zu Menü zusammenfassen'
       menu_label: Menütitel
     visibility: Sichtbarkeit
     element:
       screentype:
-        mobile: Auf Mobilgeräten anzeigen
-        desktop: Auf großen Bildschirmen anzeigen
+        mobile: 'Auf Mobilgeräten anzeigen'
+        desktop: 'Auf großen Bildschirmen anzeigen'
     sidepane:
       width: Breite
-      closed: Geschlossen starten
+      closed: 'Geschlossen starten'
       align:
         label: Position
         choice:
@@ -65,33 +65,33 @@ mb:
             one   {Diese Instanz wird von einer Anwendung genutzt}
             other {Diese Instanz wird von # Anwendungen genutzt}
         }
-      convert_to_reusable: In freie Instanz umwandeln
-      convert_to_bound: In private Instanz umwandeln
-      converted_to_bound: Eine private Kopie der freien Instanz wurde der Anwendung hinzugefügt
-      reusable_assigned_to_application: Die freie Instanz wurde der Anwendung hinzugefügt
-      create_reusable: Freie Instanz erzeugen
-      created_reusable: Neue freie Instanz erzeugt
+      convert_to_reusable: 'In freie Instanz umwandeln'
+      convert_to_bound: 'In private Instanz umwandeln'
+      converted_to_bound: 'Eine private Kopie der freien Instanz wurde der Anwendung hinzugefügt'
+      reusable_assigned_to_application: 'Die freie Instanz wurde der Anwendung hinzugefügt'
+      create_reusable: 'Freie Instanz erzeugen'
+      created_reusable: 'Neue freie Instanz erzeugt'
     application:
-      persistentView: Kartenzustand merken
-      splashscreen: Ladescreen anzeigen
-      splashscreen_autohide: Ladescreen automatisch ausblenden
+      persistentView: 'Kartenzustand merken'
+      splashscreen: 'Ladescreen anzeigen'
+      splashscreen_autohide: 'Ladescreen automatisch ausblenden'
     admin:
-      csrf_token_invalid: CSRF-Token ungültig.
+      csrf_token_invalid: 'CSRF-Token ungültig.'
       sources: Datenquellen
       source:
-        add: Datenquelle hinzufügen
-        show_metadata: Metadaten anzeigen
-        delete: Datenquelle entfernen
+        add: 'Datenquelle hinzufügen'
+        show_metadata: 'Metadaten anzeigen'
+        delete: 'Datenquelle entfernen'
         new:
-          add: Datenquelle hinzufügen
-        valid: Quelle valide
-        notvalid: Die Datenquelle ist nicht valide
-        no_source: Keine Datenquelle
-        update: Datenquelle aktualisieren
+          add: 'Datenquelle hinzufügen'
+        valid: 'Quelle valide'
+        notvalid: 'Die Datenquelle ist nicht valide'
+        no_source: 'Keine Datenquelle'
+        update: 'Datenquelle aktualisieren'
         status:
-          ok: Datenquelle OK
-          toupdate: Datenquelle inaktuell
-          unreachable: Die Datenquelle ist nicht erreichbar
+          ok: 'Datenquelle OK'
+          toupdate: 'Datenquelle inaktuell'
+          unreachable: 'Die Datenquelle ist nicht erreichbar'
         embedded_in_applications: |
           {count, plural,
               =0    {Diese Datenquelle wird von keiner Anwendung genutzt}
@@ -99,54 +99,54 @@ mb:
               other {Diese Datenquelle wird von # Anwendungen genutzt}
           }
       map:
-        max_extent: Max. Karten­ausdehnung
-        max_extent.help: Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.
-        start_extent: Initiale Karten­ausdehnung
-        start_extent.help: Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.
-        base_dpi: Standard-Auflösung [dpi]
-        base_dpi.help: Die Auflösung passt sich auf Basis dieses Wertes an die Auflösung des verwendeten Gerätes an.
+        max_extent: 'Max. Karten­ausdehnung'
+        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
+        start_extent: 'Initiale Karten­ausdehnung'
+        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
+        base_dpi: 'Standard-Auflösung [dpi]'
+        base_dpi.help: 'Die Auflösung passt sich auf Basis dieses Wertes an die Auflösung des verwendeten Gerätes an.'
       element:
         title: Titel
         type: Typ
-        add: Element hinzufügen
+        add: 'Element hinzufügen'
         show_hide: aktiv/inaktiv
-        no_element_added: Kein Element vorhanden
+        no_element_added: 'Kein Element vorhanden'
         anchor:
           label: Position
-          left-top: Oben links
-          left-bottom: Unten links
-          right-top: Oben rechts
-          right-bottom: Unten rechts
+          left-top: 'Oben links'
+          left-bottom: 'Unten links'
+          right-top: 'Oben rechts'
+          right-bottom: 'Unten rechts'
       zoombar:
         draggable: Verschiebbar
       overview:
         fix: Fixieren
       layerset:
-        add: Layerset hinzufügen
+        add: 'Layerset hinzufügen'
         title: Titel
         type: Typ
-        edit: Layerset bearbeiten
+        edit: 'Layerset bearbeiten'
         delete:
-          title: Layerset löschen
-          confirm: Wollen Sie das Layerset <span class="italic">%layerset_title%</span> wirklich löschen?
+          title: 'Layerset löschen'
+          confirm: 'Wollen Sie das Layerset <span class="italic">%layerset_title%</span> wirklich löschen?'
         id: Id
       instance:
-        add: Instanz hinzufügen
-        show_hide: Instanz an/aus
-        edit: Instanz bearbeiten
+        add: 'Instanz hinzufügen'
+        show_hide: 'Instanz an/aus'
+        edit: 'Instanz bearbeiten'
         delete:
-          title: Instanz löschen
-          confirm: Wollen sie wirklich die Instanz mit dem Titel  <span class="italic">%instance_title%</span> entfernen?
-        no_instance_added: Keine Instanz vorhanden
-        no_layer_added: Keine Ebene hinzugefügt
-        max_input_vars_exceeded: PHP-Einstellung max_input_vars zu niedrig für die Anzahl an Layern in dieser Instanz.
-        update_successful: Die Instanz wurde aktualisiert
-        converted_to_shared: Die Instanz wurde zu einer freien Instanz umgewandelt
+          title: 'Instanz löschen'
+          confirm: 'Wollen sie wirklich die Instanz mit dem Titel  <span class="italic">%instance_title%</span> entfernen?'
+        no_instance_added: 'Keine Instanz vorhanden'
+        no_layer_added: 'Keine Ebene hinzugefügt'
+        max_input_vars_exceeded: 'PHP-Einstellung max_input_vars zu niedrig für die Anzahl an Layern in dieser Instanz.'
+        update_successful: 'Die Instanz wurde aktualisiert'
+        converted_to_shared: 'Die Instanz wurde zu einer freien Instanz umgewandelt'
       template: Vorlage
       application:
         view: Anzeigen
         edit:
-          title: Anwendung bearbeiten
+          title: 'Anwendung bearbeiten'
           base_data: Basisdaten
         screenshot: Vorschaubild
         layouts: Layouts
@@ -154,24 +154,24 @@ mb:
         custom_css: CSS
         security:
           title: Sicherheit
-          public: öffentlicher Zugriff
+          public: 'öffentlicher Zugriff'
         save: Speichern
         cancel: Abbrechen
-        view_this: Anwendung anzeigen
-        duplicate: Anwendung duplizieren
+        view_this: 'Anwendung anzeigen'
+        duplicate: 'Anwendung duplizieren'
         public:
-          on_off: Anwendung publizieren/verbergen
-        delete: Anwendung löschen
-        no_application: Keine Anwendung vorhanden
+          on_off: 'Anwendung publizieren/verbergen'
+        delete: 'Anwendung löschen'
+        no_application: 'Keine Anwendung vorhanden'
         new:
-          title: Anwendung anlegen
-        create_use: Erstellen Sie zunächst eine neue Anwendung mit Basisinformationen. Danach können Sie die Anwendung bearbeiten und Elemente sowie Layersets einzufügen.
+          title: 'Anwendung anlegen'
+        create_use: 'Erstellen Sie zunächst eine neue Anwendung mit Basisinformationen. Danach können Sie die Anwendung bearbeiten und Elemente sowie Layersets einzufügen.'
         btn:
           create: Speichern
           cancel: Abbrechen
         upload:
-          button: Datei auswählen
-          label: Keine Datei ausgewählt...
+          button: 'Datei auswählen'
+          label: 'Keine Datei ausgewählt...'
         export:
           addAcl: Acls
           addSources: Quellen
@@ -184,69 +184,69 @@ mb:
             import: Importieren
         title: Titel
         url:
-          title: URL Titel
+          title: 'URL Titel'
         description: Beschreibung
         template: Vorlage
     source:
       serviceurl: Dienst-URL
       username: Benutzername
       password: Passwort
-      activate_new_layers: Neu hinzugefügte Layer aktivieren
-      select_new_layers: Neu hinzugefügte Layer auswählen
+      activate_new_layers: 'Neu hinzugefügte Layer aktivieren'
+      select_new_layers: 'Neu hinzugefügte Layer auswählen'
       load: Laden
     managerbundle:
-      new_application: Neue Anwendung
-      add_source: Neue Datenquelle
-      add_user_group: Füge Benutzer und Gruppen hinzu
-      acl_element: Acl Element
+      new_application: 'Neue Anwendung'
+      add_source: 'Neue Datenquelle'
+      add_user_group: 'Füge Benutzer und Gruppen hinzu'
+      acl_element: 'Acl Element'
       import_application: Importieren
       export_application: Exportieren
     components:
       popup:
         add_element:
-          title: Element hinzufügen
+          title: 'Element hinzufügen'
         edit_element:
-          title: Element bearbeiten
+          title: 'Element bearbeiten'
         delete_element:
-          title: Löschen bestätigen
+          title: 'Löschen bestätigen'
         add_edit_layerset:
-          title_edit: Layerset bearbeiten
-          title_add: Layerset hinzufügen
+          title_edit: 'Layerset bearbeiten'
+          title_add: 'Layerset hinzufügen'
         delete_layerset:
-          title: Layerset löschen
+          title: 'Layerset löschen'
         add_instance:
-          title: Datenquelle auswählen
+          title: 'Datenquelle auswählen'
         delete_instance:
-          title: Instanz löschen
+          title: 'Instanz löschen'
         delete_user_group:
-          title: Entfernen bestätigen
-          content: Wollen Sie die Gruppe %userGroup% wirklich entfernen?
+          title: 'Entfernen bestätigen'
+          content: 'Wollen Sie die Gruppe %userGroup% wirklich entfernen?'
     import:
       application:
-        failed: Anwendung kann nicht importiert werden
-    http_connection_error: Verbindungsaufbau fehlgeschlagen
-    http_error_response: Der kontaktierte Dienst hat eine Fehlermeldung gesendet
-    xml_invalid: Das XML Dokument ist nicht valide
-    xml_malformed: Kein XML oder ungültige XML-Struktur
+        failed: 'Anwendung kann nicht importiert werden'
+    http_connection_error: 'Verbindungsaufbau fehlgeschlagen'
+    http_error_response: 'Der kontaktierte Dienst hat eine Fehlermeldung gesendet'
+    xml_invalid: 'Das XML Dokument ist nicht valide'
+    xml_malformed: 'Kein XML oder ungültige XML-Struktur'
   core:
     admin:
       button:
-        show_label: Beschriftung anzeigen
+        show_label: 'Beschriftung anzeigen'
       element:
         autostart: Autostart
       title: Titel
     entity:
       app:
         screenshotfile:
-          error: Die Datei ist zu groß (%uploadFileSize% bytes). Die maximal zulässige Größe beträgt %maxFileSize% bytes.
-          format_error: Nicht unterstütztes Format
+          error: 'Die Datei ist zu groß (%uploadFileSize% bytes). Die maximal zulässige Größe beträgt %maxFileSize% bytes.'
+          format_error: 'Nicht unterstütztes Format'
           resolution:
-            error: Es können nur Dateien mit %screenshotHeight% x %screenshotWidth% Pixel oder größer hochgeladen werden. Ihre Datei hat %uploadWidth% x %uploadHeighth% Pixel.
+            error: 'Es können nur Dateien mit %screenshotHeight% x %screenshotWidth% Pixel oder größer hochgeladen werden. Ihre Datei hat %uploadWidth% x %uploadHeighth% Pixel.'
     importjobtype:
       admin:
-        importfile: Datei importieren
+        importfile: 'Datei importieren'
   actions:
-    secureelement: Sicheres Element
+    secureelement: 'Sicheres Element'
   wms:
     wmsloader:
       repo:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -68,16 +68,16 @@ mb:
       convert_to_reusable: 'In freie Instanz umwandeln'
       convert_to_bound: 'In private Instanz umwandeln'
       converted_to_bound: 'Eine private Kopie der freien Instanz wurde der Anwendung hinzugefügt'
-      reusable_assigned_to_application: 'Die freie Instanz wurde der Anwendung hinzugefügt'
       create_reusable: 'Freie Instanz erzeugen'
       created_reusable: 'Neue freie Instanz erzeugt'
+      reusable_assigned_to_application: 'Die freie Instanz wurde der Anwendung hinzugefügt'
     application:
       persistentView: 'Kartenzustand merken'
       splashscreen: 'Ladescreen anzeigen'
       splashscreen_autohide: 'Ladescreen automatisch ausblenden'
     admin:
-      csrf_token_invalid: 'CSRF-Token ungültig.'
       sources: Datenquellen
+      csrf_token_invalid: 'CSRF-Token ungültig.'
       source:
         add: 'Datenquelle hinzufügen'
         show_metadata: 'Metadaten anzeigen'
@@ -100,11 +100,11 @@ mb:
           }
       map:
         max_extent: 'Max. Karten­ausdehnung'
-        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
         start_extent: 'Initiale Karten­ausdehnung'
-        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
         base_dpi: 'Standard-Auflösung [dpi]'
         base_dpi.help: 'Die Auflösung passt sich auf Basis dieses Wertes an die Auflösung des verwendeten Gerätes an.'
+        max_extent.help: 'Bounding Box mit min/max x/y, die den zulässigen Kartenausschnitt markiert, in dem sich ein Nutzer bewegen darf. Bei Klick auf die Weltkugel in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
+        start_extent.help: 'Bounding Box mit min/max x/y, die den Kartenausschnitt markiert, in dem die Karte startet. Bei Klick auf das Haus in der Maßstabsleiste wird auf diese Ausdehnung gezoomt.'
       element:
         title: Titel
         type: Typ

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -68,7 +68,7 @@ mb:
       convert_to_reusable: 'Convert to shared instance'
       convert_to_bound: 'Convert to bound instance'
       converted_to_bound: 'A bound copy of the shared instance has been added to the application'
-      reusable_added_to_application: 'The shared instance has been added to the application'
+      reusable_assigned_to_application: 'The shared instance has been added to the application'
       create_reusable: 'Create shared instance'
       created_reusable: 'A new shared instance has been created'
     application:
@@ -99,7 +99,9 @@ mb:
           }
       map:
         max_extent: 'Max. extent'
+        max_extent.help: 'Bounding Box (min/max x/y) where the user is allowed to navigate. When clicking on the globe icon, the map zooms to this extent.'
         start_extent: 'Start extent'
+        start_extent.help: 'Bounding Box (min/max x/y) that is initially displayed when loading the map. When clicking on the home icon, the map zooms to this extent.'
         base_dpi: 'Default Resolution [dpi]'
         base_dpi.help: 'The resolution adapts to the screen resolution based on the configured value'
       element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -1,37 +1,37 @@
 mb:
   application:
     create:
-      success: Your application has been created.
+      success: 'Your application has been created.'
       failure:
-        create.directory: Application directory can't be created.
+        create.directory: 'Application directory can''t be created.'
     save:
-      success: Your application has been saved.
+      success: 'Your application has been saved.'
       failure:
-        general: There was an error trying to save your application.
-        create.directory: Your application has been updated but the application's directories can not be created.
+        general: 'There was an error trying to save your application.'
+        create.directory: 'Your application has been updated but the application''s directories can not be created.'
     remove:
-      success: Your application has been deleted.
+      success: 'Your application has been deleted.'
       failure:
-        general: Your application couldn't be deleted.
+        general: 'Your application couldn''t be deleted.'
   layerset:
     create:
-      success: Your layerset has been created.
+      success: 'Your layerset has been created.'
     remove:
-      success: Your layerset has been deleted.
-      failure: Your layerset can't be deleted.
+      success: 'Your layerset has been deleted.'
+      failure: 'Your layerset can''t be deleted.'
   source:
     instance:
       create:
-        success: A new instance has been created. Please edit it.
+        success: 'A new instance has been created. Please edit it.'
   manager:
     automatic: Automatic
-    autoActivate: Activate automatically
-    autoOpen: Open automatically
-    confirm_form_discard: Discard changes?
-    popup_height: Dialog height
-    popup_width: Dialog width
+    autoActivate: 'Activate automatically'
+    autoOpen: 'Open automatically'
+    confirm_form_discard: 'Discard changes?'
+    popup_height: 'Dialog height'
+    popup_width: 'Dialog width'
     screentype:
-      label: Screen type
+      label: 'Screen type'
       choice:
         all: Any
         mobile: Mobile
@@ -43,16 +43,16 @@ mb:
           left: Left
           right: Right
           center: Center
-      generate_button_menu: Generate menu for buttons
-      menu_label: Menu label
+      generate_button_menu: 'Generate menu for buttons'
+      menu_label: 'Menu label'
     visibility: Visibility
     element:
       screentype:
-        mobile: Show on mobile screens
-        desktop: Show on desktop screens
+        mobile: 'Show on mobile screens'
+        desktop: 'Show on desktop screens'
     sidepane:
       width: Width
-      closed: Initially closed
+      closed: 'Initially closed'
       align:
         label: Position
         choice:
@@ -65,32 +65,32 @@ mb:
             one   {This instance is used in one application}
             other {This instance is used in # applications}
         }
-      convert_to_reusable: Convert to shared instance
-      convert_to_bound: Convert to bound instance
-      converted_to_bound: A bound copy of the shared instance has been added to the application
-      reusable_added_to_application: The shared instance has been added to the application
-      create_reusable: Create shared instance
-      created_reusable: A new shared instance has been created
+      convert_to_reusable: 'Convert to shared instance'
+      convert_to_bound: 'Convert to bound instance'
+      converted_to_bound: 'A bound copy of the shared instance has been added to the application'
+      reusable_added_to_application: 'The shared instance has been added to the application'
+      create_reusable: 'Create shared instance'
+      created_reusable: 'A new shared instance has been created'
     application:
-      persistentView: Persistent map state
-      splashscreen: Show Splashscreen
+      persistentView: 'Persistent map state'
+      splashscreen: 'Show Splashscreen'
     admin:
       sources: Sources
-      csrf_token_invalid: Invalid CSRF token.
+      csrf_token_invalid: 'Invalid CSRF token.'
       source:
-        add: Add source
-        show_metadata: Show metadata
-        delete: Delete source
+        add: 'Add source'
+        show_metadata: 'Show metadata'
+        delete: 'Delete source'
         new:
-          add: Add source
-        valid: Source valid
-        notvalid: Source not valid.
-        no_source: No source available
-        update: Update source
+          add: 'Add source'
+        valid: 'Source valid'
+        notvalid: 'Source not valid.'
+        no_source: 'No source available'
+        update: 'Update source'
         status:
-          ok: Source OK
-          toupdate: Source not current anymore
-          unreachable: Source unreachable
+          ok: 'Source OK'
+          toupdate: 'Source not current anymore'
+          unreachable: 'Source unreachable'
         embedded_in_applications: |
           {count, plural,
               =0    {This source is not used in any application}
@@ -98,70 +98,70 @@ mb:
               other {This source is used in # applications}
           }
       map:
-        max_extent: Max. extent
-        start_extent: Start extent
-        base_dpi: Default Resolution [dpi]
-        base_dpi.help: The resolution adapts to the screen resolution based on the configured value
+        max_extent: 'Max. extent'
+        start_extent: 'Start extent'
+        base_dpi: 'Default Resolution [dpi]'
+        base_dpi.help: 'The resolution adapts to the screen resolution based on the configured value'
       element:
         title: Title
         type: Type
-        add: Add a new element to
-        show_hide: Toggle show/hide element
-        no_element_added: No element added
+        add: 'Add a new element to'
+        show_hide: 'Toggle show/hide element'
+        no_element_added: 'No element added'
         anchor:
           label: Position
-          left-top: Top left
-          left-bottom: Bottom left
-          right-top: Top right
-          right-bottom: Bottom right
+          left-top: 'Top left'
+          left-bottom: 'Bottom left'
+          right-top: 'Top right'
+          right-bottom: 'Bottom right'
       zoombar:
         draggable: Draggable
       overview:
         fix: Fix
       layerset:
-        add: Add layerset
+        add: 'Add layerset'
         title: Title
         type: Type
-        edit: Edit layerset
+        edit: 'Edit layerset'
         delete:
-          title: Delete layerset
-          confirm: Do you really want to remove the layerset with the title <span class="italic">%layerset_title%</span>?
+          title: 'Delete layerset'
+          confirm: 'Do you really want to remove the layerset with the title <span class="italic">%layerset_title%</span>?'
         id: Id
       instance:
-        add: Add instance
-        show_hide: Toggle show/hide instance
-        edit: Edit instance
+        add: 'Add instance'
+        show_hide: 'Toggle show/hide instance'
+        edit: 'Edit instance'
         delete:
-          title: Delete instance
-          confirm: Do you really want to remove the instance with the title <span class="italic">%instance_title%</span>?
-        no_instance_added: No instance added
-        no_layer_added: No layer added
-        max_input_vars_exceeded: PHP setting max_input_vars too low for the number of layers in this instance.
-        update_successful: Your instance has been updated.
-        converted_to_shared: The instance has been converted to a shared instance.
+          title: 'Delete instance'
+          confirm: 'Do you really want to remove the instance with the title <span class="italic">%instance_title%</span>?'
+        no_instance_added: 'No instance added'
+        no_layer_added: 'No layer added'
+        max_input_vars_exceeded: 'PHP setting max_input_vars too low for the number of layers in this instance.'
+        update_successful: 'Your instance has been updated.'
+        converted_to_shared: 'The instance has been converted to a shared instance.'
       template: Template
       application:
         view: View
         edit:
-          title: Edit application
-          base_data: Base data
+          title: 'Edit application'
+          base_data: 'Base data'
         screenshot: Thumbnail
         layouts: Layouts
         layersets: Layersets
         custom_css: CSS
         security:
           title: Security
-          public: public access
+          public: 'public access'
         save: Save
         cancel: Cancel
-        view_this: View this application
-        duplicate: Duplicate application
+        view_this: 'View this application'
+        duplicate: 'Duplicate application'
         public:
-          on_off: Toggle publish/unpublish application
-        delete: Delete application
-        no_application: No application available
+          on_off: 'Toggle publish/unpublish application'
+        delete: 'Delete application'
+        no_application: 'No application available'
         new:
-          title: New Application
+          title: 'New Application'
         create_use: |-
           Create a new application by providing basic information and then
                     use the edit mode to add elements and layers.
@@ -169,8 +169,8 @@ mb:
           create: Create
           cancel: Cancel
         upload:
-          button: Select file
-          label: No file selected
+          button: 'Select file'
+          label: 'No file selected'
         export:
           addAcl: ACLs
           addSources: Sources
@@ -183,69 +183,69 @@ mb:
             import: Import
         title: Title
         url:
-          title: URL Title
+          title: 'URL Title'
         description: Description
         template: Template
     source:
-      serviceurl: Service URL
+      serviceurl: 'Service URL'
       username: Username
       password: Password
-      activate_new_layers: Activate newly added layers
-      select_new_layers: Select newly added layers
+      activate_new_layers: 'Activate newly added layers'
+      select_new_layers: 'Select newly added layers'
       load: Load
     managerbundle:
-      new_application: New application
-      add_source: Add source
-      add_user_group: Add users and groups
-      acl_element: Acl element
+      new_application: 'New application'
+      add_source: 'Add source'
+      add_user_group: 'Add users and groups'
+      acl_element: 'Acl element'
       import_application: Import
       export_application: Export
     components:
       popup:
         add_element:
-          title: Add element
+          title: 'Add element'
         edit_element:
-          title: Edit element
+          title: 'Edit element'
         delete_element:
-          title: Confirm delete
+          title: 'Confirm delete'
         add_edit_layerset:
-          title_edit: Edit layerset
-          title_add: Add layerset
+          title_edit: 'Edit layerset'
+          title_add: 'Add layerset'
         delete_layerset:
-          title: Delete layerset
+          title: 'Delete layerset'
         add_instance:
-          title: Select source
+          title: 'Select source'
         delete_instance:
-          title: Confirm delete
+          title: 'Confirm delete'
         delete_user_group:
-          title: Confirm delete
-          content: Really delete %userGroup%?
+          title: 'Confirm delete'
+          content: 'Really delete %userGroup%?'
     import:
       application:
-        failed: Application cannot be imported
-    http_connection_error: Connection failed
-    http_error_response: The remote server responded with an error message
-    xml_invalid: Invalid document
-    xml_malformed: Not an XML document or invalid XML structure
+        failed: 'Application cannot be imported'
+    http_connection_error: 'Connection failed'
+    http_error_response: 'The remote server responded with an error message'
+    xml_invalid: 'Invalid document'
+    xml_malformed: 'Not an XML document or invalid XML structure'
   core:
     admin:
       button:
-        show_label: Show label
+        show_label: 'Show label'
       element:
         autostart: Autostart
       title: Title
     entity:
       app:
         screenshotfile:
-          error: The file is too large (%uploadFileSize% bytes). Allowed maximum size is %maxFileSize% bytes.
-          format_error: This format is not supported!
+          error: 'The file is too large (%uploadFileSize% bytes). Allowed maximum size is %maxFileSize% bytes.'
+          format_error: 'This format is not supported!'
           resolution:
-            error: Only image files with %screenshotHeight% x %screenshotWidth% pixel or higher can be selected. Your file is %uploadWidth% x %uploadHeighth% pixel.
+            error: 'Only image files with %screenshotHeight% x %screenshotWidth% pixel or higher can be selected. Your file is %uploadWidth% x %uploadHeighth% pixel.'
     importjobtype:
       admin:
-        importfile: Import file
+        importfile: 'Import file'
   actions:
-    secureelement: Secure element
+    secureelement: 'Secure element'
   wms:
     wmsloader:
       repo:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
@@ -66,7 +66,7 @@ mb:
       convert_to_reusable: Перетворити на спільний екземпляр
       convert_to_bound: Перетворити на зв''язаний екземпляр
       converted_to_bound: Зв''язану копію спільного екземпляра додано до застосунку
-      reusable_added_to_application: Спільний екземпляр додано до застосунку
+      reusable_assigned_to_application: Спільний екземпляр додано до застосунку
       create_reusable: Створити спільний екземпляр
       created_reusable: Створено новий спільний екземпляр
     application:

--- a/src/Mapbender/PrintBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/PrintBundle/Resources/translations/messages.de.yaml
@@ -6,11 +6,11 @@ mb:
           ok: Exportieren
           cancel: Abbrechen
       info:
-        noactivelayer: Keine aktive Ebene!
-      chooseformat: Exportformat auswählen
+        noactivelayer: 'Keine aktive Ebene!'
+      chooseformat: 'Exportformat auswählen'
       class:
         title: Bildexport
-        description: Mit dem Bildexport kann die aktuelle Kartenansicht als Bild exportiert werden. Das Bild kann als png oder jpeg abgespeichert werden.
+        description: 'Mit dem Bildexport kann die aktuelle Kartenansicht als Bild exportiert werden. Das Bild kann als png oder jpeg abgespeichert werden.'
       tag:
         image: Bild
         export: Export
@@ -26,14 +26,14 @@ mb:
           ctime: Erzeugt
           status: Status
         status:
-          pending: in Warteschleife
-          processing: in Bearbeitung
+          pending: 'in Warteschleife'
+          processing: 'in Bearbeitung'
           finished: fertig
         open: Öffnen
         delete: Löschen
         cancel: Abbrechen
-        nodata: keine Daten
-        loading: wird geladen
+        nodata: 'keine Daten'
+        loading: 'wird geladen'
     admin:
       printclient:
         renderMode:
@@ -49,10 +49,10 @@ mb:
   core:
     printclient:
       admin:
-        scales: Maßstäbe (komma-separiert)
+        scales: 'Maßstäbe (komma-separiert)'
         fileprefix: Datei-Präfix
-        optionalfields: Optionale Felder
-        replacepattern: Muster ersetzen
+        optionalfields: 'Optionale Felder'
+        replacepattern: 'Muster ersetzen'
         templates: Vorlagen
         qualitylevels: Qualitätsstufen
       label:

--- a/src/Mapbender/PrintBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/PrintBundle/Resources/translations/messages.en.yaml
@@ -6,11 +6,11 @@ mb:
           ok: Export
           cancel: Cancel
       info:
-        noactivelayer: No active layer!
-      chooseformat: Choose Export Format
+        noactivelayer: 'No active layer!'
+      chooseformat: 'Choose Export Format'
       class:
-        title: Image export
-        description: Image Export allows you to export your current mapview. You can choose png or jpeg format.
+        title: 'Image export'
+        description: 'Image Export allows you to export your current mapview. You can choose png or jpeg format.'
       tag:
         image: image
         export: export
@@ -18,8 +18,8 @@ mb:
         png: png
     printclient:
       tab:
-        settings: Job settings
-        joblist: Recent jobs
+        settings: 'Job settings'
+        joblist: 'Recent jobs'
       joblist:
         header:
           id: '#'
@@ -32,7 +32,7 @@ mb:
         open: open
         delete: delete
         cancel: Cancel
-        nodata: no data
+        nodata: 'no data'
         loading: loading
     admin:
       printclient:
@@ -42,19 +42,19 @@ mb:
             direct: direct
             queued: queued
         queueAccess:
-          label: Job queue
+          label: 'Job queue'
           choice:
             global: global
             private: private
   core:
     printclient:
       admin:
-        scales: Scales (comma-separated)
-        fileprefix: File prefix
-        optionalfields: Optional fields
-        replacepattern: Replace pattern
+        scales: 'Scales (comma-separated)'
+        fileprefix: 'File prefix'
+        optionalfields: 'Optional fields'
+        replacepattern: 'Replace pattern'
         templates: Templates
-        qualitylevels: Quality levels
+        qualitylevels: 'Quality levels'
       label:
         quality: Quality
       class:
@@ -69,5 +69,5 @@ mb:
     admin:
       printclient:
         label:
-          qualitylevels: Quality levels
+          qualitylevels: 'Quality levels'
           templates: Templates

--- a/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
@@ -119,14 +119,14 @@ class WmsInstanceInstanceLayersType extends AbstractType
         if ($this->exposeLayerOrder) {
             $layerOrderChoices = array();
             foreach (WmsInstance::validLayerOrderChoices() as $validChoice) {
-                $translationKey = "mb.wms.wmsloader.repo.instance.label.layerOrder.$validChoice";
+                $translationKey = "mb.wms.wmsloader.repo.instance.label.layerorder.$validChoice";
                 $layerOrderChoices[$translationKey] = $validChoice;
             }
             $builder->add('layerOrder', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                 'choices' => $layerOrderChoices,
                 'required' => true,
                 'auto_initialize' => true,
-                'label' => 'mb.wms.wmsloader.repo.instance.label.layerOrder',
+                'label' => 'mb.wms.wmsloader.repo.instance.label.layerorder',
             ));
         }
     }

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
@@ -65,15 +65,15 @@ mb:
             'on': an
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
-            layerOrder: Layer-Reihenfolge
-            layerOrder.standard: 'Standard (umgekehrt)'
-            layerOrder.reverse: 'QGIS Style (gleiche Reihenfolge)'
             exceptionformat: Fehlerformat
             infoformat: 'Format der GetFeatureInfo-Anfrage'
             format: 'Format der GetMap-Anfrage'
             dimensions: Dimensions
             vendorspecifics: 'Benutzerdefinierte Parameter'
             layers: Ebenen
+            layerOrder: Layer-Reihenfolge
+            layerOrder.standard: 'Standard (umgekehrt)'
+            layerOrder.reverse: 'QGIS Style (gleiche Reihenfolge)'
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
@@ -54,8 +54,8 @@ mb:
             transparency: Transparenz
             tiled: gekachelt
             title: Titel
-            minsc: Minimaler Maßstab
-            maxsc: Maximaler Maßstab
+            minsc: 'Minimaler Maßstab'
+            maxsc: 'Maximaler Maßstab'
             active: aktiv
             select: ausgewählt
             info: Info
@@ -66,19 +66,19 @@ mb:
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
             layerOrder: Layer-Reihenfolge
-            layerOrder.standard: Standard (umgekehrt)
-            layerOrder.reverse: QGIS Style (gleiche Reihenfolge)
+            layerOrder.standard: 'Standard (umgekehrt)'
+            layerOrder.reverse: 'QGIS Style (gleiche Reihenfolge)'
             exceptionformat: Fehlerformat
-            infoformat: Format der GetFeatureInfo-Anfrage
-            format: Format der GetMap-Anfrage
+            infoformat: 'Format der GetFeatureInfo-Anfrage'
+            format: 'Format der GetMap-Anfrage'
             dimensions: Dimensions
-            vendorspecifics: Benutzerdefinierte Parameter
+            vendorspecifics: 'Benutzerdefinierte Parameter'
             layers: Ebenen
           vendorspecific:
-            label: Vendor specific
+            label: 'Vendor specific'
         preview:
           title:
-            servicerepository: Dienste Repository
+            servicerepository: 'Dienste Repository'
           label:
             load: Laden
         layer:
@@ -89,10 +89,10 @@ mb:
             queryable: abfragbar
             cascaded: kaskadiert
             opaque: undurchsichtig
-            nosubset: Keine Untergruppe
-            fixedwidth: feste Breite
-            fixedheight: feste Höhe
-            latlonbounds: LatLon Grenzen
+            nosubset: 'Keine Untergruppe'
+            fixedwidth: 'feste Breite'
+            fixedheight: 'feste Höhe'
+            latlonbounds: 'LatLon Grenzen'
             boundingbox: BoundingBox
             srs: SRS
             styles: Styles
@@ -116,35 +116,35 @@ mb:
         instancelayerform:
           label:
             layerstitle: Layer-Titel
-            minscale: Minimaler Maßstab
-            maxsclase: Maximaler Maßstab
+            minscale: 'Minimaler Maßstab'
+            maxsclase: 'Maximaler Maßstab'
             active: aktiv
-            allowselecttoc: Erlaubt Auswahl im Layerbaum
+            allowselecttoc: 'Erlaubt Auswahl im Layerbaum'
             selectedtoc: 'Layerset beim Start der Anwendung auswählen. Achtung: Checkbox aktiv lassen, falls keine thematischen Ebenen verwendet werden'
-            selectedtoc.help: Das Layerset ist beim Start der Anwendung im Ebenenbaum aktiv. Einstellung sollte nur geändert werden, wenn thematische Ebenen verwendet werden
+            selectedtoc.help: 'Das Layerset ist beim Start der Anwendung im Ebenenbaum aktiv. Einstellung sollte nur geändert werden, wenn thematische Ebenen verwendet werden'
             unselectedtoc.help: 'Das Layerset ist beim Start der Anwendung im Ebenenbaum inaktiv. Achtung: Falls thematische Ebenen nicht verwendet werden, ist das Layerset dann nicht aufrufbar'
-            allowinfotoc: Erlaubt FeatureInfo im Layerbaum
-            infotoc: FeatureInfo im Layerbaum
-            allowtoggletoc: Erlaubt umschalten im Layerbaum
-            toggletoc: Umschalten im Layerbaum
-            allowreordertoc: Erlaubt sortieren im Layerbaum
-            moreinfo: Weitere Informationen
+            allowinfotoc: 'Erlaubt FeatureInfo im Layerbaum'
+            infotoc: 'FeatureInfo im Layerbaum'
+            allowtoggletoc: 'Erlaubt umschalten im Layerbaum'
+            toggletoc: 'Umschalten im Layerbaum'
+            allowreordertoc: 'Erlaubt sortieren im Layerbaum'
+            moreinfo: 'Weitere Informationen'
             id:
               title: ID
               description: 'Instance Layer Id in From: SourceId-SourceLayerId/InstanceId-InstanceLayerId'
             layersname: Name
             style: Style
       class:
-        title: WMS laden
-        description: Lädt einen WMS per getCapabilities-Request
+        title: 'WMS laden'
+        description: 'Lädt einen WMS per getCapabilities-Request'
       admin:
         label:
-          splitlayers: Layer aufteilen
+          splitlayers: 'Layer aufteilen'
     repository:
       parser:
-        couldnotparse: Das XML Dokument kann  nicht geparst werden.
-        not_supported_document: Das XML Dokument ist nicht unterstützt.
-        not_supported_version: Die WMS Version ist nicht unterstützt.
+        couldnotparse: 'Das XML Dokument kann  nicht geparst werden.'
+        not_supported_document: 'Das XML Dokument ist nicht unterstützt.'
+        not_supported_version: 'Die WMS Version ist nicht unterstützt.'
     metadata:
       section:
         common:
@@ -165,9 +165,9 @@ mb:
     dimhandler:
       class:
         title: Dimensions-Handler
-        description: Dimensions-Handler gruppiert und steuert in Der Karte Source Instanzen
+        description: 'Dimensions-Handler gruppiert und steuert in Der Karte Source Instanzen'
     dimensionsets:
-      no_dimension: Keine Dimension vorhanden.
+      no_dimension: 'Keine Dimension vorhanden.'
   core:
     dimensionset:
       admin:
@@ -191,7 +191,7 @@ mb:
         onlineresource: Online-Ressource
       vendorspecifictype:
         hidden: Versteckt
-        setdefaults: Standardwerte festlegen
+        setdefaults: 'Standardwerte festlegen'
     vendorspecifictype:
       admin:
         vstype: Parameter-Typ

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
@@ -65,15 +65,15 @@ mb:
             'on': an
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
+            layerorder: Layer-Reihenfolge
+            layerorder.standard: 'Standard (umgekehrt)'
+            layerorder.reverse: 'QGIS Style (gleiche Reihenfolge)'
             exceptionformat: Fehlerformat
             infoformat: 'Format der GetFeatureInfo-Anfrage'
             format: 'Format der GetMap-Anfrage'
             dimensions: Dimensions
             vendorspecifics: 'Benutzerdefinierte Parameter'
             layers: Ebenen
-            layerOrder: Layer-Reihenfolge
-            layerOrder.standard: 'Standard (umgekehrt)'
-            layerOrder.reverse: 'QGIS Style (gleiche Reihenfolge)'
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
@@ -4,7 +4,7 @@ mb:
       dialog:
         label:
           example: Example
-          wmsurl: Service URL
+          wmsurl: 'Service URL'
           wmsuser: User
           wmspass: Password
       error:
@@ -22,12 +22,12 @@ mb:
             title: Title
             name: Name
             version: Version
-            originurl: Origin URL
+            originurl: 'Origin URL'
             abstract: Abstract
-            onlineresource: Online Resource
-            exceptionformats: Exception Formats
+            onlineresource: 'Online Resource'
+            exceptionformats: 'Exception Formats'
             fees: Fees
-            accessconstraints: Access Constraints
+            accessconstraints: 'Access Constraints'
             person: Person
             organization: Organization
             position: Position
@@ -47,7 +47,7 @@ mb:
             save: Save
             cancel: Cancel
           label:
-            originurl: Origin URL
+            originurl: 'Origin URL'
             visible: Visible
             basesource: BaseSource
             proxy: Proxy
@@ -63,22 +63,22 @@ mb:
             reorder: reorder
             allow: allow
             'on': 'on'
-            ratio: BBOX factor
-            buffer: Tile buffer
-            layerorder: Layer ordering
+            ratio: 'BBOX factor'
+            buffer: 'Tile buffer'
+            layerorder: 'Layer ordering'
             layerorder.standard: standard
             layerorder.reverse: QGIS
-            exceptionformat: Exception format
-            infoformat: Format of GetFeatureInfo request
-            format: Format of the GetMap request
+            exceptionformat: 'Exception format'
+            infoformat: 'Format of GetFeatureInfo request'
+            format: 'Format of the GetMap request'
             dimensions: Dimensions
-            vendorspecifics: Vendor specific parameters
+            vendorspecifics: 'Vendor specific parameters'
             layers: Layers
           vendorspecific:
-            label: Vendor specifics
+            label: 'Vendor specifics'
         preview:
           title:
-            servicerepository: Service Repository
+            servicerepository: 'Service Repository'
           label:
             load: Load
         layer:
@@ -96,78 +96,78 @@ mb:
             boundingbox: BoundingBox
             srs: SRS
             styles: Styles
-            legendurl: Legend URL
+            legendurl: 'Legend URL'
             scale: Scale
             min: Min
             max: Max
             scalehint: Scalehint
             attribution: Attribution
-            onlineresource: Online Resource
-            logourl: Logo URL
+            onlineresource: 'Online Resource'
+            logourl: 'Logo URL'
             identifier: Identifier
             authority: Authority
             url: URL
             value: Value
-            metadataurl: Metadata URL
+            metadataurl: 'Metadata URL'
             dimension: Dimension
             extent: Extent
-            dataurl: Data URL
-            featurelisturl: Featurelist URL
+            dataurl: 'Data URL'
+            featurelisturl: 'Featurelist URL'
         instancelayerform:
           label:
-            layerstitle: Layer's Title
+            layerstitle: 'Layer''s Title'
             minscale: Minscale
             maxsclase: Maxsclase
             active: active
-            allowselecttoc: Allow Select at TOC
+            allowselecttoc: 'Allow Select at TOC'
             selectedtoc: 'Select layer on startup. Caution: Leave this checkbox checked if you are not using thematic layers'
-            selectedtoc.help: The layerset is active upon startup. The setting should only be changed if thematic layers are used.
+            selectedtoc.help: 'The layerset is active upon startup. The setting should only be changed if thematic layers are used.'
             unselectedtoc.help: 'The layerset is inactive upon startup. Caution: If thematic layers are not used, this layerset will not be accessible.'
-            allowinfotoc: Allow FeatureInfo at TOC
-            infotoc: FeatureInfo at TOC
-            allowtoggletoc: Allow Toggle at TOC
-            toggletoc: Toggle at TOC
-            allowreordertoc: Allow Reorder at TOC
-            moreinfo: More information
+            allowinfotoc: 'Allow FeatureInfo at TOC'
+            infotoc: 'FeatureInfo at TOC'
+            allowtoggletoc: 'Allow Toggle at TOC'
+            toggletoc: 'Toggle at TOC'
+            allowreordertoc: 'Allow Reorder at TOC'
+            moreinfo: 'More information'
             id:
               title: ID
               description: 'Instance Layer Id in the from of: SourceId-SourceLayerId/InstanceId-InstanceLayerId'
-            layersname: Layer's Name
+            layersname: 'Layer''s Name'
             style: Style
       class:
-        title: WMS loader
-        description: Loads a WMS via the getCapabilities-Request
+        title: 'WMS loader'
+        description: 'Loads a WMS via the getCapabilities-Request'
       admin:
         label:
-          splitlayers: Split layers
+          splitlayers: 'Split layers'
     repository:
       parser:
-        couldnotparse: Could not parse CapabilitiesDocument
-        not_supported_document: Not supported CapabilitiesDocument
-        not_supported_version: The WMS version is not supported
+        couldnotparse: 'Could not parse CapabilitiesDocument'
+        not_supported_document: 'Not supported CapabilitiesDocument'
+        not_supported_version: 'The WMS version is not supported'
     metadata:
       section:
         common:
-          title: General information
+          title: 'General information'
         contact:
           title: Contact
         items:
           title: Layer
           name: Name
         useconditions:
-          title: Terms of use
+          title: 'Terms of use'
       popup:
-        title: Meta data
+        title: 'Meta data'
     repo:
       instance:
         label:
           dimensions: Dimensions
     dimhandler:
       class:
-        title: Dimensions handler
-        description: DimensionsHandler groups and calls the dimension supported instances at the map
+        title: 'Dimensions handler'
+        description: 'DimensionsHandler groups and calls the dimension supported instances at the map'
     dimensionsets:
-      no_dimension: no dimension
+      no_dimension: 'no dimension'
   core:
     dimensionset:
       admin:
@@ -180,21 +180,21 @@ mb:
         dimensionsets: Dimensionsets
     wmsloader:
       admin:
-        defaultformat: Default format
-        defaultinfoformat: Default info format
+        defaultformat: 'Default format'
+        defaultinfoformat: 'Default info format'
       onlineresource:
         format: Format
         href: href
       legendurltype:
         width: Width
         height: Height
-        onlineresource: Online resource
+        onlineresource: 'Online resource'
       vendorspecifictype:
         hidden: Hidden
-        setdefaults: Set defaults
+        setdefaults: 'Set defaults'
     vendorspecifictype:
       admin:
-        vstype: Parameter type
+        vstype: 'Parameter type'
         name: Name
-        default: Default value
+        default: 'Default value'
         hidden: Hidden

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.it.yaml
@@ -65,9 +65,9 @@ mb:
             'on': attivo
             ratio: fattore BBOX
             buffer: Tile buffer
-            layerOrder: Ordine dei Layers
-            layerOrder.standard: standard
-            layerOrder.reverse: QGIS
+            layerorder: Ordine dei Layers
+            layerorder.standard: standard
+            layerorder.reverse: QGIS
           vendorspecific:
             label: specifiche per Vendor
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.uk.yaml
@@ -65,9 +65,9 @@ mb:
             'on': Включити
             ratio: BBOX фактор
             buffer: Буфер
-            layerOrder: Порядок шарів
-            layerOrder.standard: Стандартний
-            layerOrder.reverse: QGIS
+            layerorder: Порядок шарів
+            layerorder.standard: Стандартний
+            layerorder.reverse: QGIS
           vendorspecific:
             label: певний Vendor
         preview:

--- a/src/Mapbender/WmtsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmtsBundle/Resources/translations/messages.de.yaml
@@ -8,28 +8,13 @@ mb:
             theme: Themen
             serviceprovidername: 'Name des Dienstanbieters'
             serviceprovidersite: 'Webseite des Dienstanbieters'
-        layer:
-          label:
-            identifier: Identifikator
-            formats: Formate
-            abstract: Abstrakt
-            title: Titel
-            latlonbounds: 'Bounding Box'
-            tilematrixsetlinks: TileMatrixSetLinks
         tilematrixset:
           label:
-            title: Titel
-            abstract: Abstrakt
             identifier: Identifikator
             supportedcrs: 'Unterstützte CRS'
+            title: Titel
+            abstract: Abstrakt
           matrixes: Matrizen
-        tilematrix:
-          label:
-            identifier: Identifikator
-            scaledenominator: Maßstabsnenner
-            topleftcorner: 'Top-left corner'
-            tilesize: Kachelgröße
-            matrixsize: Matrixgröße
         theme:
           label:
             identifier: Identifikator
@@ -39,3 +24,18 @@ mb:
         instance:
           label:
             style: Style
+        layer:
+          label:
+            identifier: Identifikator
+            formats: Formate
+            title: Titel
+            abstract: Abstrakt
+            latlonbounds: 'Bounding Box'
+            tilematrixsetlinks: TileMatrixSetLinks
+        tilematrix:
+          label:
+            identifier: Identifikator
+            scaledenominator: Maßstabsnenner
+            topleftcorner: 'Top-left corner'
+            tilesize: Kachelgröße
+            matrixsize: Matrixgröße

--- a/src/Mapbender/WmtsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmtsBundle/Resources/translations/messages.de.yaml
@@ -6,28 +6,28 @@ mb:
           label:
             matrixsets: Matrixsets
             theme: Themen
-            serviceprovidername: Name des Dienstanbieters
-            serviceprovidersite: Webseite des Dienstanbieters
+            serviceprovidername: 'Name des Dienstanbieters'
+            serviceprovidersite: 'Webseite des Dienstanbieters'
         layer:
           label:
             identifier: Identifikator
             formats: Formate
             abstract: Abstrakt
             title: Titel
-            latlonbounds: Bounding Box
+            latlonbounds: 'Bounding Box'
             tilematrixsetlinks: TileMatrixSetLinks
         tilematrixset:
           label:
             title: Titel
             abstract: Abstrakt
             identifier: Identifikator
-            supportedcrs: Unterstützte CRS
+            supportedcrs: 'Unterstützte CRS'
           matrixes: Matrizen
         tilematrix:
           label:
             identifier: Identifikator
             scaledenominator: Maßstabsnenner
-            topleftcorner: Top-left corner
+            topleftcorner: 'Top-left corner'
             tilesize: Kachelgröße
             matrixsize: Matrixgröße
         theme:

--- a/src/Mapbender/WmtsBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/WmtsBundle/Resources/translations/messages.en.yaml
@@ -6,12 +6,12 @@ mb:
           label:
             matrixsets: Matrixsets
             theme: Theme
-            serviceprovidername: Name of service provider
-            serviceprovidersite: Website of service provider
+            serviceprovidername: 'Name of service provider'
+            serviceprovidersite: 'Website of service provider'
         tilematrixset:
           label:
             identifier: Identifier
-            supportedcrs: Supported CRS
+            supportedcrs: 'Supported CRS'
             title: Title
             abstract: Abstract
           matrixes: Matrices


### PR DESCRIPTION
The console command `mapbender:normalize-translations` does three things:
- sort all translation keys in all bundles in the `Mapbender` and `FOM` namespace in the same order as in the original translation file (usually English)
- show keys that are present in the translated file but not in the original translation file
- show (option `-p`) or automatically add (`-a`) keys that are not yet translated. Automatically added keys use the original translation marked with a configurable prefix (`--missing-key-prefix`, default: "TRANSLATE")

#### Sample usage

Show (print to console) all missing German translations:
```bash
bin/console mapbender:normalize-translations -p de
```

Automatically add all missing Spanish translations to the yaml files:
```bash
bin/console mapbender:normalize-translations -a es
```

#### Sample output
```bash
Processing translation for Mapbender\CoreBundle  …
Found unexpected key "mb.core.simplesearch.admin.title.help" in translated file not present in original
Translations keys normalized for bundle Mapbender\CoreBundle. No keys were missing.
``