### PR TITLE
Make side pane user-resizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Features:
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
 * [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518))
 * [FeatureInfo] Tabs in the feature info window are now sorted in the order they appear in the layer tree ([PR#1534](https://github.com/mapbender/mapbender/pull/1534))
+* [Sidebar] Sidebar is now user-resizable (configurable but active per default) ([PR#1539](https://github.com/mapbender/mapbender/pull/1539))
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))

--- a/src/Mapbender/CoreBundle/Element/Type/MapbenderTypeTrait.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapbenderTypeTrait.php
@@ -13,12 +13,13 @@ trait MapbenderTypeTrait
      * @param array $typeConfiguration
      * @return array
      */
-    public function createInlineHelpText(array $typeConfiguration, TranslatorInterface $trans): array
+    public function createInlineHelpText(array $typeConfiguration, TranslatorInterface $trans, bool $showAsPopover = true): array
     {
         if (empty($typeConfiguration['help'])) return $typeConfiguration;
-        $typeConfiguration['help'] = '<i class="fas fa-question-circle" data-bs-toggle="popover" data-bs-content="'
-            . htmlspecialchars( $trans->trans($typeConfiguration['help']))
-            . '" data-bs-placement="left" data-bs-html="true"></i>';
+        $content = htmlspecialchars($trans->trans($typeConfiguration['help']));
+        $typeConfiguration['help'] = $showAsPopover
+            ? '<i class="fas fa-question-circle" data-bs-toggle="popover" data-bs-content="'.$content . '" data-bs-placement="left" data-bs-html="true"></i>'
+            : '<i class="fas fa-question-circle" title="'.$content . '"></i>';
         $typeConfiguration['help_html'] = true;
         $helpAttr = array_key_exists('help_attr', $typeConfiguration) ? $typeConfiguration['help_attr'] : [];
         $typeConfiguration['help_attr'] = $helpAttr;

--- a/src/Mapbender/CoreBundle/Form/Type/Template/Fullscreen/SidepaneSettingsType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/Template/Fullscreen/SidepaneSettingsType.php
@@ -3,18 +3,23 @@
 namespace Mapbender\CoreBundle\Form\Type\Template\Fullscreen;
 
 
+use Mapbender\CoreBundle\Element\Type\MapbenderTypeTrait;
+use Mapbender\ManagerBundle\Form\Type\ScreentypeType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class SidepaneSettingsType extends AbstractType
 {
-    protected $allowResponsiveContainers;
+    use MapbenderTypeTrait;
 
-    public function __construct($allowResponsiveContainers)
+    public function __construct(private TranslatorInterface $translator, private bool $allowResponsiveContainers)
     {
-        $this->allowResponsiveContainers = $allowResponsiveContainers;
     }
 
     public function getParent()
@@ -36,22 +41,27 @@ class SidepaneSettingsType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'Mapbender\CoreBundle\Form\Type\Template\Fullscreen\SidepaneTypeType', array(
+        $builder->add('name', SidepaneTypeType::class, array(
             'label' => 'mb.core.admin.template.sidepane.type.label',
         ));
         if ($this->allowResponsiveContainers) {
-            $builder->add('screenType', 'Mapbender\ManagerBundle\Form\Type\ScreentypeType', array(
+            $builder->add('screenType', ScreentypeType::class, array(
                 'label' => 'mb.manager.screentype.label',
             ));
         }
-        $builder->add('width', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+        $builder->add('width', TextType::class, array(
             'required' => false,
             'attr' => array(
                 'placeholder' => '350px',   // HACK: this is implicitly the default (via CSS)
             ),
             'label' => 'mb.manager.sidepane.width',
         ));
-        $builder->add('align', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('resizable', CheckboxType::class, $this->createInlineHelpText([
+            'required' => false,
+            'label' => 'mb.manager.sidepane.resizable',
+            'help' => 'mb.manager.sidepane.resizable_help',
+        ], $this->translator, false));
+        $builder->add('align', ChoiceType::class, array(
             'required' => false,
             'choices' => array(
                 'mb.manager.sidepane.align.choice.left' => 'left',
@@ -61,7 +71,7 @@ class SidepaneSettingsType extends AbstractType
             'placeholder' => false,
             'empty_data' => 'left',
         ));
-        $builder->add('closed', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+        $builder->add('closed', CheckboxType::class, array(
             'required' => false,
             'label' => 'mb.manager.sidepane.closed',
         ));

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -140,6 +140,7 @@
         </service>
         <service id="form.type.template.sidepane_settings" class="Mapbender\CoreBundle\Form\Type\Template\Fullscreen\SidepaneSettingsType">
             <tag name="form.type" />
+            <argument type="service" id="translator"/>
             <argument>%mapbender.responsive.containers%</argument>
         </service>
         <service id="mb.coordsutility.form.srslist" class="Mapbender\CoreBundle\Element\Type\CoordinatesUtilitySrsListType" >

--- a/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/jquery-ui-touch-punch/jquery.ui.touch-punch.js
@@ -1,28 +1,63 @@
 /*!
- * Original version from https://github.com/furf/jquery-ui-touch-punch/blob/master/jquery.ui.touch-punch.js
- * jQuery UI Touch Punch 0.2.3
+ * jQuery UI Touch Punch 1.0.9 as modified by RWAP Software
+ * based on original touchpunch v0.2.3 which has not been updated since 2014
  *
+ * Updates by RWAP Software to take account of various suggested changes on the original code issues
+ *
+ * Original: https://github.com/furf/jquery-ui-touch-punch
  * Copyright 2011–2014, Dave Furfero
  * Dual licensed under the MIT or GPL Version 2 licenses.
  *
+ * Fork: https://github.com/RWAP/jquery-ui-touch-punch
+ *
  * Depends:
- *  jquery.ui.widget.js
- *  jquery.ui.mouse.js
+ * jquery.ui.widget.js
+ * jquery.ui.mouse.js
  */
-(function ($) {
 
-  // Detect touch support
-  $.support.touch = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
+(function( factory ) {
+    if ( typeof define === "function" && define.amd ) {
 
-  // Ignore browsers without touch support
-  if (!$.support.touch) {
-    return;
+        // AMD. Register as an anonymous module.
+        define([ "jquery", "jquery-ui" ], factory );
+    } else {
+
+        // Browser globals
+        factory( jQuery );
+    }
+}(function ($) {
+
+  // Detect touch support - Windows Surface devices and other touch devices
+  $.mspointer = window.navigator.msPointerEnabled;
+  $.touch = ( 'ontouchstart' in document
+   	|| 'ontouchstart' in window
+   	|| window.TouchEvent
+   	|| (window.DocumentTouch && document instanceof DocumentTouch)
+   	|| navigator.maxTouchPoints > 0
+   	|| navigator.msMaxTouchPoints > 0
+  );
+
+  // Ignore browsers without touch or mouse support
+  if ((!$.touch && !$.mspointer) || !$.ui.mouse) {
+	return;
   }
 
-  var mouseProto = $.ui.mouse.prototype,
+
+  let mouseProto = $.ui.mouse.prototype,
       _mouseInit = mouseProto._mouseInit,
       _mouseDestroy = mouseProto._mouseDestroy,
       touchHandled;
+
+    /**
+    * Get the x,y position of a touch event
+    * @param {Object} event A touch event
+    */
+    function getTouchCoords (event) {
+        return {
+            x: event.originalEvent.changedTouches[0].pageX,
+            y: event.originalEvent.changedTouches[0].pageY
+        };
+    }
 
   /**
    * Simulate a mouse event based on a corresponding touch event
@@ -36,9 +71,17 @@
       return;
     }
 
-    event.preventDefault();
+    //Ignore input or textarea elements so user can still enter text
+    if ($(event.target).is("input") || $(event.target).is("textarea")) {
+      return;
+    }
 
-    var touch = event.originalEvent.changedTouches[0],
+    // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    let touch = event.originalEvent.changedTouches[0],
         simulatedEvent = document.createEvent('MouseEvents');
 
     // Initialize the simulated mouse event using the touch event's coordinates
@@ -70,7 +113,13 @@
    */
   mouseProto._touchStart = function (event) {
 
-    var self = this;
+    let self = this;
+
+    // Interaction time
+    this._startedMove = event.timeStamp;
+
+    // Track movement to determine if interaction was a click
+    self._startPos = getTouchCoords(event);
 
     // Ignore the event if another widget is already being handled
     if (touchHandled || !self._mouseCapture(event.originalEvent.changedTouches[0])) {
@@ -104,7 +153,7 @@
       return;
     }
 
-    // Interaction was not a click
+    // Interaction was moved
     this._touchMoved = true;
 
     // Simulate the mousemove event
@@ -129,11 +178,26 @@
     simulateMouseEvent(event, 'mouseout');
 
     // If the touch interaction did not move, it should trigger a click
-    if (!this._touchMoved) {
+    // Check for this in two ways - length of time of simulation and distance moved
+    // Allow for Apple Stylus to be used also
+    let timeMoving = event.timeStamp - this._startedMove;
+    if (!this._touchMoved || timeMoving < 500) {
+        // Simulate the click event
+        simulateMouseEvent(event, 'click');
+    } else {
+      let endPos = getTouchCoords(event);
+      if ((Math.abs(endPos.x - this._startPos.x) < 10) && (Math.abs(endPos.y - this._startPos.y) < 10)) {
 
-      // Simulate the click event
-      simulateMouseEvent(event, 'click');
+          // If the touch interaction did not move, it should trigger a click
+          if (!this._touchMoved || event.originalEvent.changedTouches[0].touchType === 'stylus') {
+              // Simulate the click event
+              simulateMouseEvent(event, 'click');
+          }
+      }
     }
+
+    // Unset the flag to determine the touch movement stopped
+    this._touchMoved = false;
 
     // Unset the flag to allow other widgets to inherit the touch event
     touchHandled = false;
@@ -147,10 +211,15 @@
    */
   mouseProto._mouseInit = function () {
 
-    var self = this;
+    let self = this;
+
+    // Microsoft Surface Support = remove original touch Action
+    if ($.support.mspointer) {
+      self.element[0].style.msTouchAction = 'none';
+    }
 
     // Delegate the touch handlers to the widget's element
-    self.element.bind({
+    self.element.on({
       touchstart: $.proxy(self, '_touchStart'),
       touchmove: $.proxy(self, '_touchMove'),
       touchend: $.proxy(self, '_touchEnd')
@@ -165,10 +234,10 @@
    */
   mouseProto._mouseDestroy = function () {
 
-    var self = this;
+    let self = this;
 
     // Delegate the touch handlers to the widget's element
-    self.element.unbind({
+    self.element.off({
       touchstart: $.proxy(self, '_touchStart'),
       touchmove: $.proxy(self, '_touchMove'),
       touchend: $.proxy(self, '_touchEnd')
@@ -178,4 +247,4 @@
     _mouseDestroy.call(self);
   };
 
-})(jQuery);
+}));

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -231,6 +231,19 @@ ul.toolBar, .toolBar > ul {
     }
   }
 }
+
+.sidePane.resizable::after {
+    content: '';
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    cursor: ew-resize;
+}
+
 .metadataDialog{
   .popupContent {
     height: 100%;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -234,14 +234,21 @@ ul.toolBar, .toolBar > ul {
 
 .sidePane.resizable::after {
     content: '';
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
     position: absolute;
-    right: 0;
     top: 0;
-    width: 4px;
+    width: 3px;
     height: 100%;
     cursor: ew-resize;
+}
+
+.sidePane.left.resizable::after {
+    border-left: 1px solid #ccc;
+    right: 0;
+}
+
+.sidePane.right.resizable::after {
+    border-right: 1px solid #ccc;
+    left: 0;
 }
 
 .metadataDialog{

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -232,6 +232,10 @@ ul.toolBar, .toolBar > ul {
   }
 }
 
+.sidePane.resizable {
+    touch-action: pan-y;
+}
+
 .sidePane.resizable::after {
     content: '';
     position: absolute;

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -1,35 +1,90 @@
-/**
- * Migrated to Mapbender from FOM v3.0.6.3
- * See https://github.com/mapbender/fom/tree/v3.0.6.3/src/FOM/CoreBundle/Resources/public/js/frontend
- */
-$(function() {
+$(function () {
+    const $switchButton = $(".toggleSideBar");
+    const $sidePane = $switchButton.closest("div.sidePane");
+    const sidePane = $sidePane[0];
 
-    var switchButton = $(".toggleSideBar");
-    var sidePane = switchButton.closest("div.sidePane");
+    let mousePosition = 0;
+    const BORDER_SIZE = 6;
+    // if you want to customize the max/min size use custom css (min-width/max-width on .sidePane.resizable),
+    const MAX_SIZE_WINDOW_PERCENTAGE = 0.95;
+    const MIN_SIZE_PX = 120;
 
-    if (sidePane.hasClass('closed')) {
-        if (sidePane.hasClass("right")) {
-            sidePane.css({right: (sidePane.outerWidth(true) * -1) + "px"});
+    // TOGGLE SIDEPANE FUNCTIONALITY
+    if ($sidePane.hasClass('closed')) {
+        if ($sidePane.hasClass("right")) {
+            $sidePane.css({right: ($sidePane.outerWidth(true) * -1) + "px"});
         } else {
-            sidePane.css({left: (sidePane.outerWidth(true) * -1) + "px"});
+            $sidePane.css({left: ($sidePane.outerWidth(true) * -1) + "px"});
         }
     }
 
-    switchButton.on('click', function() {
-        var wasOpen = !sidePane.hasClass('closed');
+    $switchButton.on('click', function () {
+        var wasOpen = !$sidePane.hasClass('closed');
         var animation = {};
-        var align = sidePane.hasClass('right') ? 'right' : 'left';
+        var align = $sidePane.hasClass('right') ? 'right' : 'left';
         if (wasOpen) {
-            animation[align] = "-" + sidePane.outerWidth(true) + "px";
+            animation[align] = "-" + $sidePane.outerWidth(true) + "px";
         } else {
             animation[align] = "0px";
         }
 
-        sidePane.animate(animation, {
+        $sidePane.animate(animation, {
             duration: 300,
-            complete: function() {
-                sidePane.toggleClass('closed', wasOpen);
+            complete: function () {
+                $sidePane.toggleClass('closed', wasOpen);
             }
         });
+    });
+
+    // RESIZE SIDEPANE FUNCTIONALITY
+    const sidePaneWidth = function () {
+        return parseInt(getComputedStyle(sidePane, '').width);
+    }
+    const resize = function (e) {
+        if (e.buttons === 0) {
+            // catch mouse released outside the window
+            document.removeEventListener("mousemove", resize, false);
+            return;
+        }
+
+        const dx = mousePosition - e.x;
+        mousePosition = e.x;
+        let calculatedWidth = sidePaneWidth() - dx;
+
+        // make sure sidepane does not become unreasonably big or small
+        if (calculatedWidth > Math.floor(window.innerWidth * MAX_SIZE_WINDOW_PERCENTAGE)) {
+            const overflow = calculatedWidth - Math.floor(window.innerWidth * MAX_SIZE_WINDOW_PERCENTAGE);
+            calculatedWidth -= overflow;
+            mousePosition -= overflow;
+        }
+
+        if (calculatedWidth < MIN_SIZE_PX) {
+            const underflow = MIN_SIZE_PX - calculatedWidth;
+            calculatedWidth += underflow;
+            mousePosition += underflow;
+        }
+
+        sidePane.style.width = calculatedWidth + "px";
+    }
+
+    const constrainSize = function () {
+        if (!sidePane) return;
+        if (sidePaneWidth() > Math.floor(window.innerWidth * MAX_SIZE_WINDOW_PERCENTAGE)) {
+            sidePane.style.width = Math.floor(window.innerWidth * MAX_SIZE_WINDOW_PERCENTAGE) + "px";
+        }
+    }
+
+    // make sure sidebar is resizable even when making the window smaller
+    window.addEventListener("resize", constrainSize, false);
+
+    $(document).on('mousedown', '.sidePane.resizable', function (e) {
+        if (sidePaneWidth() - e.offsetX < BORDER_SIZE) {
+            mousePosition = e.x;
+            document.addEventListener("mousemove", resize, false);
+        }
+    });
+
+    $(document).on('mouseup', '.sidePane.resizable', function (e) {
+        document.removeEventListener("mousemove", resize, false);
     });
 });

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -2,6 +2,7 @@ $(function () {
     const $switchButton = $(".toggleSideBar");
     const $sidePane = $switchButton.closest("div.sidePane");
     const sidePane = $sidePane[0];
+    const sidePaneLeft = $sidePane.hasClass('left');
 
     let mousePosition = 0;
     const BORDER_SIZE = 6;
@@ -49,7 +50,7 @@ $(function () {
 
         const dx = mousePosition - e.x;
         mousePosition = e.x;
-        let calculatedWidth = sidePaneWidth() - dx;
+        let calculatedWidth = sidePaneWidth() + (sidePaneLeft ? -1 : 1) * dx;
 
         // make sure sidepane does not become unreasonably big or small
         if (calculatedWidth > Math.floor(window.innerWidth * MAX_SIZE_WINDOW_PERCENTAGE)) {
@@ -78,7 +79,7 @@ $(function () {
     window.addEventListener("resize", constrainSize, false);
 
     $(document).on('mousedown', '.sidePane.resizable', function (e) {
-        if (sidePaneWidth() - e.offsetX < BORDER_SIZE) {
+        if ((sidePaneLeft && sidePaneWidth() - e.offsetX < BORDER_SIZE) || (!sidePaneLeft && e.offsetX < BORDER_SIZE)) {
             mousePosition = e.x;
             document.addEventListener("mousemove", resize, false);
         }

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -1,5 +1,4 @@
-<div class="{{ 'sidePane flex-fill ' ~ region_class | trim }}"
-     {# @todo: provide default sidepane width not just at the CSS level; correct initial display of closed sidepane requires a known width #}
+<div class="{{ 'sidePane flex-fill ' ~ region_class | trim }}{% if region_props.resizable %} resizable{% endif %}"
      {%- if region_props.width | default('') -%}
          {%- if region_props.closed | default(false) -%}
              {{ ' ' }}style="width: {{ region_props.width }}; {{ 'left' in region_class ? 'left' : 'right' }}: -{{ region_props.width }};"

--- a/src/Mapbender/CoreBundle/Resources/views/index.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/index.html.twig
@@ -6,7 +6,7 @@
     <title>{% block title %}{{ pagetitle | default(title | default(fom.server_name)) }}{% endblock %}</title>
     <meta name="description" content="Mapbender" />
 {% block mobilejs %}
-    {%- set scaleFactor = scaleFactor|default('0.7') -%}
+    {%- set scaleFactor = scaleFactor|default('1.0') -%}
     <meta name="viewport" content="width=device-width, initial-scale={{ scaleFactor }}, maximum-scale={{ scaleFactor }}, minimum-scale={{ scaleFactor }}, user-scalable=no"/>
 {% endblock %}
     <link rel="stylesheet" type="text/css" href="{{ asset('components/cookieconsent/build/cookieconsent.min.css') }}"/>

--- a/src/Mapbender/CoreBundle/Template/Fullscreen.php
+++ b/src/Mapbender/CoreBundle/Template/Fullscreen.php
@@ -4,6 +4,8 @@ namespace Mapbender\CoreBundle\Template;
 
 use Mapbender\CoreBundle\Component\Template;
 use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\CoreBundle\Form\Type\Template\Fullscreen\SidepaneSettingsType;
+use Mapbender\CoreBundle\Form\Type\Template\Fullscreen\ToolbarSettingsType;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 
 /**
@@ -88,7 +90,7 @@ class Fullscreen extends Template
                 );
             case 'js':
                 return array(
-                    '@FOMCoreBundle/Resources/public/js/frontend/sidepane.js',
+                    '@MapbenderCoreBundle/Resources/public/widgets/sidepane.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.container.info.js',
                 );
             case 'trans':
@@ -123,10 +125,10 @@ class Fullscreen extends Template
     {
         switch ($regionName) {
             case 'sidepane':
-                return 'Mapbender\CoreBundle\Form\Type\Template\Fullscreen\SidepaneSettingsType';
+                return SidepaneSettingsType::class;
             case 'toolbar':
             case 'footer':
-                return 'Mapbender\CoreBundle\Form\Type\Template\Fullscreen\ToolbarSettingsType';
+                return ToolbarSettingsType::class;
             default:
                 return null;
         }
@@ -146,6 +148,7 @@ class Fullscreen extends Template
                     'name' => 'accordion',
                     'align' => 'left',
                     'closed' => false,
+                    'resizable' => true,
                 );
             default:
                 return parent::getRegionPropertiesDefaults($regionName);

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -52,6 +52,8 @@ mb:
         desktop: 'Auf großen Bildschirmen anzeigen'
     sidepane:
       width: Breite
+      resizable: 'Größe veränderbar'
+      resizable_help: 'Falls aktiviert, kann der Nutzer die Größe der Sidepane durch Halten und Ziehen am rechten Rand verändern. Die maximale/minimale Breite lässt sich per Benutzerdefiniertem CSS bearbeiten (min-width/max-width auf .sidePane.resizable)'
       closed: 'Geschlossen starten'
       align:
         label: Position

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -52,6 +52,8 @@ mb:
         desktop: 'Show on desktop screens'
     sidepane:
       width: Width
+      resizable: Resizable
+      resizable_help: 'If checked, the user can resize the sidebar by dragging on its right edge. If you want to constrain the min/max width, use custom css (min-width/max-width on .sidePane.resizable).'
       closed: 'Initially closed'
       align:
         label: Position


### PR DESCRIPTION
Adds an option to the side pane region's properties in the default Fullscreen template:

![grafik](https://github.com/mapbender/mapbender/assets/3438255/1b72792f-81fe-4904-901c-67ac587ca77f)

It is active by default. The key for yaml applications is `resizable`.


Users can now drag the side pane on its right edge to make it smaller or larger. 

By default, the minimum size is 120px. the maximum is 95% of the screen's width. These values can be further restricted by using custom css:

```css
.sidePane.resizable {
  min-width: 200px;
  max-width: 500px;
}
```
