### PR TITLE
Remove option "hideSelect" from layertree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Other:
 * \*.yml file extension changed to \*.yaml for consistency with symfony core ([PR#1513](https://github.com/mapbender/mapbender/pull/1513))
 * [Button] added new icons for map, earth, map-pin, share-arrow ([PR#1525](https://github.com/mapbender/mapbender/pull/1525))
 * Changed default login-backdrop image ([PR#1542](https://github.com/mapbender/mapbender/pull/1542))
+* [Layertree] Removed option `hideSelect` ([PR#1543](https://github.com/mapbender/mapbender/pull/1543))
+
 
 ## v3.3.5
 Features:

--- a/src/Mapbender/CoreBundle/Element/Layertree.php
+++ b/src/Mapbender/CoreBundle/Element/Layertree.php
@@ -76,7 +76,6 @@ class Layertree extends AbstractElementService implements ImportAwareInterface
         return array(
             "autoOpen" => false,
             "showBaseSource" => true,
-            "hideSelect" => false,
             "hideInfo" => false,
             "menu" => array(),
             "useTheme" => false,

--- a/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
@@ -35,10 +35,6 @@ class LayertreeAdminType extends AbstractType
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.hideinfo',
             ))
-            ->add('hideSelect', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-                'required' => false,
-                'label' => 'mb.core.admin.layertree.label.hideselect',
-            ))
             ->add('menu', 'Mapbender\CoreBundle\Element\Type\LayerTreeMenuType', array(
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.menu',

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -5,7 +5,6 @@
             target: null,
             showBaseSource: true,
             allowReorder: true,
-            hideSelect: false,
             hideInfo: false,
             themes: null,
             menu: []
@@ -226,9 +225,6 @@
                 $('.-fn-toggle-children', $li).addClass('disabled-placeholder');
             }
             if (layer.children && layer.children.length && (treeOptions.allow.toggle || treeOptions.toggle)) {
-                if (this.options.hideSelect && treeOptions.selected && !treeOptions.allow.selected) {
-                    $('.-fn-toggle-selected', $li).remove();
-                }
                 for (var j = layer.children.length - 1; j >= 0; j--) {
                     $childList.append(this._createLayerNode(layer.children[j]));
                 }

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -505,7 +505,6 @@ mb:
             useTheme: 'Thema anzeigen'
             label: Themenname
           hidenottoggleable: 'Nicht aufklappbare Ordner ausblenden'
-          hideselect: 'Visibility bei Ordnern ausblenden'
           hideinfo: 'Info ausblenden'
           menu: Menü
       template:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -505,7 +505,6 @@ mb:
             useTheme: 'Theme show'
             label: 'theme name'
           hidenottoggleable: 'Hide not toggleable'
-          hideselect: 'Hide visibility by folders'
           hideinfo: 'Hide info'
           menu: Menu
       template:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
@@ -278,7 +278,6 @@ mb:
             useTheme: null
             label: null
           hidenottoggleable: null
-          hideselect: null
           hideinfo: null
     htmlelement:
       class:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
@@ -278,7 +278,6 @@ mb:
             useTheme: Afficher le thème
             label: nom du thème
           hidenottoggleable: Ne pas afficher les couches non-basculables
-          hideselect: Ne pas afficher la visiblité pour les dossiers
           hideinfo: Ne pas afficher l'information
       template:
         sidepane:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
@@ -302,7 +302,6 @@ mb:
             useTheme: Mostra tema
             label: nome del tema
           hidenottoggleable: Funzione nascondi non modificabile
-          hideselect: Nascondi la visibilità per le cartelle
           hideinfo: Nascondi info
     htmlelement:
       class:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
@@ -278,7 +278,6 @@ mb:
             useTheme: Gebruik thema
             label: thema naam
           hidenottoggleable: Verberg niet-schakelbaar
-          hideselect: Verberg kiesbaar
           hideinfo: Verberg info
     htmlelement:
       class:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
@@ -278,7 +278,6 @@ mb:
             useTheme: Camada temática
             label: Nome do tema
           hidenottoggleable: Ocultar arquivos que não pode-se abrir
-          hideselect: Ocultar visibilidade de arquivos
           hideinfo: Ocultar info
       template:
         sidepane:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
@@ -302,7 +302,6 @@ mb:
             useTheme: Показать рубрики
             label: Рубрика
           hidenottoggleable: Скрыть не переключаемые папки
-          hideselect: Скрыть видимость у папок
           hideinfo: Скрыть информацию
       template:
         sidepane:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
@@ -278,7 +278,6 @@ mb:
             useTheme: Temaları göster
             label: Tema isimleri
           hidenottoggleable: Açılıp kapanamayan(lar)ı gizle
-          hideselect: Klasöri kullanarak gizle
           hideinfo: Bilgileri gizle
       template:
         sidepane:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
@@ -356,7 +356,6 @@ mb:
             useTheme: Показати тему
             label: назва теми
           hidenottoggleable: Приховати папки, що не перемикаються
-          hideselect: Приховати видимість за папками
           hideinfo: Приховати інформацію
       template:
         sidepane:

--- a/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/layertree.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/ElementAdmin/layertree.html.twig
@@ -8,10 +8,7 @@
     {%- if form.configuration.target is defined -%}{{- form_row(form.configuration.target) -}}{%- endif -%}
     {{ form_row(form.configuration.menu) }}
     <div class="mb-3">
-        {{ form_widget(form.configuration.hideSelect, {'label_attr': {'class': 'checkbox-inline'}}) }}
         {{ form_widget(form.configuration.hideInfo, {'label_attr': {'class': 'checkbox-inline'}}) }}
-    </div>
-    <div class="mb-3">
         {{ form_widget(form.configuration.useTheme, {'label_attr': {'class': 'checkbox-inline'}}) }}
     </div>
     {% if form.configuration.themes is defined %}


### PR DESCRIPTION
The meaning of the option was highly ambigious and its use is very limited for its prominence in the layertree editor.

Use the following custom css to hide all disabled checkboxes:

```css
.leaveContainer > .-fn-toggle-selected.disabled
{
  display: none;
}
```

and this code to only hide disabled checkboxes on the top level (matches the behaviour of the old `hideSelect` setting:

```css
.mb-element-layertree > .layers > .leave > .leaveContainer > .-fn-toggle-selected.disabled
{
  display: none;
}
```


fixes #1445 