### PR TITLE
[LayerTree] Ensure all parent layers become visible when toggling a child layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Features:
 * [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518))
 * [FeatureInfo] Tabs in the feature info window are now sorted in the order they appear in the layer tree ([PR#1534](https://github.com/mapbender/mapbender/pull/1534))
 * [Sidebar] Sidebar is now user-resizable (configurable but active per default) ([PR#1539](https://github.com/mapbender/mapbender/pull/1539))
+* [LayerTree] When activating a layer, all its parent layers are also activated ([PR#1544](https://github.com/mapbender/mapbender/pull/1544))
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -396,6 +396,10 @@
             var layer = $target.closest('li.leave').data('layer');
             this.model.controlLayer(layer, null, newState);
         },
+        /**
+         * initalise a layer menu, called when the burger menu is clicked
+         * @param $layerNode jQuery
+         */
         _initMenu: function ($layerNode) {
             var layer = $layerNode.data('layer');
             var source = layer.source;
@@ -404,14 +408,18 @@
             if (layer.getParent()) {
                 $('.layer-control-root-only', menu).remove();
             }
-            var atLeastOne = !!$('.layer-remove-btn', menu).length;
+
+            const activeMenuItems = this._filterMenu(layer);
+            if (!activeMenuItems.length) {
+                menu.remove();
+                return;
+            }
 
             // element must be added to dom and sized before Dragdealer init...
             $('.leaveContainer:first', $layerNode).after(menu);
 
             var $opacityControl = $('.layer-control-opacity', menu);
             if ($opacityControl.length) {
-                atLeastOne = true;
                 var $handle = $('.layer-opacity-handle', $opacityControl);
                 $handle.attr('unselectable', 'on');
                 new Dragdealer($('.layer-opacity-bar', $opacityControl).get(0), {
@@ -431,14 +439,11 @@
             }
             var $zoomControl = $('.layer-zoom', menu);
             if ($zoomControl.length && layer.hasBounds()) {
-                atLeastOne = true;
                 $zoomControl.on('click', $.proxy(this._zoomToLayer, this));
             } else {
                 $zoomControl.remove();
             }
-            if (layer.options.metadataUrl && $('.layer-metadata', menu).length) {
-                atLeastOne = true;
-            } else {
+            if (!layer.options.metadataUrl || !$('.layer-metadata', menu).length) {
                 $('.layer-metadata', menu).remove();
             }
 
@@ -446,12 +451,8 @@
             var $dimensionsControl = $('.layer-control-dimensions', menu);
             if (dims.length && $dimensionsControl.length) {
                 this._initDimensionsMenu($layerNode, menu, dims, source);
-                atLeastOne = true;
             } else {
                 $dimensionsControl.remove();
-            }
-            if (!atLeastOne) {
-                menu.remove();
             }
         },
         _toggleMenu: function (e) {
@@ -464,8 +465,20 @@
             return false;
         },
         _filterMenu: function (layer) {
-            var enabled = this.options.menu;
-            var supported = ['layerremove'];
+            const enabled = this.options.menu;
+            const supported = this._getSupportedMenuOptions(layer);
+
+            return supported.filter(function (name) {
+                return -1 !== enabled.indexOf(name);
+            });
+        },
+        /**
+         * returns a list of supported menu options for this layer. Override this if you have a custom menu option
+         * @param layer Mapbender.SourceLayer
+         * @returns {string[]}
+         */
+        _getSupportedMenuOptions(layer) {
+            const supported = ['layerremove'];
             if (layer.options.metadataUrl) {
                 supported.push('metadata');
             }
@@ -479,10 +492,7 @@
             if (layer.hasBounds()) {
                 supported.push('zoomtolayer');
             }
-
-            return supported.filter(function (name) {
-                return -1 !== enabled.indexOf(name);
-            });
+            return supported;
         },
         _initDimensionsMenu: function ($element, menu, dims, source) {
             var self = this;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -368,8 +368,8 @@
             ;
         },
         _toggleSelected: function (e) {
-            var $target = $(e.currentTarget);
-            var newState = $target.toggleClass('active').hasClass('active');
+            const $target = $(e.currentTarget);
+            const newState = $target.toggleClass('active').hasClass('active');
             this.updateIconVisual_($target, newState, null);
             var layer = $target.closest('li.leave').data('layer');
             var source = layer && layer.source;
@@ -387,8 +387,36 @@
                 }
             }
 
+            if (newState) {
+                this._updateParentState($(e.currentTarget).closest('li.leave'));
+            }
+
             return false;
         },
+        /**
+         * ensure all parent layers become visible when toggling a child layer
+         */
+        _updateParentState: function ($target) {
+            const $parentTarget = $target.parent().closest('li.leave, li.themeContainer');
+            const $parentCheckbox = $parentTarget.find('> .leaveContainer > .-fn-toggle-selected');
+
+            const layer = $parentTarget.data('layer');
+            const source = layer && layer.source;
+            const themeId = !source && $parentTarget.closest('.themeContainer').attr('data-layersetid');
+
+            // already in root level, no parents left to check
+            if (!(layer && layer.source) && !themeId) return;
+
+            if ($parentCheckbox.hasClass('active')) {
+                // recursively check the next higher hierarchy level
+                this._updateParentState($parentTarget);
+            } else {
+                // only trigger checkbox click when it was not checked before
+                // _toggleSelected will take care of checking for the higher hierarchy levels
+                $parentCheckbox.trigger('click');
+            }
+        },
+
         _toggleInfo: function (e) {
             var $target = $(e.currentTarget);
             var newState = $target.toggleClass('active').hasClass('active');


### PR DESCRIPTION
If a user activates a layer in the layertree by clicking the checkbox, what he/she wants is to see the layer on the map. Until now, this was only the case when all parent layers were already active. With this change, all parent layers will automatically become active when one of its children becomes active.

Also, refactored the initMenu and filterMenu functions to greatly simplify extending the menu with custom functionality.