### PR TITLE
Prevent dragging a popup window outside the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Bugfixes:
 * Fix WMS configuration cannot be unserialized when updating from mapbender <3.2.4 versions in PHP >= 8.2 ([PR#1477](https://github.com/mapbender/mapbender/pull/1477))
 * Do not crash application after a layerset has been removed and the map element has not yet been saved ([PR#1482](https://github.com/mapbender/mapbender/pull/1482))
 * Correctly handle removal of GetFeatureInfo capability when refreshing sources ([#1480](https://github.com/mapbender/mapbender/issues/1480), [PR#1488](https://github.com/mapbender/mapbender/pull/1488))
+* Popup movement is now restricted to the viewport ([PR#1547](https://github.com/mapbender/mapbender/pull/1547))
 * [FeatureInfo][Mobile Template] Auto-activate did not work in mobile template; empty popups are now prevented when triggering the FeatureInfo via a button ([#1467](https://github.com/mapbender/mapbender/issues/1467), [PR#1471](https://github.com/mapbender/mapbender/pull/1471))
 * [Map element] Make base dpi configurable to circumvent discrepancies in Mapbender and WMS resolutions ([PR#1486](https://github.com/mapbender/mapbender/pull/1486))
 * [LayerTree] Correctly show folder state (opened/closed) when thematic layers are active ([PR#1478](https://github.com/mapbender/mapbender/pull/1478))

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
@@ -186,7 +186,22 @@
             $btn.addClass(confOrNode.cssClass || '');
             return $btn.get(0);
         },
-        __dummy__: null
+        /**
+         * make sure the popup never leaves the current viewport
+         */
+        restrictPositioning: function() {
+            this.$element.on('dragstop', function (event, ui) {
+                let forcedX = null;
+                let forcedY = null;
+                let $target = $(event.target);
+                if (ui.position.top < 0) forcedY = 0;
+                if (ui.position.top > window.innerHeight - 50) forcedY = window.innerHeight - 50;
+                if (ui.position.left < 0) forcedX = 0;
+                if (ui.position.left > window.innerWidth - 50) forcedX = window.innerWidth - 50;
+                if (forcedX !== null) $target.css('left', forcedX);
+                if (forcedY !== null) $target.css('top', forcedY);
+            });
+        },
     };
 
     window.Mapbender.Popup = function Popup(options) {
@@ -333,6 +348,7 @@
                     containment: containment,
                     scroll: false
                 });
+                this.restrictPositioning();
             }
             this.focus();
         },
@@ -554,6 +570,7 @@
                 if (draggableOptions) {
                     self.$element.css('position', 'relative');
                     self.$element.draggable(draggableOptions);
+                    self.restrictPositioning();
                 }
                 self.$element.trigger('openend');
             }, 100);


### PR DESCRIPTION
Until now it was possible to drag a popup window (like print or legend) outside  the viewport by releasing the mouse button outside the current browser window. The dialog was then gone until the respective element was disabled and reenabled.

New restrictions:
- a popup window's left edge may never be placed further left than the left of the viewport
- a popup window's top edge may never be placed further left than the top of the viewport
- a popup window's right edge may never be placed further than 50px from the right edge of the viewport (which leaves the heading visible so it can be dragged back to the main screen)
- a popup window's bottom edge may never be placed further than 50px from the bottom edge of the viewport (which leaves the heading visible so it can be dragged back to the main screen)