### PR TITLE
[ImageTransport] Return null if image download fails

### DIFF
--- a/src/Mapbender/PrintBundle/Component/LayerRendererWms.php
+++ b/src/Mapbender/PrintBundle/Component/LayerRendererWms.php
@@ -132,7 +132,7 @@ class LayerRendererWms extends LayerRenderer
         if (count($grid->getTiles()) === 1) {
             // Single-tile grid can trivially be resolved with a single request, avoiding the temporary
             // image used for tile merging.
-            $layerImage = $this->imageTransport->downloadImage($baseUrl, $layerDef['opacity']);
+            $layerImage = $this->imageTransport->downloadImage($baseUrl, $layerDef['opacity'], $this->logger);
         } else {
             $layerImage = imagecreatetruecolor($grid->getWidth(), $grid->getHeight());
             imagesavealpha($layerImage, true);
@@ -145,7 +145,7 @@ class LayerRendererWms extends LayerRenderer
                 $params = $this->getBboxAndSizeParams($tileExtent, $offsetBox->getWidth(), $offsetBox->getHeight(), $flipXy);
                 $tileUrl = UrlUtil::validateUrl($baseUrl, $params);
                 // echo "Next tile request to {$tileUrl}\n";
-                $tileImage = $this->imageTransport->downloadImage($tileUrl, $layerDef['opacity']);
+                $tileImage = $this->imageTransport->downloadImage($tileUrl, $layerDef['opacity'], $this->logger);
                 if (!$tileImage) {
                     continue;
                 }

--- a/src/Mapbender/PrintBundle/Component/LegendHandler.php
+++ b/src/Mapbender/PrintBundle/Component/LegendHandler.php
@@ -3,6 +3,7 @@
 
 namespace Mapbender\PrintBundle\Component;
 
+use Psr\Log\LoggerInterface;
 use Mapbender\PrintBundle\Component\Legend\LegendBlock;
 use Mapbender\PrintBundle\Component\Legend\LegendBlockContainer;
 use Mapbender\PrintBundle\Component\Legend\LegendBlockGroup;
@@ -43,6 +44,8 @@ class LegendHandler
     protected $legendPageFontName = 'Arial';
     /** @var float */
     protected $legendPageFontSize = 11;
+    /** @var LoggerInterface */
+    protected $logger = null;
 
     /**
      * @param ImageTransport $imageTransport
@@ -54,6 +57,14 @@ class LegendHandler
         $this->imageTransport = $imageTransport;
         $this->resourceDir = $resourceDir;
         $this->pdfUtil = new PdfUtil($tempDir, 'mb_print_legend');
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger($logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -234,7 +245,7 @@ class LegendHandler
      */
     public function prepareUrlBlock($title, $url)
     {
-        $image = $this->imageTransport->downloadImage($url);
+        $image = $this->imageTransport->downloadImage($url, 1.0, $this->logger);
         if ($image) {
             return new LegendBlock($image, $title);
         } else {

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -60,6 +60,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
         $this->templateParser = $templateParser;
         $this->imageTransport = $imageTransport;
         $this->legendHandler = $legendHandler;
+        $this->legendHandler->setLogger($logger);
 
         $this->pluginHost = $pluginHost;
         $this->resourceDir = $resourceDir;

--- a/src/Mapbender/WmtsBundle/Component/Export/LayerRendererTiled.php
+++ b/src/Mapbender/WmtsBundle/Component/Export/LayerRendererTiled.php
@@ -67,7 +67,7 @@ abstract class LayerRendererTiled extends LayerRenderer
     {
         foreach ($imageTiles as $imageTile) {
             $tileUrl = $tileMatrix->getTileUrl($imageTile->getTileX(), $imageTile->getTileY());
-            $tileImage = $this->imageTransport->downloadImage($tileUrl, $opacity);
+            $tileImage = $this->imageTransport->downloadImage($tileUrl, $opacity, $this->logger);
             if ($tileImage) {
                 imagecopyresampled($image, $tileImage,
                     $imageTile->getOffsetX(), $imageTile->getOffsetY(),


### PR DESCRIPTION
Currently if downloadImage() is unable to download an image, it tries to do the Gd-Operations on null.

Instead downloadImage() should check if $image is null. With this patch, if $image is indeed null an error gets logged (since a null image is undesirable, but a failed download is not necessarily the wrong behaviour for a system) and returns null. This requires a new argument to downloadImage() ($logger), which all callers have to pass. Most already have a $logger that can be used, but LegendHandler.php does not, so a new normally-null logger is introduced and set from PrintService.

Fixes #1549 