### PR TITLE
Fix wildcard translation fallback language if not defined in the target language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Bugfixes:
 * [Print] Fix crash when encountering a network error during printing ([#1549](https://github.com/mapbender/mapbender/issues/1549), [PR#1551](https://github.com/mapbender/mapbender/pull/1551) - thanks [@enno-t](https://github.com/enno-t))
 * Popup movement is now restricted to the viewport ([PR#1547](https://github.com/mapbender/mapbender/pull/1547))
 * Dropdown Element can now handle two options with the same value ([PR#1557](https://github.com/mapbender/mapbender/pull/1557))
+* Wildcard translations added in elements now correctly use the fallback language if not defined in the target language ([PR#1559](https://github.com/mapbender/mapbender/pull/1559))
 
 Other:
 * \*.yml file extension changed to \*.yaml for consistency with symfony core ([PR#1513](https://github.com/mapbender/mapbender/pull/1513))

--- a/src/Mapbender/CoreBundle/Asset/TranslationCompiler.php
+++ b/src/Mapbender/CoreBundle/Asset/TranslationCompiler.php
@@ -22,11 +22,11 @@ class TranslationCompiler
     /** @var Twig\Environment */
     protected $templateEngine;
     /** @var string[]|null */
-    protected ?array $allMessages;
+    protected ?array $allMessages = null;
     /** @var string[]|null */
-    protected ?array $allMessagesFallbackLocale;
+    protected ?array $allMessagesFallbackLocale = null;
 
-    protected ?string $fallbackLocale;
+    protected ?string $fallbackLocale = null;
 
     protected $treatTemplatesAsOptional = true;
 

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -272,6 +272,7 @@
                  lazy="true">
             <argument type="service" id="translator" />
             <argument type="service" id="twig" />
+            <argument>%fallback_locale%</argument>
         </service>
         <service id="mapbender.application_asset.service"
                  class="%mapbender.application_asset.service.class%"


### PR DESCRIPTION
Previous (buggy behaviour): If a wildcard translation was defined in an element's required assets and none of the wildcard strings was defined in the target language, the TranslationCompiler threw an error causing no translations at all to be available. 

New behaviour: For wildcard translations the fallback locale's translation is used like it already was the case for non-wildcard translations.