### PR TITLE
Fix visiblelayers param to work by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Features:
 * [Sidebar] Sidebar is now user-resizable (configurable but active per default) ([PR#1539](https://github.com/mapbender/mapbender/pull/1539))
 * [LayerTree] When activating a layer, all its parent layers are also activated ([PR#1544](https://github.com/mapbender/mapbender/pull/1544))
 * [SearchRouter] Extends configuration to handle labeling. ([PR#1553](https://github.com/mapbender/mapbender/pull/1553))
+* [Map] visiblelayers parameter now supports also rootlayer and layer name (not only sourceinstanceid, instanceid) ([PR#1565](https://github.com/mapbender/mapbender/pull/1565))
 
 
 Bugfixes:

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -488,6 +488,11 @@ window.Mapbender.MapModelBase = (function() {
                 if (idParts.length >= 2) {
                     var sourceId = idParts[0];
                     var layerId = idParts[1];
+                    if (isNaN(sourceId) || isNaN(layerId)) {
+                        var sourceAndLayerId = self.findSourceAndLayerIdByName(sourceId, layerId);
+                        sourceId = sourceAndLayerId.sourceId;
+                        layerId = sourceAndLayerId.layerId;
+                    }
                     console.log("Activating", sourceId, layerId);
                     var source = self.getSourceById(sourceId);
                     var layer = source && source.getLayerById(layerId);
@@ -500,6 +505,22 @@ window.Mapbender.MapModelBase = (function() {
                     }
                 }
             });
+        },
+
+        findSourceAndLayerIdByName: function (sourceName, layerName) {
+            var sourceAndLayerId = {};
+            this.getSources().forEach(function (source) {
+                var config = source.children[0];
+                if (config.options.name === sourceName) {
+                    sourceAndLayerId.sourceId = config.source.id;
+                    config.children.forEach(function (child) {
+                        if (child.options.name === layerName) {
+                            sourceAndLayerId.layerId = child.options.id;
+                        }
+                    });
+                }
+            });
+            return sourceAndLayerId;
         }
     };
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -508,13 +508,14 @@ window.Mapbender.MapModelBase = (function() {
         },
 
         findSourceAndLayerIdByName: function (sourceName, layerName) {
-            var sourceAndLayerId = {};
+            const sourceAndLayerId = {};
             this.getSources().forEach(function (source) {
-                var config = source.children[0];
-                if (config.options.name === sourceName) {
+                if (!source.children || !source.children.length) return;
+                const config = source.children[0];
+                if (config.options.name === sourceName || config.options.title === sourceName) {
                     sourceAndLayerId.sourceId = config.source.id;
                     config.children.forEach(function (child) {
-                        if (child.options.name === layerName) {
+                        if (child.options.name === layerName || child.options.title === layerName) {
                             sourceAndLayerId.layerId = child.options.id;
                         }
                     });


### PR DESCRIPTION
This enhances the `visiblelayers` url parameter to work with given source- and layer-name also. So far only source- and layer-ID are allowed.
@astroidex Please test if it works as expected.

see documentation to find out about visiblelayers
https://doc.mapbender.org/en/elements/basic/map.html#make-layer-visible

?visiblelayers=Mapbender/Mapbender_Names,Mapbender/Mapbender_User,39/149
