### PR TITLE
[Print Client] Support print of a textbox on top of the map

### DIFF
--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -207,17 +207,20 @@ class PrintService extends ImageExportService implements PrintServiceInterface
     protected function buildPdf($mapImageName, $templateData, $jobData)
     {
         // @todo: eliminate instance variable $this->pdf
+        // needs a pdf generated via selection
         $this->pdf = $pdf = $this->makeBlankPdf($templateData, $jobData['template']);
         $tplidx = $pdf->importPage(1);
-        $pdf->useTemplate($tplidx);
+
         $this->addMapImage($pdf, $mapImageName, $templateData);
         unlink($mapImageName);
 
-        // @todo: reimplement "transparent background pdf" logic? (purpose / testability unknown)
+        $pdf->useTemplate($tplidx);
+
         $this->afterMainMap($pdf, $templateData, $jobData);
 
         return $pdf;
     }
+
 
     /**
      * Returns the binary string representation of the $pdf


### PR DESCRIPTION
- some pdf print templates use a textbox on top of the map
- this worked in older version
- see Ticket #1414 - will support textbox on the map again. But needs pdf template generated via selection
- modified function supports the print on top again, but it need a pdf templated hat was generated via Select all -> Export PDF - Selection