### PR TITLE
[Ruler]: Add option to make type user-selectable and allow usage in sidepane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,14 @@ Features:
 * [SearchRouter] Extends configuration to handle labeling. ([PR#1553](https://github.com/mapbender/mapbender/pull/1553))
 * [Map] visiblelayers parameter now supports also rootlayer and layer name (not only sourceinstanceid, instanceid) ([PR#1565](https://github.com/mapbender/mapbender/pull/1565))
 * [SearchRouter] Sorting for searchresults table ([PR#1572](https://github.com/mapbender/mapbender/pull/1572))
+* [Ruler] Add option to make type user-selectable ([PR#1581](https://github.com/mapbender/mapbender/pull/1581))
 
 Bugfixes:
 * [Simple Search] Correctly handle deletion of configurations (([#1502](https://github.com/mapbender/mapbender/issues/1502), [PR#1503](https://github.com/mapbender/mapbender/pull/1503))
 * [LayerTree] Restore layertree configuration after source update ([PR#1497](https://github.com/mapbender/mapbender/pull/1497))
 * [SearchRouter] Fix possiblility to enable/disable result option count ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [Print] Fix crash when encountering a network error during printing ([#1549](https://github.com/mapbender/mapbender/issues/1549), [PR#1551](https://github.com/mapbender/mapbender/pull/1551) - thanks [@enno-t](https://github.com/enno-t))
+* [Ruler] Allow usage in side-pane ([PR#1581](https://github.com/mapbender/mapbender/pull/1581))
 * Deletion of data sources did not work in some cases ([PR#1552](https://github.com/mapbender/mapbender/pull/1552))
 * Popup movement is now restricted to the viewport ([PR#1547](https://github.com/mapbender/mapbender/pull/1547))
 * Dropdown Element can now handle two options with the same value ([PR#1557](https://github.com/mapbender/mapbender/pull/1557))

--- a/src/Mapbender/CoreBundle/Element/Ruler.php
+++ b/src/Mapbender/CoreBundle/Element/Ruler.php
@@ -30,16 +30,20 @@ class Ruler extends AbstractElementService
      */
     public function getRequiredAssets(Element $element)
     {
-        return array(
-            'js' => array(
+        return [
+            'js' => [
                 '@MapbenderCoreBundle/Resources/public/mapbender.element.ruler.js',
-            ),
-            'css' => array(),
-            'trans' => array(
+            ],
+            'css' => [
+                '@MapbenderCoreBundle/Resources/public/mapbender.element.ruler.css',
+            ],
+            'trans' => [
                 'mb.core.ruler.create_error',
                 'mb.core.ruler.help',
-            ),
-        );
+                'mb.core.ruler.tag.line',
+                'mb.core.ruler.tag.area',
+            ],
+        ];
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Type/RulerAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/RulerAdminType.php
@@ -35,6 +35,7 @@ class RulerAdminType extends AbstractType
                     'choices' => array(
                         "mb.core.ruler.tag.line" => "line",
                         "mb.core.ruler.tag.area" => "area",
+                        "mb.core.ruler.tag.both" => "both",
                     ),
                 ))
             ->add('help', TextType::class, $this->createInlineHelpText([

--- a/src/Mapbender/CoreBundle/Resources/public/element/mapbender.element.coordinatesutility.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mapbender.element.coordinatesutility.js
@@ -60,7 +60,7 @@
         _setup: function () {
             this.highlightLayer = window.Mapbender.vectorLayerPool.getElementLayer(this, 0);
 
-            this.isPopUpDialog = !this.element.closest('.sidePane,.sideContent').length;
+            this.isPopUpDialog = Mapbender.ElementUtil.checkDialogMode(this.element);
 
             this._initializeMissingSrsDefinitions(this.options.srsList);
             this._setupButtons();

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.css
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.css
@@ -1,0 +1,9 @@
+.mb-ruler__radiobuttons {
+    margin-bottom: 10px;
+}
+.mb-ruler__radiobuttons label {
+    display: block;
+}
+.mb-ruler__radiobuttons input {
+    margin-right: 5px;
+}

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.ruler.js
@@ -19,10 +19,11 @@
         popup: null,
         layer: null,
         mapModel: null,
+        isDialog: true,
 
         _create: function () {
             var self = this;
-            if (this.options.type !== 'line' && this.options.type !== 'area') {
+            if (this.options.type !== 'line' && this.options.type !== 'area' && this.options.type !== 'both') {
                 throw Mapbender.trans("mb.core.ruler.create_error");
             }
             Mapbender.elementRegistry.waitReady('.mb-element-map').then(function (mbMap) {
@@ -70,7 +71,7 @@
                 color: this.options.strokeColor,
             }));
 
-            this.layer.getNativeLayer().setStyle(function(feature) {
+            this.layer.getNativeLayer().setStyle(function (feature) {
                 return this._getStyle(feature, true);
             }.bind(this));
 
@@ -113,22 +114,49 @@
             return style;
         },
         _setup: function (mbMap) {
-            var self = this;
+            this.isDialog = Mapbender.ElementUtil.checkDialogMode(this.element);
             this.mapModel = mbMap.getModel();
             this.layer = Mapbender.vectorLayerPool.getElementLayer(this, 0);
+            this.createContentContainer();
             this.control = this._createControl();
-            this.container = $('<div/>');
-            this.help = $('<p/>').text(Mapbender.trans(this.options.help));
-            this.total = $('<div/>').addClass('total-value').css({'font-weight': 'bold'});
-            this.segments = $('<ul/>');
-            this.segments.append()
-            if (this.options.help) this.container.append(this.help);
-            this.container.append(this.total);
-            this.container.append(this.segments);
 
             $(document).bind('mbmapsrschanged', $.proxy(this._mapSrsChanged, this));
 
             this._trigger('ready');
+        },
+        createContentContainer: function() {
+            this.container = $('<div/>');
+            this.total = $('<div/>').addClass('total-value').css({'font-weight': 'bold'});
+            this.segments = $('<ul/>');
+            this.segments.append();
+            if (this.options.type === 'both') {
+                const $buttonContainer = $(document.createElement("div")).attr("class", "mb-ruler__radiobuttons");
+                $buttonContainer.append(this.createRadioButton("line", true));
+                $buttonContainer.append(this.createRadioButton("area"));
+                this.container.append($buttonContainer);
+                this.options.type = "line";
+            }
+            if (this.options.help) {
+                const help = $('<p/>').text(Mapbender.trans(this.options.help));
+                this.container.append(help);
+            }
+            this.container.append(this.total);
+            this.container.append(this.segments);
+        },
+        createRadioButton: function (type, checked) {
+            const radioLine = $(document.createElement("input"))
+                .attr("type", "radio")
+                .attr("name", "draw_type")
+                .attr("checked", checked)
+                .on('click', () => {
+                    if (this.options.type === type) return;
+                    this.options.type = type;
+                    this._reset();
+                    this.mapModel.olMap.removeInteraction(this.control);
+                    this.control = this._createControl();
+                    this.mapModel.olMap.addInteraction(this.control);
+                });
+            return $("<label />").append(radioLine).append(Mapbender.trans("mb.core.ruler.tag." + type));
         },
         /**
          * Default action for mapbender element
@@ -148,12 +176,24 @@
                 this.layer.hide();
             }
         },
+        reveal: function () {
+            this.activate();
+        },
+        hide: function () {
+            this.deactivate();
+        },
         activate: function (callback) {
             this.callback = callback ? callback : null;
-            var self = this;
             this._toggleControl(true);
 
             this._reset();
+            if (this.isDialog) {
+                this.showPopup();
+            } else {
+                this.element.append(this.container);
+            }
+        },
+        showPopup: function () {
             if (!this.popup || !this.popup.$element) {
                 this.popup = new Mapbender.Popup2({
                     title: this.element.attr('data-title'),
@@ -162,7 +202,7 @@
                     resizable: true,
                     closeOnESC: true,
                     destroyOnClose: true,
-                    content: self.container,
+                    content: this.container,
                     width: 300,
                     height: 300,
                     buttons: [
@@ -251,16 +291,14 @@
             var calcOptions = {
                 projection: this.mapModel.getCurrentProjectionCode()
             };
-            // Openlayers 6 special: ol.Sphere namespace renamed to lowercase ol.sphere
-            var sphereNamespace = (ol.Sphere || ol.sphere);
             switch (type) {
                 case 'line':
-                    return sphereNamespace.getLength(geometry, calcOptions);
+                    return ol.sphere.getLength(geometry, calcOptions);
                 default:
                     console.warn("Unsupported geometry type in measure calculation", type, feature);
                 // fall through to area
                 case 'area':
-                    return sphereNamespace.getArea(geometry, calcOptions);
+                    return ol.sphere.getArea(geometry, calcOptions);
             }
         },
 

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -187,6 +187,7 @@ mb:
       tag:
         line: Linie
         area: Fläche
+        both: 'Vom Nutzer auswählbar'
         measure: Messen
       help: 'Doppelklicken zum Beenden'
       admin:

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -187,6 +187,7 @@ mb:
       tag:
         line: line
         area: area
+        both: user-selectable
         measure: measure
       help: 'Double-click to end drawing'
       admin:


### PR DESCRIPTION
Added choice "both" for the type option along with "line" and "area" to offer the user the choice to switch between the two modes on the fly.

![grafik](https://github.com/mapbender/mapbender/assets/3438255/226f2729-bffa-4419-a767-3f897036a824)

Also, using the ruler in the sidepane was not possible before, now both the usage as popup (triggered via a button) and in the sidepane is possible.