### PR TITLE
Make manager template and login template configurable in AssetsController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Features:
 * New console command `mapbender:normalize-translations` to quickly find and complement missing translations ([PR#1538](https://github.com/mapbender/mapbender/pull/1538))
 * New console command `mapbender:wms:assign` to add a wms source instance to an application ([PR#1552](https://github.com/mapbender/mapbender/pull/1552))
 * Modified command `mapbender:wms:show`: parameter id is now optional, if omitted all sources are shown; id can be replaced by origin url; added option `--json` for json output. ([PR#1552](https://github.com/mapbender/mapbender/pull/1552))
+* Make ManagerTemplate and LoginTemplate configurable ([PR#1583](https://github.com/mapbender/mapbender/pull/1583))
 * [SearchRouter] New option exportcsv to download the result list as CSV ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [ApplicationAssetService] Allow overriding sass/css and js assets by calling ApplicationAssetService::registerAssetOverride or by using the new parameter `mapbender.asset_overrides` ([PR#1512](https://github.com/mapbender/mapbender/pull/1512))
 * [Button] Allow customization of the icons available for selection in the button edit form. See PR description for details. ([PR#1518](https://github.com/mapbender/mapbender/pull/1518))

--- a/src/Mapbender/CoreBundle/Controller/AssetsController.php
+++ b/src/Mapbender/CoreBundle/Controller/AssetsController.php
@@ -9,8 +9,6 @@ use Mapbender\Component\Application\TemplateAssetDependencyInterface;
 use Mapbender\CoreBundle\Asset\ApplicationAssetService;
 use Mapbender\CoreBundle\Component\ApplicationYAMLMapper;
 use Mapbender\CoreBundle\Entity\Application;
-use Mapbender\ManagerBundle\Template\LoginTemplate;
-use Mapbender\ManagerBundle\Template\ManagerTemplate;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,12 +22,14 @@ class AssetsController extends YamlApplicationAwareController
     protected $isDebug;
 
     public function __construct(protected TranslatorInterface     $translator,
-                                ApplicationYAMLMapper   $yamlRepository,
+                                ApplicationYAMLMapper             $yamlRepository,
                                 protected ApplicationAssetService $assetService,
-                                EntityManagerInterface $em,
-                                                        $containerTimestamp,
-                                                        $cacheDir,
-                                                        $isDebug)
+                                EntityManagerInterface            $em,
+                                                                  $containerTimestamp,
+                                                                  $cacheDir,
+                                                                  $isDebug,
+                                protected string                  $templateClass,
+                                protected string                  $loginTemplateClass)
     {
         parent::__construct($yamlRepository, $em);
         $this->containerTimestamp = intval(ceil($containerTimestamp));
@@ -76,7 +76,7 @@ class AssetsController extends YamlApplicationAwareController
         ]);
 
         if ($source instanceof Application) {
-            $content = $this->assetService->getAssetContent($source, $type, $sourceMap,$sourceMapRoute);
+            $content = $this->assetService->getAssetContent($source, $type, $sourceMap, $sourceMapRoute);
         } else {
             $content = $this->assetService->getBackendAssetContent($source, $type, $sourceMap, $sourceMapRoute);
         }
@@ -111,17 +111,13 @@ class AssetsController extends YamlApplicationAwareController
         return $path;
     }
 
-    /**
-     * @param string $slug
-     * @return TemplateAssetDependencyInterface|null
-     */
-    private function getManagerAssetDependencies($slug)
+    protected function getManagerAssetDependencies(string $slug): ?TemplateAssetDependencyInterface
     {
         switch ($slug) {
             case 'manager':
-                return new ManagerTemplate();
+                return new $this->templateClass();
             case 'mb3-login':
-                return new LoginTemplate();
+                return new $this->loginTemplateClass();
             default:
                 return null;
         }

--- a/src/Mapbender/CoreBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/controllers.xml
@@ -96,6 +96,8 @@
             <argument>%container.compilation_timestamp_float%</argument>
             <argument>%kernel.cache_dir%</argument>
             <argument>%kernel.debug%</argument>
+            <argument>%mapbender.manager.manager.template_class%</argument>
+            <argument>%mapbender.manager.manager.login_template_class%</argument>
             <tag name="container.service_subscriber" />
             <call method="setContainer">
                 <argument type="service" id="Psr\Container\ContainerInterface" />

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -45,6 +45,8 @@
         </parameter>
         <parameter key="mapbender.disabled_elements" type="collection" />
         <parameter key="mapbender.uploads_dir">uploads</parameter>
+        <parameter key="mapbender.manager.manager.login_template_class">Mapbender\ManagerBundle\Template\LoginTemplate</parameter>
+        <parameter key="mapbender.manager.manager.template_class">Mapbender\ManagerBundle\Template\ManagerTemplate</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Added new parameters:

-  `mapbender.manager.manager.template_class` (default value: Mapbender\ManagerBundle\Template\ManagerTemplate)
-  `mapbender.manager.manager.login_template_class` (default value: Mapbender\ManagerBundle\Template\LoginTemplate)

If you want to customize the css of your application's backoffice, overwrite the parameters with the FCQN of a class that implements `Mapbender\Component\Application\TemplateAssetDependencyInterface` (or extends from the mapbender core's ManagerTemplate)