### PR TITLE
[PrintClient] Parse text alignment when parsing ODG for print templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Bugfixes:
 * [LayerTree] Restore layertree configuration after source update ([PR#1497](https://github.com/mapbender/mapbender/pull/1497))
 * [SearchRouter] Fix possiblility to enable/disable result option count ([PR#1509](https://github.com/mapbender/mapbender/pull/1509))
 * [Print] Fix crash when encountering a network error during printing ([#1549](https://github.com/mapbender/mapbender/issues/1549), [PR#1551](https://github.com/mapbender/mapbender/pull/1551) - thanks [@enno-t](https://github.com/enno-t))
+* [Print] In print templates, respect text alignment (left/center/right) ([PR#1587](https://github.com/mapbender/mapbender/pull/1587))
 * [Ruler] Allow usage in side-pane ([PR#1581](https://github.com/mapbender/mapbender/pull/1581))
 * [FeatureInfo] Allow usage in side-pane ([PR#1582](https://github.com/mapbender/mapbender/pull/1582))
 * [Sketch] Already use selected color while drawing ([PR#1584](https://github.com/mapbender/mapbender/pull/1584))

--- a/src/Mapbender/PrintBundle/Component/OdgParser.php
+++ b/src/Mapbender/PrintBundle/Component/OdgParser.php
@@ -21,7 +21,7 @@ class OdgParser
 
     const STYLE_ATTRIBUTES = [
         'fontsize' => 'fo:font-size',
-        'color' => 'fo:color',
+        'fontcolor' => 'fo:color',
         'alignment' => 'fo:text-align'
     ];
 

--- a/src/Mapbender/PrintBundle/Component/OdgParser.php
+++ b/src/Mapbender/PrintBundle/Component/OdgParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mapbender\PrintBundle\Component;
 
 use Mapbender\PrintBundle\Component\Region\FontStyle;
@@ -11,17 +12,18 @@ use Symfony\Component\Config\Definition\Exception\Exception;
  */
 class OdgParser
 {
-    /** Default orientation */
     const DEFAULT_ORIENTATION = 'landscape';
-
-    /** Default font name */
     const DEFAULT_FONT_NAME = 'Arial';
-
-    /** Default font color */
     const DEFAULT_FONT_COLOR = '#000000';
+    const DEFAULT_ALIGNMENT = 'L';
 
-    /** Default font size */
     const DEFAULT_FONT_SIZE = '10pt';
+
+    const STYLE_ATTRIBUTES = [
+        'fontsize' => 'fo:font-size',
+        'color' => 'fo:color',
+        'alignment' => 'fo:text-align'
+    ];
 
     /** Conversion factor for meters to centimeters */
     const CONVERSION_FACTOR = 10;
@@ -60,11 +62,11 @@ class OdgParser
         $odgPath = $this->getTemplateFilePath($template, 'odg');
         $xml = '';
 
-        if(!is_file($odgPath)){
+        if (!is_file($odgPath)) {
             throw new Exception("Print template '$template' doesn't exists.");
         }
         $zip = new \ZipArchive();
-        $zip->open($odgPath, 16 /** =\ZipArchive::RDONLY PHP >=7.4.3 */);
+        $zip->open($odgPath, 16/** =\ZipArchive::RDONLY PHP >=7.4.3 */);
         $index = 0;
         while ($stat = $zip->statIndex($index)) {
             if ($stat['name'] === $file) {
@@ -89,7 +91,7 @@ class OdgParser
      */
     public function getMapSize($template)
     {
-        $doc        = new \DOMDocument();
+        $doc = new \DOMDocument();
         $xmlContent = $this->readOdgFile($template, 'content.xml');
         $doc->loadXML($xmlContent);
 
@@ -97,7 +99,7 @@ class OdgParser
         $draMapNode = (new \DOMXPath($doc))->query("//draw:custom-shape[@draw:name='map']")->item(0);
 
         return json_encode(array(
-            'width'  => static::parseNumericNodeAttribute($draMapNode, 'svg:width') / static::CONVERSION_FACTOR,
+            'width' => static::parseNumericNodeAttribute($draMapNode, 'svg:width') / static::CONVERSION_FACTOR,
             'height' => static::parseNumericNodeAttribute($draMapNode, 'svg:height') / static::CONVERSION_FACTOR
         ));
     }
@@ -118,14 +120,14 @@ class OdgParser
 
         $doc = new \DOMDocument();
         $doc->loadXML($this->readOdgFile($templateName, 'styles.xml'));
-        $xPath        = new \DOMXPath($doc);
-        $node         = $xPath->query("//style:page-layout-properties");
+        $xPath = new \DOMXPath($doc);
+        $node = $xPath->query("//style:page-layout-properties");
         $templateObject = $this->parsePageGeometryIntoObject($node->item(0));
 
         $doc = new \DOMDocument();
         $doc->loadXML($this->readOdgFile($templateName, 'content.xml'));
 
-        $xPath        = new \DOMXPath($doc);
+        $xPath = new \DOMXPath($doc);
         $this->parseCustomShapes($templateObject, $xPath);
         $this->parseTextFields($templateObject, $xPath);
         return $templateObject;
@@ -150,15 +152,16 @@ class OdgParser
     protected function parseTextFields(Template $templateObject, \DOMXPath $xPath)
     {
         foreach ($xPath->query("draw:page/draw:frame", $xPath->document->getElementsByTagName('drawing')->item(0)) as $node) {
-            $name      = $node->getAttribute('draw:name');
+            $name = $node->getAttribute('draw:name');
 
             if (empty($name)) {
                 continue;
             }
             $textField = $this->parseShapeIntoRegion($node);
-            $styleNode = $this->detectStyleNode($xPath, $node);
-            $styleData = $this->parseStyleNode($styleNode);
+            $styleNodes = $this->detectStyleNodes($xPath, $node);
+            $styleData = $this->parseStyleNodes($styleNodes);
             $textField->setFontStyle(new FontStyle($styleData['font'], $styleData['fontsize'], $styleData['fontcolor']));
+            $textField->setAlignment($styleData['alignment']);
             $textField->setName($name);
             $templateObject->addTextField($textField);
         }
@@ -169,12 +172,13 @@ class OdgParser
      * Parse node attribute
      *
      * @param \DOMElement $node
-     * @param  string     $xPath
-     * @param mixed       $defaultValue
+     * @param string $xPath
+     * @param mixed $defaultValue
      * @return mixed
      */
     static function parseNodeAttribute($node, $xPath, $defaultValue = '')
     {
+        if ($node === null) return $defaultValue;
         $value = $node->getAttribute($xPath);
         return empty($value) ? $defaultValue : $value;
     }
@@ -183,8 +187,8 @@ class OdgParser
      * Parse float node attribute
      *
      * @param \DOMElement $node
-     * @param  string     $xPath
-     * @param mixed       $defaultValue
+     * @param string $xPath
+     * @param mixed $defaultValue
      * @return mixed
      */
     static function parseNumericNodeAttribute($node, $xPath, $defaultValue = 0)
@@ -207,10 +211,10 @@ class OdgParser
     public static function parseShape($customShape)
     {
         return array(
-            'width'  => static::parseNumericNodeAttribute($customShape, 'svg:width'),
+            'width' => static::parseNumericNodeAttribute($customShape, 'svg:width'),
             'height' => static::parseNumericNodeAttribute($customShape, 'svg:height'),
-            'x'      => static::parseNumericNodeAttribute($customShape, 'svg:x'),
-            'y'      => static::parseNumericNodeAttribute($customShape, 'svg:y'),
+            'x' => static::parseNumericNodeAttribute($customShape, 'svg:x'),
+            'y' => static::parseNumericNodeAttribute($customShape, 'svg:y'),
         );
     }
 
@@ -221,7 +225,7 @@ class OdgParser
     public function parseShapeIntoRegion($customShape)
     {
         $shd = static::parseShape($customShape);
-        return new TemplateRegion($shd['width'], $shd['height'], array($shd['x'],$shd['y']));
+        return new TemplateRegion($shd['width'], $shd['height'], array($shd['x'], $shd['y']));
 
     }
 
@@ -233,9 +237,9 @@ class OdgParser
     {
         return array(
             'orientation' => static::parseNodeAttribute($node, 'style:print-orientation', static::DEFAULT_ORIENTATION),
-            'pageSize'    => array(
+            'pageSize' => array(
                 'height' => static::parseNumericNodeAttribute($node, 'fo:page-height'),
-                'width'  => static::parseNumericNodeAttribute($node, 'fo:page-width'),
+                'width' => static::parseNumericNodeAttribute($node, 'fo:page-width'),
             ),
         );
     }
@@ -251,50 +255,49 @@ class OdgParser
     }
 
     /**
-     * @param \DOMXPath $xPath
-     * @param \DOMElement $parentNode
-     * @return \DOMElement|null
+     * @return \DOMElement[]
      */
-    public function detectStyleNode($xPath, $parentNode)
+    public function detectStyleNodes(\DOMXPath $xPath, \DOMElement $parentNode): array
     {
-        /** @var \DOMElement|null $textParagraph */
-        $textParagraph = $xPath->query("draw:text-box/text:p", $parentNode)->item(0);
-        /** @var \DOMElement|null $textNode */
-        $textNode      = $xPath->query("draw:text-box/text:p/text:span", $parentNode)->item(0);
-        if ($textNode) {
-            $styleAttribute = $textNode->getAttribute('text:style-name');
-        } elseif ($textParagraph) {
-            $styleAttribute = $textParagraph->getAttribute('text:style-name');
-        } else {
-            $styleAttribute = null;
+        $nodes = [];
+        foreach (["draw:text-box/text:p", "draw:text-box/text:p/text:span"] as $xPathString) {
+            /** @var ?\DOMElement|null $textParagraph */
+            $node = $xPath->query($xPathString, $parentNode)->item(0);
+            if (!$node) continue;
+
+            $styleAttribute = $node->getAttribute('text:style-name');
+            if (!$styleAttribute) continue;
+
+            foreach (['style:paragraph-properties', 'style:text-properties'] as $stylePropertyName) {
+                $selector = '//style:style[@style:name="' . $styleAttribute . '"]/' . $stylePropertyName;
+                $styleNode = $xPath->query($selector)->item(0);
+                if ($styleNode !== null) $nodes[] = $styleNode;
+            }
         }
-        if ($styleAttribute) {
-            $selector = '//style:style[@style:name="' . $styleAttribute . '"]/style:text-properties';
-            return $xPath->query($selector)->item(0);
-        } else {
-            return null;
-        }
+        return $nodes;
     }
 
     /**
      * Should extract font style properties from given $node, or default styles if node is emptyish.
      *
-     * @param \DOMElement|null $node
+     * @param \DOMElement[] $node
      * @return array
      */
-    public function parseStyleNode($node)
+    public function parseStyleNodes(array $nodes): array
     {
-        if ($node) {
-            $fontSize  = static::parseNodeAttribute($node, 'fo:font-size', static::DEFAULT_FONT_SIZE);
-            $fontColor = static::parseNodeAttribute($node, 'fo:color', static::DEFAULT_FONT_COLOR);
-        } else {
-            $fontSize = static::DEFAULT_FONT_SIZE;
-            $fontColor = static::DEFAULT_FONT_COLOR;
-        }
-        return array(
+        $data = [
             'font' => static::DEFAULT_FONT_NAME,
-            'fontsize' => $fontSize,
-            'fontcolor' => $fontColor,
-        );
+            'fontsize' => static::DEFAULT_FONT_SIZE,
+            'fontcolor' => static::DEFAULT_FONT_COLOR,
+            'alignment' => static::DEFAULT_ALIGNMENT,
+        ];
+
+        foreach ($nodes as $node) {
+            foreach (self::STYLE_ATTRIBUTES as $attribute => $xmlTag) {
+                $result = static::parseNodeAttribute($node, $xmlTag, null);
+                if ($result) $data[$attribute] = $result;
+            }
+        }
+        return $data;
     }
 }

--- a/src/Mapbender/PrintBundle/Component/PrintService.php
+++ b/src/Mapbender/PrintBundle/Component/PrintService.php
@@ -409,7 +409,7 @@ class PrintService extends ImageExportService implements PrintServiceInterface
                 $lineHeight = $region->getFontStyle()->getLineHeightMm();
                 $this->applyFontStyle($pdf, $region);
                 $pdf->SetXY($region['x'] - 1, $region['y'] + 0.25 * $lineHeight);
-                $pdf->MultiCell($region['width'], $lineHeight, utf8_decode($text), 0, 'L');
+                $pdf->MultiCell($region['width'], $lineHeight, utf8_decode($text), 0, $region->getAlignment());
             }
         }
         // reset text color to default black

--- a/src/Mapbender/PrintBundle/Component/TemplateRegion.php
+++ b/src/Mapbender/PrintBundle/Component/TemplateRegion.php
@@ -25,6 +25,8 @@ class TemplateRegion implements \ArrayAccess
     /** @var Template|null */
     protected $parentTemplate;
 
+    protected string $alignment = OdgParser::DEFAULT_ALIGNMENT;
+
     /**
      * @param float $width in mm
      * @param float $height in mm
@@ -121,6 +123,21 @@ class TemplateRegion implements \ArrayAccess
         return $this->offsets[1];
     }
 
+    public function getAlignment(): string
+    {
+        return $this->alignment;
+    }
+
+    public function setAlignment(string $alignment): void
+    {
+        $this->alignment = match (strtolower($alignment)) {
+            'l', 'left' => 'L',
+            'r', 'right' => 'R',
+            'c', 'center' => 'C',
+            default => $this->alignment
+        };
+    }
+
 
     // array-style access support
     public function offsetGet($offset): mixed
@@ -133,6 +150,7 @@ class TemplateRegion implements \ArrayAccess
             'font' => $this->style->getFontName(),
             'fontsize' => $this->style->getSize(),
             'color' => $this->style->getColor(),
+            'alignment' => $this->alignment,
             default => throw new \RuntimeException("Invalid offset " . print_r($offset, true)),
         };
     }
@@ -140,7 +158,7 @@ class TemplateRegion implements \ArrayAccess
     public function offsetExists($offset): bool
     {
         return match ($offset) {
-            'x', 'y', 'width', 'height' => true,
+            'x', 'y', 'width', 'height', 'alignment' => true,
             'font', 'fontsize', 'color' => !!$this->style,
             default => false,
         };


### PR DESCRIPTION
Previously, all generated text from print templates was left-aligned. Now, the alignment of text fields used in LibreOffice Draw is repected.

