### PR TITLE
Do not crash when passport does not exist in FailedLoginListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next bugfix release
+* Do not crash when passport does not exist in FailedLoginListener ([PR#1601](https://github.com/mapbender/mapbender/pull/1601))
+
+
 ## v4.0.0
 Breaking changes (for details on migration process see [UPGRADING.md]):
 * PHP 8.1 is now the minimum supported PHP version

--- a/src/FOM/UserBundle/EventListener/FailedLoginListener.php
+++ b/src/FOM/UserBundle/EventListener/FailedLoginListener.php
@@ -3,9 +3,11 @@
 namespace FOM\UserBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
+use FOM\UserBundle\Entity\User;
 use FOM\UserBundle\Entity\UserLogEntry;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 
 /**
@@ -31,7 +33,10 @@ class FailedLoginListener implements EventSubscriberInterface
     public function onLoginFailure(LoginFailureEvent $event): void
     {
         $em = $this->entityManager;
-        $userName = $event->getPassport()->getUser()->getUserIdentifier();
+        $passport = $event->getPassport();
+        if (!$passport) return;
+
+        $userName = $passport->getUser()?->getUserIdentifier();
         $ipAddress = $_SERVER["REMOTE_ADDR"];
         $repository = $em->getRepository(UserLogEntry::class);
         $userInfo = [

--- a/src/Mapbender/CoreBundle/Entity/Element.php
+++ b/src/Mapbender/CoreBundle/Entity/Element.php
@@ -3,6 +3,7 @@ namespace Mapbender\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping as ORM;
+use Mapbender\Component\Collections\WeightSortedCollectionMember;
 use Mapbender\Component\Enumeration\ScreenTypes;
 
 /**
@@ -13,7 +14,7 @@ use Mapbender\Component\Enumeration\ScreenTypes;
  */
 #[ORM\Entity]
 #[ORM\Table(name: 'mb_core_element')]
-class Element
+class Element implements WeightSortedCollectionMember
 {
     /**
      * @var integer


### PR DESCRIPTION
When logging in and the login could not be assigned to a user an exception occured.