### PR TITLE
Add ValidatableConfigurationInterface to validate an element's configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bugfixes:
 
 Other:
 * Extract Application Resolving Logic to separate service that can be overwritten by DI ([PR#1604](https://github.com/mapbender/mapbender/pull/1604))
+* Add ValidatableConfigurationInterface to validate an element's configuration ([PR#1607](https://github.com/mapbender/mapbender/pull/1607))
 
 
 ## v4.0.0

--- a/docs/elements/elements.md
+++ b/docs/elements/elements.md
@@ -40,6 +40,10 @@ The following methods must be overridden in the PHP class:
 - `getWidgetName(): string`: The jQueryUI widget's name (see [below](#javascript-widgets))
 - `getView(Element $element): ElementView`: The element's view, either static or a twig template (see [below](#rendering-the-view))
 
+You can also implement the class `Mapbender\CoreBundle\Component\ElementBase\ValidatableConfigurationInterface` and override the `validate` method. Validate the configuration here. The method is called in two cases:
+- when saving a form in the administration backend. The `$form` attribute will be non-null. You should create a form error in this case, e.g. `$form->get('configuration')->get('mykey')->addError(new FormError('Something went wrong'));` 
+- when accessing an application in the frontend. In this case, the `$form` argument will be null. Throw a `Mapbender\CoreBundle\Component\ElementBase\ValidationFailedException` if a validation error occurs. Caution: This message will be shown to frontend users.
+
 
 ## PHP Form type
 A form type is used to configure the element in the backend. By convention, it's placed in your bundle's `Element/Type` namespace and should extend from `Symfony\Component\Form\AbstractType`. 

--- a/src/Mapbender/CoreBundle/Component/ElementBase/ValidatableConfigurationInterface.php
+++ b/src/Mapbender/CoreBundle/Component/ElementBase/ValidatableConfigurationInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Mapbender\CoreBundle\Component\ElementBase;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+interface ValidatableConfigurationInterface
+{
+    /**
+     * Validate the configuration here. The method is called in two cases:
+     * - when saving a form in the administration backend. The `$form` attribute will be non-null.
+     *   You should create a form error in this case, e.g.
+     *   `$form->get('configuration')->get('mykey')->addError(new FormError('Something went wrong'));`
+     * - when accessing an application in the frontend. In this case, the `$form` argument will be null.
+     *   Throw a ValidationFailedException` if a validation error occurs.
+     *   Caution: This message will be shown to frontend users.
+     * @throws ValidationFailedException
+     */
+    public static function validate(array $configuration, FormInterface $form, TranslatorInterface $translator): void;
+}
+
+class ValidationFailedException extends \RuntimeException
+{
+
+}

--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -254,8 +254,10 @@ class Map extends AbstractElementService
             foreach ([0, 1] as $index) {
                 if ($extent[$index] >= $extent[$index + 2]) {
                     $msg = $translator->trans('mb.core.map.error.extent_wrong');
+                    $msg = str_replace("%dim", $index === 0 ? 'x' : 'y', $msg);
                     if ($form !== null) {
                         $form->get('configuration')->get($key)->get($index)->addError(new FormError($msg));
+                        $form->get('configuration')->get($key)->get($index + 2)->addError(new FormError(""));
                     } else {
                         throw new ValidationFailedException($msg);
                     }

--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -8,9 +8,14 @@ use Mapbender\Component\Element\ImportAwareInterface;
 use Mapbender\Component\Element\MainMapElementInterface;
 use Mapbender\Component\Element\StaticView;
 use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
+use Mapbender\CoreBundle\Component\ElementBase\ValidatableConfigurationInterface;
+use Mapbender\CoreBundle\Component\ElementBase\ValidationFailedException;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Entity\SRS;
 use Mapbender\ManagerBundle\Component\Mapper;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Map element.
@@ -18,7 +23,7 @@ use Mapbender\ManagerBundle\Component\Mapper;
  * @author Christian Wygoda
  */
 class Map extends AbstractElementService
-    implements MainMapElementInterface, ConfigMigrationInterface, ImportAwareInterface
+    implements MainMapElementInterface, ConfigMigrationInterface, ImportAwareInterface, ValidatableConfigurationInterface
 {
 
     const MINIMUM_TILE_SIZE = 128;
@@ -103,7 +108,7 @@ class Map extends AbstractElementService
     {
         $customTitles = array();
         $configuration = $element->getConfiguration();
-        $mainSrsParts  = preg_split("/\s*\|\s*/", trim($configuration["srs"]));
+        $mainSrsParts = preg_split("/\s*\|\s*/", trim($configuration["srs"]));
         $defaultSrsName = $mainSrsParts[0];
         $configuration['srs'] = $defaultSrsName;
         if (!empty($mainSrsParts[1])) {
@@ -146,11 +151,10 @@ class Map extends AbstractElementService
     {
         // Remove nulls, readd defaults
         // @todo: prevent saving invalid empty values via form constraints
-        $conf = \array_filter($element->getConfiguration(), function($v) {
+        $conf = \array_filter($element->getConfiguration(), function ($v) {
             return $v !== null;
         });
         $conf += static::getDefaultConfiguration();
-
         $conf['tileSize'] = \intval(max(self::MINIMUM_TILE_SIZE, $conf['tileSize']));
         $conf = $this->buildSrsConfigs($element) + $conf;
         return $conf;
@@ -240,5 +244,24 @@ class Map extends AbstractElementService
         $config['scales'] = array_values(array_map('intval', $config['scales']));
 
         $entity->setConfiguration($config);
+    }
+
+    public static function validate(array $configuration, ?FormInterface $form, TranslatorInterface $translator): void
+    {
+        // check that max > min for all cases
+        foreach (['extent_start', 'extent_max'] as $key) {
+            $extent = $configuration[$key];
+            foreach ([0, 1] as $index) {
+                if ($extent[$index] >= $extent[$index + 2]) {
+                    $msg = $translator->trans('mb.core.map.error.extent_wrong');
+                    if ($form !== null) {
+                        $form->get('configuration')->get($key)->get($index)->addError(new FormError($msg));
+                    } else {
+                        throw new ValidationFailedException($msg);
+                    }
+                }
+            }
+
+        }
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -197,6 +197,7 @@
             <argument type="service" id="mapbender.source.url_processor.service" />
             <argument type="service" id="router" />
             <argument type="service" id="assets._default_package" />
+            <argument type="service" id="translator" />
             <argument>%kernel.debug%</argument>
         </service>
         <service id="mapbender.source.typedirectory.service" class="%mapbender.source.typedirectory.service.class%">

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.application.js
@@ -308,6 +308,9 @@ $.extend(Mapbender, (function($) {
     function initElement(id, data) {
         var instance;
         var $node = $(document.getElementById(id));
+        if (data.errors) {
+            throw new Error('Configuration error: ' + data.errors.join('\n'));
+        }
         if (!$node.length) {
             throw new Error('Element #' + id + ' not found in DOM');
         }
@@ -392,7 +395,7 @@ $.extend(Mapbender, (function($) {
                 // Log original stack trace (clickable in Chrome, unfortunately not in Firefox) separately
                 console.log(e.stack);
             }
-            $.notify('Your element with id ' + id + ' (widget ' + elementData.init + ') failed to initialize properly.', 'error');
+            $.notify('Your element with id ' + id + ' (widget ' + elementData.init + ') failed to initialize properly: ' + e.message, 'error');
         }
     }
 

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -367,6 +367,8 @@ mb:
         scales: 'Maßstäbe (komma-separiert)'
         othersrs: 'Andere SRS'
         srs: SRS
+      error:
+        extent_wrong: 'Der Mindestwert muss kleiner sein als der Maximalwert.'
     scalebar:
       class:
         title: Maß­stabs­leiste

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -368,7 +368,7 @@ mb:
         othersrs: 'Andere SRS'
         srs: SRS
       error:
-        extent_wrong: 'Der Mindestwert muss kleiner sein als der Maximalwert.'
+        extent_wrong: 'min %dim muss kleiner sein als max %dim.'
     scalebar:
       class:
         title: Maß­stabs­leiste

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -368,7 +368,7 @@ mb:
         othersrs: 'Other SRS'
         srs: SRS
       error:
-        extent_wrong: 'The minimum value must be smaller than the maximum value'
+        extent_wrong: 'min %dim must be smaller than max %dim'
     scalebar:
       class:
         title: 'Scale bar'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -367,6 +367,8 @@ mb:
         scales: 'Scales (comma-separated)'
         othersrs: 'Other SRS'
         srs: SRS
+      error:
+        extent_wrong: 'The minimum value must be smaller than the maximum value'
     scalebar:
       class:
         title: 'Scale bar'

--- a/src/Mapbender/ManagerBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/ManagerBundle/Resources/config/controllers.xml
@@ -53,9 +53,11 @@
                  public="true">
             <argument type="service" id="mapbender.element_inventory.service" />
             <argument type="service" id="mapbender.element_entity_factory" />
+            <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="mapbender.manager.element_form_factory.service" />
             <argument type="service" id="fom.security.permission_manager" />
             <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
+            <argument type="service" id="translator" />
             <tag name="container.service_subscriber" />
             <call method="setContainer">
                 <argument type="service" id="Psr\Container\ContainerInterface" />


### PR DESCRIPTION
An interface `Mapbender\CoreBundle\Component\ElementBase\ValidatableConfigurationInterface` with the method `validate` was added. This enables an element to validate its configuration, e.g. to check that the minimum extent is smaller than the maximum extent in the map element. 

The method is called in two cases:
- when saving a form in the administration backend. The `$form` attribute will be non-null. You should create a form error in this case, e.g. `$form->get('configuration')->get('mykey')->addError(new FormError('Something went wrong'));` 

Example of the error display:

![grafik](https://github.com/user-attachments/assets/2e9de225-4898-44f2-bf51-f9ffb09972ef)



- when accessing an application in the frontend. In this case, the `$form` argument will be null. This also allows YAML-defined applications to be checked. Throw a `Mapbender\CoreBundle\Component\ElementBase\ValidationFailedException` if a validation error occurs. Caution: This message will be shown to frontend users.

Example of the error display:

![grafik](https://github.com/user-attachments/assets/3a8b4fb6-af70-4620-b75c-de4828dca7b8)
