### PR TITLE
[Map] Transformation failed in some cases when EPSG:3847 is transformed into UTM coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 * [Security] Fix `published: false` was ignored in YAML applications ([PR#1614](https://github.com/mapbender/mapbender/pull/1614))
 * [Manager] Fix empty region placeholder in layout editor ([#1606](https://github.com/mapbender/mapbender/issues/1606), [PR#1611](https://github.com/mapbender/mapbender/pull/1611))
 * [DataUpload] Fix data type recognition in some browsers / operating systems ([#1603](https://github.com/mapbender/mapbender/issues/1603), [PR#1610](https://github.com/mapbender/mapbender/pull/1610))
+* [Map] Transformation failed in some cases when EPSG:3847 is transformed into UTM coordinates ([#1602](https://github.com/mapbender/mapbender/issues/1602), [PR#1613](https://github.com/mapbender/mapbender/pull/1613))
 * Never use a disabled map element ([#1608](https://github.com/mapbender/mapbender/issues/1608), [PR#1609](https://github.com/mapbender/mapbender/pull/1609))
 
 Other:

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapEngineOl4.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapEngineOl4.js
@@ -194,6 +194,11 @@ window.Mapbender.MapEngineOl4 = (function() {
             var to = this._getProj(toProj, true);
             var transformFn = ol.proj.getTransform(from, to);
             var transformed = ol.extent.applyTransform(bounds, transformFn);
+            // transformation fails in some cases when EPSG:3847 is transformed into UTM coordinates.
+            // Workaround: If max x / min x used to be (close to) -1 and is now (close to) 1, change the sign of min x
+            if (Math.abs(bounds[0] / bounds[2] + 1) < 0.000001 && Math.abs(transformed[0] / transformed[2] - 1) < 0.0000001) {
+                transformed[0] *= -1;
+            }
             return this.boundsFromArray(transformed);
         },
         removeLayers: function(olMap, olLayers) {


### PR DESCRIPTION
The problem occurred in the mapbender_user demo. The map element was set to EPSG:3857 and worldwide maximum bounds (`[ -20037508.34278924, -20037508.34278924, 20037508.34278924, 20037508.34278924 ]`). OpenLayers transformed that into EPSG:25832 (UTM32) with `[ 586331.6298902088, -10543719.766426057, 586331.6298902095, 10543719.766426057 ]`, which is technically not wrong (-180° W is the same point on earth as 180° E), but still messed up the maximum extent calculation.

The workaround is now to check if max x / min x used to be -1 and is 1 after the transformation, in that case the sign is changed.


fixes #1602 