### PR TITLE
[Security] Fix `published: false` was ignored in YAML applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next bugfix release
 Bugfixes:
 * Do not crash when passport does not exist in FailedLoginListener ([PR#1601](https://github.com/mapbender/mapbender/pull/1601))
+* [Security] Fix `published: false` was ignored in YAML applications ([PR#1614](https://github.com/mapbender/mapbender/pull/1614))
 
 Other:
 * Extract Application Resolving Logic to separate service that can be overwritten by DI ([PR#1604](https://github.com/mapbender/mapbender/pull/1604))

--- a/src/FOM/UserBundle/Security/Permission/YamlApplicationVoter.php
+++ b/src/FOM/UserBundle/Security/Permission/YamlApplicationVoter.php
@@ -13,7 +13,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * Yaml application's security is also stated in the yaml file, therefore the
  * regular PermissionManager can't be used.
  *
- * The following yaml keys are relevant for it's security:
+ * The following yaml keys are relevant for its security:
  * `published: true`: only used when `roles` is not present. It grants view rights to the public
  * `roles`: Can contain the following children:
  * - public: grants access to the public

--- a/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
+++ b/src/Mapbender/CoreBundle/Component/ApplicationYAMLMapper.php
@@ -146,7 +146,7 @@ class ApplicationYAMLMapper
         }
 
         $application->setYamlRoles(array_key_exists('roles', $definition) ? $definition['roles'] : []);
-        if (isset($definition['published']) && !$application->getYamlRoles()) {
+        if (isset($definition['published']) && $definition['published'] && !$application->getYamlRoles()) {
             $application->setYamlRoles([YamlApplicationVoter::ROLE_PUBLIC]);
         }
 

--- a/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser130.php
+++ b/src/Mapbender/WmsBundle/Component/WmsCapabilitiesParser130.php
@@ -21,15 +21,15 @@ class WmsCapabilitiesParser130 extends WmsCapabilitiesParser
     protected function parseService(WmsSource $source, \DOMElement $serviceEl)
     {
         parent::parseService($source, $serviceEl);
-        $layerLimit = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'LayerLimit')));
+        $layerLimit = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'LayerLimit') ?? ''));
         if ($layerLimit > 0) {
             $source->setLayerLimit($layerLimit);
         }
-        $maxWidth = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'MaxWidth')));
+        $maxWidth = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'MaxWidth') ?? ''));
         if ($maxWidth > 0) {
             $source->setMaxWidth($maxWidth);
         }
-        $maxHeight = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'MaxHeight')));
+        $maxHeight = \intval(\trim($this->getFirstChildNodeText($serviceEl, 'MaxHeight') ?? ''));
         if ($maxHeight > 0) {
             $source->setMaxHeight($maxHeight);
         }
@@ -49,8 +49,8 @@ class WmsCapabilitiesParser130 extends WmsCapabilitiesParser
         foreach ($this->getChildNodesByTagName($layerEl, 'CRS') as $crsEl) {
             $layer->addSrs(\trim($crsEl->textContent));
         }
-        $minScaleText = \trim($this->getFirstChildNodeText($layerEl, 'MinScaleDenominator'));
-        $maxScaleText = \trim($this->getFirstChildNodeText($layerEl, 'MaxScaleDenominator'));
+        $minScaleText = \trim($this->getFirstChildNodeText($layerEl, 'MinScaleDenominator') ?? '');
+        $maxScaleText = \trim($this->getFirstChildNodeText($layerEl, 'MaxScaleDenominator') ?? '');
 
         if (\strlen($minScaleText) || \strlen($maxScaleText)) {
             $min = \strlen($minScaleText) ? $minScaleText : null;

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -116,8 +116,6 @@ class WmsInstanceLayer extends SourceInstanceItem
             $this->maxScale = null;
         }
         if (!$this->sublayer->count() && ($this->toggle !== null || $this->allowtoggle !== null)) {
-            /** @todo: write a migration / automatic bootstrap process that fixes bad values permanently */
-            @trigger_error("WARNING: resetting invalid toggle / allowtoggle state on " . get_class($this) . " #{$this->id}", E_USER_DEPRECATED);
             $this->setToggle(null);
             $this->setAllowtoggle(null);
         }


### PR DESCRIPTION
A YAML application was only hidden from public view if the `published` key was not present at all, `published: false` was interpreted like `published: true`. This PR fixes this behaviour.