### PR TITLE
Fix compatibility with OracleDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## next bugfix release
+:warning: requires schema update: `bin/console doctrine:schema:update --complete --force`
+
 Bugfixes:
 * Fix compatibility with OracleDB ([PR#1619](https://github.com/mapbender/mapbender/pull/1619))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next bugfix release
+Bugfixes:
+* Fix compatibility with OracleDB ([PR#1619](https://github.com/mapbender/mapbender/pull/1619))
+
 ## v4.0.0
 Breaking changes (for details on migration process see [UPGRADING.md]):
 * PHP 8.1 is now the minimum supported PHP version

--- a/src/FOM/UserBundle/Entity/Permission.php
+++ b/src/FOM/UserBundle/Entity/Permission.php
@@ -84,7 +84,7 @@ class Permission implements SubjectInterface
      * Can store an attribute for custom resource domains. When using this, make sure to implement a sensible
      * strategy to delete permission entries for deleted attributes
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(name: "resource_ref", type: 'string', nullable: true)]
     protected ?string $resource = null;
 
     /** Stores the action for the given resource domain, like "view" or "edit"  */


### PR DESCRIPTION
Rename field fom_permission.resource to fom.permission.resource-ref to prevent oracledb reserved word issues