### PR TITLE
[Mobile Template] Allow scrolling layer tree on the left edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bugfixes:
 * [Map] Transformation failed in some cases when EPSG:3847 is transformed into UTM coordinates ([#1602](https://github.com/mapbender/mapbender/issues/1602), [PR#1613](https://github.com/mapbender/mapbender/pull/1613))
 * Never use a disabled map element ([#1608](https://github.com/mapbender/mapbender/issues/1608), [PR#1609](https://github.com/mapbender/mapbender/pull/1609))
 * Fix compatibility with OracleDB ([PR#1619](https://github.com/mapbender/mapbender/pull/1619))
+* [Mobile Template] Allow scrolling layer tree on the left edge ([#1617](https://github.com/mapbender/mapbender/issues/1617), [PR#1620](https://github.com/mapbender/mapbender/pull/1620))
 
 Other:
 * Extract Application Resolving Logic to separate service that can be overwritten by DI ([PR#1604](https://github.com/mapbender/mapbender/pull/1604))

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -161,6 +161,7 @@
             $("ul.layers", this.element).each(function () {
                 $(this).sortable({
                     axis: 'y',
+                    handle: '.leaveContainer',
                     items: "> li",
                     distance: 6,
                     cursor: "move",

--- a/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
+++ b/src/Mapbender/MobileBundle/Resources/public/sass/theme/mobile.scss
@@ -33,7 +33,6 @@ $toolBarBorderColor: rgba($ciColor, 0.6) !default;
   font-size: 153%;
   background-color: #fff;
   height: 100%;
-  padding: $space $space 0 $space;
   z-index: 3;
   .panel-content {
     display: flex;
@@ -58,6 +57,11 @@ $toolBarBorderColor: rgba($ciColor, 0.6) !default;
   flex: 1;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  padding: $space $space 0 $space;
+}
+
+.mobilePane .contentTitle {
+    margin: $space $space 0 $space;
 }
 
 body.mobile-template {
@@ -65,6 +69,7 @@ body.mobile-template {
     // Pad out rows to not look weird against potential even / odd background coloring
     padding-left: 0.5em;
     padding-right: 0.5em;
+    max-width: calc(100vw - 20px - 1em);
   }
 }
 


### PR DESCRIPTION
refs #1617

Solution: Replaced margin on the left hand side of the layer tree by padding. On the left hand side (20px wide), scrolling is now possible while the rest of the row still allows for reordering layers.