### PR TITLE
Move asset overriding to its own service to avoid request stack problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bugfixes:
 * Fix compatibility with OracleDB ([PR#1619](https://github.com/mapbender/mapbender/pull/1619))
 * [Mobile Template] Allow scrolling layer tree on the left edge ([#1617](https://github.com/mapbender/mapbender/issues/1617), [PR#1620](https://github.com/mapbender/mapbender/pull/1620))
 * [SearchRouter] Upper case column names did not work in SearchRouter ([PR#1623](https://github.com/mapbender/mapbender/pull/1623))
+* Fix base path when using AssetOverriding (check PR text if you used asset overriding before) ([#1618](https://github.com/mapbender/mapbender/issues/1618), [PR#1622](https://github.com/mapbender/mapbender/pull/1622))
 
 Other:
 * Extract Application Resolving Logic to separate service that can be overwritten by DI ([PR#1604](https://github.com/mapbender/mapbender/pull/1604))

--- a/docs/gitarchive/gitarchive.md
+++ b/docs/gitarchive/gitarchive.md
@@ -45,10 +45,10 @@ Translations keys normalized for bundle Mapbender\CoreBundle. No keys were missi
 
 #### Overriding JavaScript and CSS/Sass Resources
 
-##### Option 1: use the ApplicationAssetService class
+##### Option 1: use the ApplicationAssetOverrides class
 
-- Inject the Service `mapbender.application_asset.service` into your class, e.g. within your bundle file's boot method using `$this->container->get('mapbender.application_asset.service')` or using constructor injection in any PHP file: `<argument type="service" id="mapbender.application_asset.service" />`. If using the latter approach, make sure you use a file that will be called, e.g. the Template
-- Call `ApplicationAssetService::registerAssetOverride` or `ApplicationAssetService::registerAssetOverrides` to mark assets for replacement. For example:
+- Inject the Service `mapbender.application_asset.overrides.service` into your class, e.g. within your bundle file's boot method using `$this->container->get('mapbender.application_asset.overrides.service')` or using constructor injection in any PHP file: `<argument type="service" id="mapbender.application_asset.overrides.service" />`. If using the latter approach, make sure you use a file that will be called, e.g. the Template
+- Call `ApplicationAssetOverrides::registerAssetOverride` or `ApplicationAssetOverrides::registerAssetOverrides` to mark assets for replacement. For example:
 
 ```php
 class MyBundle extends Bundle
@@ -58,7 +58,7 @@ class MyBundle extends Bundle
     public function boot(): void
     {
         parent::boot();
-        $assetService = $this->container->get('mapbender.application_asset.service');
+        $assetService = $this->container->get('mapbender.application_asset.overrides.service');
         $assetService->registerAssetOverride('@MapbenderCoreBundle/Resources/public/sass/element/button.scss', '@MyBundle/Resources/public/element/my_button.scss');
 
         $assetService->registerAssetOverrides([

--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetOverrides.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetOverrides.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Mapbender\CoreBundle\Asset;
+
+/**
+ * Allows to override specific resources
+ *
+ *
+ * Example (add in your bundle class):
+ *
+ * public function boot(): void
+    {
+        parent::boot();
+        $assetService = $this->container->get('mapbender.application_asset.overrides.service');
+        $assetService->registerAssetOverride(
+            '@MapbenderCoreBundle/Resources/public/sass/element/layertree.scss',
+            '@MyBundle/Resources/public/element/custom_layertree.scss'
+        );
+    }
+ */
+class ApplicationAssetOverrides
+{
+    protected array $assetOverrideMap = [];
+
+    public function __construct(?array $assetOverrides = null)
+    {
+        if (is_array($assetOverrides)) {
+            $this->registerAssetOverrides($assetOverrides);
+        }
+    }
+
+    /**
+     * after calling this function, everytime $originalRef is requested, $newRef will be included instead
+     * Can be used to override internal templates, javascript or css files
+     * @see self::registerAssetOverrides() for registering multiple files at a time
+     */
+    public function registerAssetOverride(string $originalRef, string $newRef): void
+    {
+        $this->assetOverrideMap[$originalRef] = $newRef;
+    }
+
+    /**
+     * after calling this function, everytime an asset that corresponds to a key in the overrideMap is requested,
+     * it is replaced by the asset of the corresponding value
+     * Can be used to override internal templates, javascript or css files
+     */
+    public function registerAssetOverrides(array $overrideMap): void
+    {
+        $this->assetOverrideMap = array_merge($this->assetOverrideMap, $overrideMap);
+    }
+
+    public function getMap(): array
+    {
+        return $this->assetOverrideMap;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -255,6 +255,12 @@
             <argument type="service" id="twig" />
             <argument>%fallback_locale%</argument>
         </service>
+        <service id="mapbender.application_asset.overrides.service"
+                 class="Mapbender\CoreBundle\Asset\ApplicationAssetOverrides"
+                 lazy="true"
+                 public="true">
+            <argument>%mapbender.asset_overrides%</argument>
+        </service>
         <service id="mapbender.application_asset.service"
                  class="%mapbender.application_asset.service.class%"
                  lazy="true"
@@ -266,9 +272,9 @@
             <argument type="service" id="mapbender.element_inventory.service" />
             <argument type="service" id="mapbender.source.typedirectory.service" />
             <argument type="service" id="mapbender.application_template_registry" />
+            <argument type="service" id="mapbender.application_asset.overrides.service" />
             <argument>%kernel.debug%</argument>
             <argument>%mapbender.strict.asset.bundle_scopes%</argument>
-            <argument>%mapbender.asset_overrides%</argument>
         </service>
         <service id="mapbender.xmlvalidator.service" class="Mapbender\CoreBundle\Component\XmlValidatorService">
             <argument type="service" id="mapbender.http_transport.service" />


### PR DESCRIPTION
Problem was, that the request stack is not yet initialised when booting the bundle. However, through many interdependencies, the PathPackage was required in the ApplicationAssetService initialising the basePath to empty string.

Solution: Do not inject the ApplicationAssetService service when registrering overrides in the bundle, but a standalone new service ApplicationAssetOverrides, that does not have any dependencies and therefore also does not trigger the PathPackage to be initialised.

:warning: Any application already using asset overriding needs to be changed:

When injecting the service: `mapbender.application_asset.service` -> `mapbender.application_asset.overrides.service`

When using the class directly: `Mapbender\CoreBundle\Asset\ApplicationAssetService` -> `Mapbender\CoreBundle\Asset\ApplicationAssetOverrides`


refs #1618 