### PR TITLE
Fix ajax requests fail in YAML applications (regression introduced in 4.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next bugfix release
+Bugfixes:
+* Fix ajax requests fail in YAML applications (regression introduced in 4.0.1) ([#1628](https://github.com/mapbender/mapbender/issues/1628), [PR#1634](https://github.com/mapbender/mapbender/pull/1634))
+
+
 ## v4.0.1
 :warning: requires schema update: `bin/console doctrine:schema:update --complete --force`
 

--- a/src/Mapbender/CoreBundle/Controller/ElementController.php
+++ b/src/Mapbender/CoreBundle/Controller/ElementController.php
@@ -39,7 +39,7 @@ class ElementController extends AbstractController
     public function element(Request $request, $slug, $id, string $action)
     {
         $application = $this->applicationResolver->getApplicationEntity($slug);
-        $id = intval($id);
+        $id = is_numeric($id) ? intval($id) : $id;
         $element = $application->getElements()->matching(Criteria::create()->where(Criteria::expr()->eq('id', $id)))->first();
         if (!$element) {
             throw new NotFoundHttpException();


### PR DESCRIPTION
closes #1628 