### PR TITLE
Frontend source refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## next release
+Features:
+* Allow selecting WMS layer styles via the layer tree contextmenu ([PR#1636](https://github.com/mapbender/mapbender/pull/1636))
 
 Other:
 * Sources now use native ES6 classes instead of prototype pseudo-classes. Easier API for custom layer tree menu items and legends. ([PR#1635](https://github.com/mapbender/mapbender/pull/1635))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next release
+
+Other:
+* Sources now use native ES6 classes instead of prototype pseudo-classes. Easier API for custom layer tree menu items and legends. ([PR#1635](https://github.com/mapbender/mapbender/pull/1635))
+
+
 ## v4.0.2
 Bugfix:
 * Fix ajax requests fail in YAML applications (regression introduced in 4.0.1) ([#1628](https://github.com/mapbender/mapbender/issues/1628), [PR#1634](https://github.com/mapbender/mapbender/pull/1634))

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,12 +2,29 @@
 
 ## next release
 
-### The following methods are removed
+### Sources refactored
+Sources now use native ES6 classes instead of prototype pseudo-classes. This means, for custom sources, you
+must also use this syntax now. Refer to the [new docs entry](sources/sources.md) for details.
+
+The following has changed apart from the class syntax:
+- several methods that were already present in the WMSSource have been moved to the abstract Mapbender.Source
+- new event `mbmapsourcelayersreordered` that fires when the layer order within a source is moved. In earlier versions, `mbmapsourcemoved` was called then.
+- `Mapbender.Source.wmsloader` renamed to `Mapbender.Source.isDynamicSource`
+
+A layer's legend can now also be a style definition instead of a plain url. If you handle legend urls, adapt accordingly (see [documentation]((sources/sources.md)) for new syntax):
+- In mapbender.element.legend.js:  New methods `createLegendForLayer`, `createLegendForStyle`
+- In LegendHandler.php: New method `prepareStyleBlock`
+- New parameter `mapbender.print.canvas_legend.class` defaulting to `Mapbender\PrintBundle\Component\CanvasLegend` for the rendering class for custom styled legends
+
+The layer tree menu option handling has been changed:
+- New method `Mapbender.SourceLayer.getSupportedMenuOptions` that should be overridden by sources, was handled in the LayerTree element until now
+- Menu item markup now require the `data-menu-action` attribute
+- New method in the layertree element for easier overriding: `_initMenuAction`
+
+The following methods are removed:
 - `Mapbender.Geo.SourceHandler.isLayerInScale`: Use `layer.isInScale`
 - `Mapbender.Geo.SourceHandler.isLayerWithinBounds`: Use `layer.intersectsExtent`. The method requires an srsname which can be obtained using `Mapbender.Model.getCurrentProjectionCode()`
-
-### The following was added
-- new event `mbmapsourcelayersreordered` that fires when the layer order within a source is moved. In earlier versions, `mbmapsourcemoved` was called then. 
+- `Mapbender.Source.initializeLayers()`: Use `Mapbender.Source.createNativeLayers()`
 
 ## v4.0.0
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,5 +1,14 @@
 # Upgrading Guide
 
+## next release
+
+### The following methods are removed
+- `Mapbender.Geo.SourceHandler.isLayerInScale`: Use `layer.isInScale`
+- `Mapbender.Geo.SourceHandler.isLayerWithinBounds`: Use `layer.intersectsExtent`. The method requires an srsname which can be obtained using `Mapbender.Model.getCurrentProjectionCode()`
+
+### The following was added
+- new event `mbmapsourcelayersreordered` that fires when the layer order within a source is moved. In earlier versions, `mbmapsourcemoved` was called then. 
+
 ## v4.0.0
 
 ### Upgrade database

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -56,20 +56,20 @@ createNativeLayers(srsName, mapOptions) {
 
 - `updateEngine()`: this method is called when the content should be updated, e.g. because a layer's visibility has
   been toggled, a new layer has been added, the layer order has changed etc.    
-  Use `this.getNativeLayer()` to access the OL native layer and perform operations on it (refer to the open layers docs)
-  Note that new layers are hidden by default, so make sure to call `Mapbender.mapEngine.setLayerVisibility(olLayer, true)`
+  Use `this.getNativeLayer()` to access the OL native layer and perform operations on it (refer to the open layers docs)  
+  Note that new layers are hidden by default, so make sure to call `Mapbender.mapEngine.setLayerVisibility(olLayer, true)`  
   Also, you need to check the individual layer's `layer.state.visibility` property, this will be updated when a layer
   is toggled in the layer tree.
 
-- `setLayerOrder(newLayerIdOrder)`: The layers within this source has been reordered in the layer tree. The argument
-  list all the ids in the new order. The default implementation might or might not work for your usecase.
+- `setLayerOrder(newLayerIdOrder)`: The layers within this source have been reordered in the layer tree. The argument
+  list all the ids in the new order. There is a default implementation available that might work for your use case already.
 
 
 Also, you can override the following methods:
 
 - `getSettings()`, `applySettings(settings)`, `applySettingsDiff(settings)`, `diffSettings(from, to)`: 
-  modifies runtime settings you might need for your source. Per default, this is only opacity.
-- `getConfiguredSettings()`: returns the initial settings during initialisation
+  modifies runtime settings you might need for your source. By default, this is only opacity.
+- `getConfiguredSettings()`: returns the initial settings set during initialisation
 - `getFeatureInfoLayers()`: returns all layers that support feature info
 - `checkRecreateOnSrsSwitch(oldProj, newProj)`: indicates whether this source should be recreated when a srs change occurs
 - `getPrintConfigs(bounds, scale, srsName)`: Returns information that is passed to the printing service when printing or exporting a map
@@ -88,7 +88,7 @@ For a SourceLayer no methods are required to be overridden. The following overri
 - `hasBounds()`: is this layer restricted to spatial bbox?
 - `getBounds(projCode, inheritFromParent)`: if `hasBounds()` returns true, calculate and return the bbox in the given SRS
 - `isInScale(scale)`: Should the layer be displayed at this scale level?
-- `intersectsExtent(extent, srsName)`: Does the layer has contents in this extent?
+- `intersectsExtent(extent, srsName)`: Does the layer have features in this extent?
 - `getSupportedMenuOptions()`: Returns a list of menu options supported by this layer. See [below](#custom-layer-tree-menu-item) for details
 - `getLegend()`: Returns the legend for this layer. The legend can be either an external url to an image (e.g. for WMS services) 
    or a style definition that is rendered on a canvas. See [below](#legend-entries-for-custom-sources) for details
@@ -98,7 +98,7 @@ The following methods are also available to be used which you probably don't nee
 - `getSelected()` / `setSelected(state)`: Gets/sets the visibility of this layer. Caution: This does not mean it's visible on the map, if parent layers are not selected.
 - `getActive()`: Checks if the layer is actually visible on the map (i.e. whether this layer and all parents `getSelected` return true)
 - `remove()`: Deletes this layer
-- `addChild(newsourceLayer)`: Adds a new sublayer
+- `addChild(newSourceLayer)`: Adds a new sublayer
 - `getId()` / `getName()`
 
 ## Registering your new source

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -1,0 +1,321 @@
+# Sources
+
+A data source describes the content that is displayed on a map. The core mapbender supports the following data sources:
+- Web Map Service (WMS)
+- Web Map Tile Service (WMTS)
+- Tile Map Service (TMS)
+- Web Map Service Time (WMS-T)
+
+More data sources, among them OGC API Features, are in the pipeline for a future release.
+
+## Custom data sources 
+This tutorial describes how to create a new source purely on the frontend side. This can be useful if 
+you want to display data e.g. from a GeoJSON file or directly from a PostGIS database. 
+
+If you want to create a data source that can also be configured in the backoffice, have a look at the WmsBundle or 
+WmtsBundle. Note that a new configurable data source is a complex addition to Mapbender that requires deep knowledge of
+the mapbender core.
+
+Creating a new data source in the frontend is a lot simpler, but might be overkill already. If you just want to display
+data, you can create a [custom element](../elements/elements.md) and use the method `Mapbender.vectorLayerPool.getElementLayer(this, 0)`
+to obtain a layer you can display features on.
+
+If you want your new source to appear in the layer tree in a hierarchical way where the layers should be sortable, toggleable
+and integrated into the legend, creating a custom data source is the right choice for the task. 
+
+## Extending from `Mapbender.Source` and `Mapbender.SourceLayer`
+Both `Source` and `SourceLayer` are JavaScript native classes that you can extend to create your own custom source:
+
+```js
+class MySource extends Mapbender.Source {
+    //...
+}
+```
+
+The `Source` represents the data source itself and is responsible for the data rendering and managing the layers.  
+Within a `Source`, there can be multiple `SourceLayer`s. Each SourceLayer gets an individual entry in the LayerTree and 
+can be toggled individually. For example, in a WMS service within one url there can be multiple layers.
+
+### `Mapbender.Source`
+When extending from `Mapbender.Source` you need to implement the following methods:
+
+- `createNativeLayers(srsName, mapOptions)`: Eventually your data will be rendered on an [OpenLayers map](https://openlayers.org/).
+  Create and return the native layers you need here. For example, for a single vector layer:
+
+```js
+createNativeLayers(srsName, mapOptions) {
+    this.nativeLayers = [new ol.layer.Vector({
+        source: new ol.source.Vector()
+    })];
+    return this.nativeLayers;
+}
+```
+
+- `getSelected()`: Is the source selected in the layer tree. In most cases, 
+  you can delegate this to the root layer (`return this.getRootLayer().getSelected()`)
+
+- `updateEngine()`: this method is called when the content should be updated, e.g. because a layer's visibility has
+  been toggled, a new layer has been added, the layer order has changed etc.    
+  Use `this.getNativeLayer()` to access the OL native layer and perform operations on it (refer to the open layers docs)
+  Note that new layers are hidden by default, so make sure to call `Mapbender.mapEngine.setLayerVisibility(olLayer, true)`
+  Also, you need to check the individual layer's `layer.state.visibility` property, this will be updated when a layer
+  is toggled in the layer tree.
+
+- `setLayerOrder(newLayerIdOrder)`: The layers within this source has been reordered in the layer tree. The argument
+  list all the ids in the new order. The default implementation might or might not work for your usecase.
+
+
+Also, you can override the following methods:
+
+- `getSettings()`, `applySettings(settings)`, `applySettingsDiff(settings)`, `diffSettings(from, to)`: 
+  modifies runtime settings you might need for your source. Per default, this is only opacity.
+- `getConfiguredSettings()`: returns the initial settings during initialisation
+- `getFeatureInfoLayers()`: returns all layers that support feature info
+- `checkRecreateOnSrsSwitch(oldProj, newProj)`: indicates whether this source should be recreated when a srs change occurs
+- `getPrintConfigs(bounds, scale, srsName)`: Returns information that is passed to the printing service when printing or exporting a map
+
+The following methods are also available to be used which you probably don't need to override:
+
+- `getLayerById(id)`: Gets the Mapbender.SourceLayer with the given id
+- `getRootLayer()`: Every source should have exactly one root layer which is returned by this method
+- `getNativeLayer(index)`: Gets the native layer with the specified index (or the first one if index is undefined)
+- `getActive()`: Is the source and all its parents selected, e.g. is it visible
+
+### `Mapbender.SourceLayer`
+
+For a SourceLayer no methods are required to be overridden. The following overrides might be useful:
+
+- `hasBounds()`: is this layer restricted to spatial bbox?
+- `getBounds(projCode, inheritFromParent)`: if `hasBounds()` returns true, calculate and return the bbox in the given SRS
+- `isInScale(scale)`: Should the layer be displayed at this scale level?
+- `intersectsExtent(extent, srsName)`: Does the layer has contents in this extent?
+- `getSupportedMenuOptions()`: Returns a list of menu options supported by this layer. See [below](#custom-layer-tree-menu-item) for details
+- `getLegend()`: Returns the legend for this layer. The legend can be either an external url to an image (e.g. for WMS services) 
+   or a style definition that is rendered on a canvas. See [below](#legend-entries-for-custom-sources) for details
+
+The following methods are also available to be used which you probably don't need to override:
+
+- `getSelected()` / `setSelected(state)`: Gets/sets the visibility of this layer. Caution: This does not mean it's visible on the map, if parent layers are not selected.
+- `getActive()`: Checks if the layer is actually visible on the map (i.e. whether this layer and all parents `getSelected` return true)
+- `remove()`: Deletes this layer
+- `addChild(newsourceLayer)`: Adds a new sublayer
+- `getId()` / `getName()`
+
+## Registering your new source
+
+In order for the source factory to find your new source and layer classes, you need to register them in the type map:
+
+```js
+Mapbender.SourceLayer.typeMap['my-identifier'] = MySourceLayer;
+Mapbender.Source.typeMap['my-identifier'] = MySource;
+```
+
+## Instantiating a new source
+After defining your new source, you need to instantiate it somewhere, e.g. in a custom element.
+
+This works with the following code:
+
+```js
+const source = Mapbender.Source.factory(sourceDef);
+Mapbender.model.addSource(source);
+
+// shortcut
+const source2 = Mapbender.model.addSourceFromConfig(sourceDef);
+```
+
+The sourceDef needs to be an JS object with the following properties:
+```js
+const sourceDef = {
+    type: "my-identifier", // should match the Source identifier from section 'Registering your new source'
+    id: "some-unique-source-id",
+    configuration: {
+        type: "search", // should match the SourceLayer identifier from section 'Registering your new source'
+        children: [{ // source should have exactly one child: the root layer
+            options: {
+                id: "some-unique-root-layer-id",
+                title: "Root Layer title for the layer tree",
+                opacity: 1.0, // only required for root layer
+            },
+            children: [subLayer1, subLayer2],
+        }]
+    }
+}
+```
+
+Like the root layer, the sublayers need to have an `options` property where id and title are required (add as many more
+properties as you need, you can access them in your `updateEngine` method) and have an optional `children` array for
+deeper hierarchies.
+
+To add layers to an existing custom source later, use the following code:
+
+```js
+const rootLayer = mySourceLayer.getRootLayer();
+const newLayerSource = Mapbender.SourceLayer.factory(newLayerConfig, mySourceLayer, rootLayer)
+rootLayer.addChild(newLayerSource);
+```
+
+
+## Legend entries for custom sources
+If your source provides a legend, override the method `getLegend` in your SourceLayer. It will be rendered
+both on in the legend element and in pdf exports if legends are enabled there.
+
+If you want to refer to an external image url, return the following object:
+
+```js
+{
+    type: 'url',
+    url: 'https.//...',
+}
+```
+
+You can also provide a style definition. It looks like this:
+
+```js
+{
+    type: 'style',
+    title: 'Heading for the legend graphic',
+    layers: [
+        {
+            title: 'Sublayer 1',
+            style: styleDefinitionSubLayer1
+        },
+        {
+            title: 'Sublayer 2',
+            style: styleDefinitionSubLayer2
+        }
+    ]
+}
+```
+
+The style definition can contain the following all optional properties:
+
+- fillColor
+- fillOpacity (0-1).
+- strokeColor
+- strokeOpacity (0-1)
+- strokeWidth (in pixels)
+- fontFamily
+- fontColor
+- fontWeight
+- labelOutlineWidth (in pixels)
+- labelOutlineColor
+
+
+For both urls and style definitions, there is the additional property `topLevel`. Set this to true, if you manage
+your legend on the root layer level.
+
+## Custom layer tree menu item
+The core mapbender supports the following menu options in the layer tree:
+
+- **layerremove**: Deletes this layer
+- **metadata**: Opens metadata in a new window. options.medataUrl should be defined
+- **opacity**: Opacity slider between 0 and 1
+- **dimension**: selection slider for dimensions like e.g. time
+- **zoomtolayer**: Changes the map's view to fit the layer
+
+If you want to add another layer tree menu item, perform the following steps:
+
+Add a new element extending the core LayerTree:
+
+```php
+<?php
+
+use Mapbender\CoreBundle\Entity\Element;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Mapbender\CoreBundle\Element\Layertree as CoreLayerTree;
+
+#[AutoconfigureTag('mapbender.element', ['replaces' => CoreLayerTree::class])]
+class LayerTree extends CoreLayerTree
+{
+    public function getWidgetName(Element $element)
+    {
+        return 'custom.layertree';
+    }
+
+    public static function getType()
+    {
+        return CustomLayerTreeAdminType::class;
+    }
+
+    public function getTwigTemplatePath(): string
+    {
+        return '@Custom/Element/layertree.html.twig';
+    }
+
+    public function getRequiredAssets(Element $element)
+    {
+        $assets = parent::getRequiredAssets($element);
+        $assets['js'][] = '@CustomBundle/Resources/public/js/layertree.js';
+        return $assets;
+    }
+}
+```
+
+If you want to have your new menu item selectable in the Layer Tree configuration backend, add two more PHP classes:
+
+```php
+class CustomLayerTreeAdminType extends LayertreeAdminType
+{
+    public function getMenuCollectionType(): string
+    {
+        return CustomLayerTreeMenuType::class;
+    }
+}
+
+
+class CustomLayerTreeMenuType extends LayerTreeMenuType
+{
+    public function getChoices(): array
+    {
+        $choices = parent::getChoices();
+        $choices[] = "new-menu-item";
+        return $choices;
+    }
+
+}
+```
+
+In the twig template, extend from the core layertree template. You can override the block `layertree_menu_custom` if you
+have a more complex menu item, or `layertree_menu_custom_textend` for simple icons. ALways use the `data-menu-action` 
+attribute, then enabling/disabling according to the setting in the backoffice will happen automatically.
+
+```html
+{% extends "@MapbenderCore/Element/layertree.html.twig" %}
+
+{% block layertree_menu_custom %}
+   <div data-menu-action="new-menu-item">
+       Arbitrary complex structure goes here
+   </div>
+{% endblock %}
+
+{% block layertree_menu_custom_textend %}
+   <span data-menu-action="new-menu-item" class="fa fas fa-my-icon hover-highlight-effect clickable" title="..."></span>
+{% endblock %}
+```
+
+
+In the overridden JavaScript widget, initialise the new functionality:
+
+```js
+(function ($) {
+    $.widget("custom.layertree", $.mapbender.mbLayertree, {
+        _setup: function (mbMap) {
+            this._super(mbMap);
+            // use the following line if the menu item should always be enabled. Then you don't need to override 
+            // the admin type
+            this.options.menu.push('searchremove');
+        },
+        _createEvents: function () {
+            this._super();
+            // add a click (or whatever you need) listener here. 
+            this.element.on('click', '[data-menu-action=new-menu-item]', () => ...);
+        },
+    });
+})(jQuery);
+
+```
+
+
+[↑ Back to top](#sources)
+
+[← Back to README](../README.md)

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -305,6 +305,16 @@ In the overridden JavaScript widget, initialise the new functionality:
             // the admin type
             this.options.menu.push('searchremove');
         },
+        // override this if your menu item needs initialisation (not necessary for buttons)
+        _initMenuAction(action, $actionElement, $layerNode, layer) {
+            switch(action) {
+                case 'new-menu-item':
+                    // do something for initialisation
+                    break;
+                default:
+                    return this._super(action, $actionElement, $layerNode, layer);
+            }
+        },
         _createEvents: function () {
             this._super();
             // add a click (or whatever you need) listener here. 

--- a/src/Mapbender/CoreBundle/Element/Layertree.php
+++ b/src/Mapbender/CoreBundle/Element/Layertree.php
@@ -86,7 +86,7 @@ class Layertree extends AbstractElementService implements ImportAwareInterface
 
     public function getView(Element $element)
     {
-        $view = new TemplateView('@MapbenderCore/Element/layertree.html.twig');
+        $view = new TemplateView($this->getTwigTemplatePath());
         $view->attributes['class'] = 'mb-element-layertree';
         $view->attributes['data-title'] = $element->getTitle();
         $view->variables['configuration'] = array(
@@ -128,5 +128,10 @@ class Layertree extends AbstractElementService implements ImportAwareInterface
         // Force menu to a list of strings (= JavaScript Array, never Object)
         $config['menu'] = \array_values($config['menu']);
         return $config;
+    }
+
+    public function getTwigTemplatePath(): string
+    {
+        return '@MapbenderCore/Element/layertree.html.twig';
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Legend.php
+++ b/src/Mapbender/CoreBundle/Element/Legend.php
@@ -37,6 +37,7 @@ class Legend extends AbstractElementService implements ConfigMigrationInterface
     {
         return array(
             'js' => array(
+                '@MapbenderCoreBundle/Resources/public/element/LegendEntry.js',
                 '@MapbenderCoreBundle/Resources/public/mapbender.element.legend.js',
             ),
             'css' => array(

--- a/src/Mapbender/CoreBundle/Element/Type/LayerTreeMenuType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayerTreeMenuType.php
@@ -14,13 +14,7 @@ class LayerTreeMenuType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $choices = array(
-            'mb.core.layertree.admin.layerremove' => 'layerremove',
-            'mb.core.layertree.admin.opacity' => 'opacity',
-            'mb.core.layertree.admin.zoomtolayer' => 'zoomtolayer',
-            'mb.core.layertree.admin.metadata' => 'metadata',
-            'mb.core.layertree.admin.dimension' => 'dimension',
-        );
+        $choices = $this->getChoices();
         $resolver->setDefaults(array(
             'choices' => $choices,
             'multiple' => true,
@@ -33,5 +27,19 @@ class LayerTreeMenuType extends AbstractType
     public function getParent(): string
     {
         return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getChoices(): array
+    {
+        return array(
+            'mb.core.layertree.admin.layerremove' => 'layerremove',
+            'mb.core.layertree.admin.opacity' => 'opacity',
+            'mb.core.layertree.admin.zoomtolayer' => 'zoomtolayer',
+            'mb.core.layertree.admin.metadata' => 'metadata',
+            'mb.core.layertree.admin.dimension' => 'dimension',
+        );
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayertreeAdminType.php
@@ -4,6 +4,7 @@ namespace Mapbender\CoreBundle\Element\Type;
 
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class LayertreeAdminType extends AbstractType
@@ -15,27 +16,27 @@ class LayertreeAdminType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('autoOpen', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('autoOpen', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.manager.autoOpen',
             ))
-            ->add('useTheme', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('useTheme', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.usetheme',
             ))
-            ->add('allowReorder', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('allowReorder', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instancelayerform.label.allowreordertoc',
             ))
-            ->add('showBaseSource', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('showBaseSource', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.showbasesources',
             ))
-            ->add('hideInfo', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('hideInfo', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.hideinfo',
             ))
-            ->add('menu', 'Mapbender\CoreBundle\Element\Type\LayerTreeMenuType', array(
+            ->add('menu', $this->getMenuCollectionType(), array(
                 'required' => false,
                 'label' => 'mb.core.admin.layertree.label.menu',
             ))
@@ -44,5 +45,10 @@ class LayertreeAdminType extends AbstractType
                 'required' => false,
             ))
         ;
+    }
+
+    public function getMenuCollectionType(): string
+    {
+        return LayerTreeMenuType::class;
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/LegendEntry.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/LegendEntry.js
@@ -1,0 +1,137 @@
+/**
+ * @typedef {Object} LegendDefinitionStyle
+ * @property {string} [fillColor] - Optional fill color.
+ * @property {number} [fillOpacity] - Optional fill opacity (0-1).
+ * @property {string} [strokeColor] - Optional stroke color.
+ * @property {number} [strokeOpacity] - Optional stroke opacity (0-1).
+ * @property {number} [strokeWidth] - Optional stroke width (in pixels).
+ * @property {string} [fontFamily] - Optional font family.
+ * @property {string} [fontColor] - Optional font color.
+ * @property {string | number} [fontWeight] - Optional font weight.
+ * @property {number} [labelOutlineWidth] - Optional label outline width (in pixels).
+ * @property {string} [labelOutlineColor] - Optional label outline color.
+ */
+
+/**
+ * @typedef {Object} LegendDefinitionLayer
+ * @property {string} title
+ * @property {LegendDefinitionStyle} style
+ */
+
+/**
+ * @typedef {Object} LegendDefinition
+ * @property {'style'} type - Indicates the type is a style (and not an url)
+ * @property {string} title - Heading for the layer group
+ * @property {LegendDefinitionLayer} layers
+ */
+
+/**
+ * This class is used for displaying legend entries that are rendered by the browser,
+ * e.g. for layers that are created from digitizer entries
+ */
+class LegendEntry {
+    /**
+     * @param {LegendDefinition} legendDefinition
+     */
+    constructor(legendDefinition) {
+        this.legendDefinition = legendDefinition;
+        this.container = this._createContainer();
+
+        this._addHeading();
+        legendDefinition.layers.forEach((layer) => {
+            const subContainer = document.createElement("div");
+            subContainer.append(this._createCanvasForLayer("Label", 35, 15, layer.style));
+            subContainer.append(this._createLayerHeading(layer.title));
+            this.container.append(subContainer);
+        });
+    }
+
+    getContainer() {
+        return this.container;
+    }
+
+    _createContainer() {
+        const container = document.createElement("div");
+        container.className = "legend-custom";
+        return container;
+    }
+
+    _addHeading() {
+        const heading = document.createElement("h3");
+        heading.innerText = this.legendDefinition.title;
+        heading.className = "legend-custom__heading";
+        this.container.append(heading);
+    }
+
+    _createLayerHeading(title) {
+        const heading = document.createElement("h4");
+        heading.innerText = title;
+        heading.className = "legend-custom__layer";
+        return heading;
+    }
+
+    /**
+     *
+     * @param {String} label
+     * @param {number} width
+     * @param {number} height
+     * @param {LegendDefinitionStyle} style
+     * @returns {HTMLCanvasElement}
+     * @private
+     */
+    _createCanvasForLayer(label, width, height, style) {
+
+        const canvas = document.createElement('canvas');
+        canvas.className = "legend-custom__canvas";
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+
+        // Fill the shape
+        if (style.fillColor) {
+            ctx.fillStyle = this.hexToRgba(style.fillColor, style.fillOpacity);
+            ctx.fillRect(0, 0, width, height);
+        }
+
+        // Stroke the shape
+        if (style.strokeColor && style.strokeWidth > 0) {
+            ctx.strokeStyle = this.hexToRgba(style.strokeColor, style.strokeOpacity);
+            ctx.lineWidth = style.strokeWidth;
+            ctx.strokeRect(0, 0, width, height);
+        }
+
+        // Draw the label
+        if (label) {
+            ctx.font = `${style.fontWeight} 9px ${style.fontFamily}`;
+            ctx.fillStyle = style.fontColor;
+
+            // Measure the text to find the center position
+            const textMetrics = ctx.measureText(label);
+            const textX = (width - textMetrics.width) / 2;
+            const textY = (height + 9) / 2;
+
+            if (style.labelOutlineWidth > 0) {
+                ctx.lineWidth = style.labelOutlineWidth;
+                ctx.strokeStyle = style.labelOutlineColor;
+                ctx.strokeText(label, textX, textY);
+            }
+
+            ctx.fillText(label, textX, textY);
+        }
+        return canvas;
+    }
+
+    hexToRgba(hex, opacity = 1) {
+        let r = 0, g = 0, b = 0;
+        if (hex.length === 4) {
+            r = parseInt(hex[1] + hex[1], 16);
+            g = parseInt(hex[2] + hex[2], 16);
+            b = parseInt(hex[3] + hex[3], 16);
+        } else if (hex.length === 7) {
+            r = parseInt(hex[1] + hex[2], 16);
+            g = parseInt(hex[3] + hex[4], 16);
+            b = parseInt(hex[5] + hex[6], 16);
+        }
+        return `rgba(${r},${g},${b},${opacity})`;
+    }
+}

--- a/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/resetView.js
@@ -31,7 +31,7 @@
         resetDynamicSources: function() {
             var model = this.mbMap.getModel();
             model.sourceTree.forEach(function(source) {
-                if (source.wmsloader) {
+                if (source.isDynamicSource) {
                     model.removeSource(source);
                 }
             });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -209,8 +209,7 @@ window.Mapbender.MapModelBase = (function() {
             var source = this.getSourceById(sourceId);
             Mapbender.Geo.SourceHandler.setLayerOrder(source, newLayerIdOrder);
             this._checkSource(source, false);
-            // @todo: rename this event; it's about layers within a source
-            $(this.mbMap.element).trigger('mbmapsourcemoved', {
+            $(this.mbMap.element).trigger('mbmapsourcelayersreordered', {
                 mbMap: this.mbMap,
                 source: source
             });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -589,7 +589,7 @@ window.Mapbender.MapModelBase = (function() {
                     mbMap: this.mbMap,
                     source: source
                 });
-                var olLayers = source.initializeLayers(projCode, this.mbMap.options);
+                var olLayers = source.createNativeLayers(projCode, this.mbMap.options);
                 for (var j = 0; j < olLayers.length; ++j) {
                     var olLayer = olLayers[j];
                     Mapbender.mapEngine.setLayerVisibility(olLayer, false);
@@ -724,7 +724,7 @@ window.Mapbender.MapModelBase = (function() {
             for (var i = 0; i < this.sourceTree.length; ++i) {
                 var source = this.sourceTree[i];
                 if (source.checkRecreateOnSrsSwitch(srsNameFrom, srsNameTo)) {
-                    var olLayers = source.initializeLayers(srsNameTo, this.mbMap.options);
+                    var olLayers = source.createNativeLayers(srsNameTo, this.mbMap.options);
                     for (var j = 0; j < olLayers.length; ++j) {
                         var olLayer = olLayers[j];
                         Mapbender.mapEngine.setLayerVisibility(olLayer, false);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/MapModelBase.js
@@ -206,8 +206,8 @@ window.Mapbender.MapModelBase = (function() {
          * engine-agnostic
          */
         setSourceLayerOrder: function(sourceId, newLayerIdOrder) {
-            var source = this.getSourceById(sourceId);
-            Mapbender.Geo.SourceHandler.setLayerOrder(source, newLayerIdOrder);
+            const source = this.getSourceById(sourceId);
+            source.setLayerOrder(newLayerIdOrder);
             this._checkSource(source, false);
             $(this.mbMap.element).trigger('mbmapsourcelayersreordered', {
                 mbMap: this.mbMap,

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -685,6 +685,9 @@ window.Mapbender = Mapbender || {};
             if (this.hasBounds()) {
                 supported.push('zoomtolayer');
             }
+            if (this.options.availableStyles && this.options.availableStyles.length > 1) {
+                supported.push('select_style');
+            }
             return supported;
         }
     }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -591,6 +591,15 @@ window.Mapbender = Mapbender || {};
         }
 
         /**
+         * @param {Mapbender.SourceLayer} child
+         */
+        addChild(child) {
+            this.children.push(child);
+            this.children.forEach((child) => child.siblings = this.children);
+            Mapbender.Model.updateSource(this.source);
+        }
+
+        /**
          * @param {string} projCode
          * @param {boolean} inheritFromParent
          * @returns {number[]|boolean} false if bounds could not be calculated

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -631,6 +631,16 @@ window.Mapbender = Mapbender || {};
             return null;
         }
 
+        /**
+         * Returns the legend for this layer. The legend can be either an external
+         * url (e.g. for WMS services) or a style definition that is rendered on a canvas
+         *
+         * @return {null|{type: 'url', url: string, topLevel: boolean}|LegendDefinition}
+         */
+        getLegend() {
+            return null;
+        }
+
         hasBounds() {
             var layer = this;
             do {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -206,7 +206,7 @@ window.Mapbender = Mapbender || {};
         }
 
         /**
-         * Creates the native OpenLayers layers required for this source
+         * Creates the native OpenLayers layers required for this source and stores them in the class variable nativeLayers
          * @abstract
          * @param {String} srsName
          * @param {Object} [mapOptions]

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -632,6 +632,34 @@ window.Mapbender = Mapbender || {};
             } while (layer);
             return false;
         }
+
+        /**
+         * Returns a list of menu options supported by this layer.
+         * Core mapbender menu options:
+         * - layerremove: Deletes this layer
+         * - metadata: Opens metadata in a new window. options.medataUrl should be defined
+         * - opacity: Opacity slider between 0 and 1. See {Mapbender.Source.setOpacity}
+         * - dimension: selection slider for dimensions like e.g. time
+         * - zoomtolayer: Changes the map's view to fit the layer
+         * @returns {string[]}
+         */
+        getSupportedMenuOptions() {
+            const supported = ['layerremove'];
+            if (this.options.metadataUrl) {
+                supported.push('metadata');
+            }
+            // opacity + dimension are only available on root layer
+            if (!this.getParent()) {
+                supported.push('opacity');
+                if ((this.source.configuration.options.dimensions || []).length) {
+                    supported.push('dimension');
+                }
+            }
+            if (this.hasBounds()) {
+                supported.push('zoomtolayer');
+            }
+            return supported;
+        }
     }
 
     Mapbender.Source.typeMap = {};

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -539,6 +539,10 @@ window.Mapbender = Mapbender || {};
             return this.options.treeOptions.selected;
         }
 
+        setSelected(state) {
+            this.options.treeOptions.selected = !!state;
+        }
+
         getId() {
             return this.options.id;
         }
@@ -641,6 +645,10 @@ window.Mapbender = Mapbender || {};
             return null;
         }
 
+        /**
+         * is this layer restricted to spatial bbox?
+         * @returns {boolean}
+         */
         hasBounds() {
             var layer = this;
             do {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -441,6 +441,15 @@ window.Mapbender = Mapbender || {};
             });
         }
 
+        /**
+         * reorders the layers of this source. The default implementation forwards to
+         * [Mapbender.Geo.SourceHandler.setLayerOrder] which works for hierarchical sources like WMS and WMTS
+         * @param {string[]} newLayerIdOrder the layer ids in their new order
+         */
+        setLayerOrder(newLayerIdOrder) {
+            Mapbender.Geo.SourceHandler.setLayerOrder(this, newLayerIdOrder);
+        }
+
         _bboxArrayToBounds(bboxArray, projCode) {
             return Mapbender.mapEngine.boundsFromArray(bboxArray);
         }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -186,6 +186,7 @@ window.Mapbender = Mapbender || {};
              * @type {object}
              */
             this.configuration = definition.configuration || {};
+            this.configuration.options = this.configuration.options || {};
             this.configuration.children = (this.configuration.children || []).map(childDef => Mapbender.SourceLayer.factory(childDef, this, null));
 
             this.children = this.configuration.children;
@@ -486,7 +487,20 @@ window.Mapbender = Mapbender || {};
         constructor(definition, source, parent) {
             super(((definition || {}).options || {}).title || '', parent)
             this.options = definition.options || {};
-            this.state = definition.state || {};
+            this.options.treeOptions = this.options.treeOptions || {
+                selected: true,
+                info: false,
+                toggle: true,
+                allow: {selected: true, info: false, toggle: true,}
+            };
+
+            this.state = definition.state || {
+                info: null,
+                outOfBounds: false,
+                outOfScale: false,
+                visibility: true,
+            };
+
             this.source = source;
             var childDefs = definition.children || [];
             var i, child, childDef;

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -512,7 +512,7 @@
                     }
                 }
             } else {
-                $('.layer-styles', menu).remove();
+                $layerStyleControl.remove();
             }
         },
         _toggleMenu: function (e) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -240,7 +240,7 @@
             return $li;
         },
         _createSourceTree: function (source) {
-            return this._createLayerNode(source.configuration.children[0]);
+            return this._createLayerNode(source.getRootLayer());
         },
         _onSourceAdded: function (event, data) {
             var source = data.source;
@@ -296,7 +296,7 @@
                 }
             }
 
-            resetLayer(source.configuration.children[0], null);
+            resetLayer(source.getRootLayer(), null);
         },
         _updateLayerDisplay: function ($li, layer) {
             if (layer && layer.state && Object.keys(layer.state).length) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -203,7 +203,6 @@
 
             var $li = this.template.clone();
             $li.data('layer', layer);
-
             $li.attr('data-id', layer.options.id);
             $li.attr('data-sourceid', layer.source.id);
 
@@ -241,8 +240,7 @@
             return $li;
         },
         _createSourceTree: function (source) {
-            var li = this._createLayerNode(source.configuration.children[0]);
-            return li;
+            return this._createLayerNode(source.configuration.children[0]);
         },
         _onSourceAdded: function (event, data) {
             var source = data.source;
@@ -360,7 +358,7 @@
             this._updateFolderState($node);
             return false;
         },
-        _updateFolderState: function($node) {
+        _updateFolderState: function ($node) {
             const active = $node.hasClass('showLeaves');
             $node.children('.leaveContainer').children('.-fn-toggle-children').children('i')
                 .toggleClass('fa-folder-open', active)
@@ -429,24 +427,47 @@
          * @param $layerNode jQuery
          */
         _initMenu: function ($layerNode) {
-            var layer = $layerNode.data('layer');
-            var source = layer.source;
-            var menu = $(this.menuTemplate.clone());
-            var mapModel = this.model;
-            if (layer.getParent()) {
-                $('.layer-control-root-only', menu).remove();
-            }
+            const layer = $layerNode.data('layer');
+            const $menu = $(this.menuTemplate.clone());
 
             const activeMenuItems = this._filterMenu(layer);
             if (!activeMenuItems.length) {
-                menu.remove();
+                $menu.remove();
                 return;
             }
+            $layerNode.find('.leaveContainer:first', $layerNode).after($menu);
 
-            // element must be added to dom and sized before Dragdealer init...
-            $('.leaveContainer:first', $layerNode).after(menu);
+            $menu.find('[data-menu-action]').each((index, el) => {
+                const $actionElement = $(el);
+                const action = $actionElement.attr('data-menu-action');
+                if (activeMenuItems.includes(action)) {
+                    this._initMenuAction(action, $actionElement, $layerNode, layer);
+                } else {
+                    $actionElement.remove();
+                }
+            });
+        },
+        /**
+         *
+         * @param {string} action
+         * @param {jQuery} $actionElement the dom element with the data-action attribute
+         * @param {jQuery} $layerNode the dom element for the layer node
+         * @param {Mapbender.SourceLayer} layer
+         * @private
+         */
+        _initMenuAction(action, $actionElement, $layerNode, layer) {
+            switch (action) {
+                case 'opacity':
+                    return this._initOpacitySlider($actionElement, layer);
+                case 'dimension':
+                    return this._initDimensionsMenu($layerNode, $menu, dims, layer.source);
+                case 'zoomtolayer':
+                    return $actionElement.on('click', this._zoomToLayer.bind(this));
+            }
+        },
 
-            var $opacityControl = $('.layer-control-opacity', menu);
+        _initOpacitySlider: function ($opacityControl, layer) {
+            const source = layer.source;
             if ($opacityControl.length) {
                 var $handle = $('.layer-opacity-handle', $opacityControl);
                 $handle.attr('unselectable', 'on');
@@ -457,30 +478,13 @@
                     speed: 1,
                     steps: 100,
                     handleClass: "layer-opacity-handle",
-                    animationCallback: function (x, y) {
+                    animationCallback: (x, y) => {
                         var opacity = Math.max(0.0, Math.min(1.0, x));
                         var percentage = Math.round(opacity * 100);
                         $handle.text(percentage);
-                        mapModel.setSourceOpacity(source, opacity);
+                        this.model.setSourceOpacity(source, opacity);
                     }
                 });
-            }
-            var $zoomControl = $('.layer-zoom', menu);
-            if ($zoomControl.length && layer.hasBounds()) {
-                $zoomControl.on('click', $.proxy(this._zoomToLayer, this));
-            } else {
-                $zoomControl.remove();
-            }
-            if (!layer.options.metadataUrl || !$('.layer-metadata', menu).length) {
-                $('.layer-metadata', menu).remove();
-            }
-
-            var dims = source.configuration.options.dimensions || [];
-            var $dimensionsControl = $('.layer-control-dimensions', menu);
-            if (dims.length && $dimensionsControl.length) {
-                this._initDimensionsMenu($layerNode, menu, dims, source);
-            } else {
-                $dimensionsControl.remove();
             }
         },
         _toggleMenu: function (e) {
@@ -502,30 +506,15 @@
         },
         /**
          * returns a list of supported menu options for this layer. Override this if you have a custom menu option
-         * @param layer Mapbender.SourceLayer
+         * @param {Mapbender.SourceLayer} layer
          * @returns {string[]}
          */
         _getSupportedMenuOptions(layer) {
-            const supported = ['layerremove'];
-            if (layer.options.metadataUrl) {
-                supported.push('metadata');
-            }
-            // opacity + dimension are only available on root layer
-            if (!layer.getParent()) {
-                supported.push('opacity');
-                if ((layer.source.configuration.options.dimensions || []).length) {
-                    supported.push('dimension');
-                }
-            }
-            if (layer.hasBounds()) {
-                supported.push('zoomtolayer');
-            }
-            return supported;
+            return layer.getSupportedMenuOptions();
         },
-        _initDimensionsMenu: function ($element, menu, dims, source) {
+        _initDimensionsMenu: function ($element, $actionElement, dims, source) {
             var self = this;
             var dimData = $element.data('dimensions') || {};
-            var template = $('.layer-control-dimensions', menu);
             var $controls = [];
             var dragHandlers = [];
             var updateData = function (key, props) {
@@ -536,7 +525,7 @@
                 $element.data('dimensions', mergedData);
             };
             $.each(dims, function (idx, item) {
-                var $control = template.clone();
+                var $control = $actionElement.clone();
                 var label = $('.layer-dimension-title', $control);
 
                 var dimDataKey = source.id + '~' + idx;
@@ -584,7 +573,7 @@
                 }
                 $controls.push($control);
             });
-            template.replaceWith($controls);
+            $actionElement.replaceWith($controls);
             dragHandlers.forEach(function (dh) {
                 dh.reflow();
             });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -285,17 +285,20 @@
         _resetSourceAtTree: function (source) {
             var self = this;
 
-            function resetLayer(layer) {
+            function resetLayer(layer, $parent) {
                 var $li = $('li[data-id="' + layer.options.id + '"]', self.element);
+                if (!$li.length && $parent) {
+                    $parent.find('ul.layers').append(self._createLayerNode(layer));
+                }
                 self._updateLayerDisplay($li, layer);
                 if (layer.children) {
                     for (var i = 0; i < layer.children.length; i++) {
-                        resetLayer(layer.children[i]);
+                        resetLayer(layer.children[i], $li);
                     }
                 }
             }
 
-            resetLayer(source.configuration.children[0]);
+            resetLayer(source.configuration.children[0], null);
         },
         _updateLayerDisplay: function ($li, layer) {
             if (layer && layer.state && Object.keys(layer.state).length) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -155,7 +155,7 @@
         },
 
         createLegendForStyle: function (layer) {
-            return (new LegendEntry(layer.legend)).getContainer()
+            return (new LegendEntry(layer.legend)).getContainer();
         },
 
         /**

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.legend.js
@@ -49,7 +49,7 @@
             var rerenderOn = [
                 'mbmapsourceadded',
                 'mbmapsourcechanged',
-                'mbmapsourcemoved',
+                'mbmapsourcelayersreordered',
                 'mbmapsourcesreordered',
                 'mbmapsourcelayerremoved'
             ];

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.overview.js
@@ -139,7 +139,7 @@
                 // Legacy HACK: Overview ignores backend settings on instance layers, enables all children
                 //        of the root layer with non-empty names, ignores every other layer
                 if (source.type !== 'wms' || source.hasVisibleLayers(srsName)) {
-                    source.initializeLayers(srsName);
+                    source.createNativeLayers(srsName);
                     layers = layers.concat(source.getNativeLayers());
                 }
             }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -98,26 +98,7 @@ Mapbender.Geo.SourceHandler = {
         });
         return stateChanged;
     },
-    /**
-     * @param {Object} layer
-     * @param {number} scale current value fetched from Mapbender.Model if omitted
-     * @return {boolean}
-     * @deprecated call layer.isInScale
-     */
-    isLayerInScale: function(layer, scale) {
-        return layer.isInScale(scale);
-    },
-    /**
-     * @param {Object} layer
-     * @param {*} extent
-     * @return {boolean}
-     * @deprecated call layer.intersectsExtent
-     */
-    isLayerWithinBounds: function(layer, extent) {
-        var srsName = Mapbender.Model.getCurrentProjectionCode();
-        return layer.intersectsExtent(extent, srsName);
-    },
-    setLayerOrder: function setLayerOrder(source, layerIdOrder) {
+    setLayerOrder: function(source, layerIdOrder) {
         var listsSorted = [];
         var _pickChildId = function(ids, layer) {
             if (!ids.length) {
@@ -143,8 +124,7 @@ Mapbender.Geo.SourceHandler = {
             var childB = _pickChildId(layerIdOrder, b);
             var ixA = layerIdOrder.includes(childA) ? layerIdOrder.indexOf(childA) : Number.MAX_SAFE_INTEGER;
             var ixB = layerIdOrder.includes(childB) ? layerIdOrder.indexOf(childB) : Number.MIN_SAFE_INTEGER;
-            let ret = parseInt(ixA,10) - parseInt(ixB,10);
-            return ret;
+            return parseInt(ixA, 10) - parseInt(ixB, 10);
         };
         var parentIdOrder = [];
         for (var idIx = 0; idIx < layerIdOrder.length; ++idIx) {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/legend.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/legend.scss
@@ -9,3 +9,24 @@
     margin-bottom: 0.5em;
   }
 }
+
+.legend-custom {
+  padding: 3px;
+
+  &__heading {
+    margin-top: 5px;
+    margin-left: -3px;
+    font-weight: 800;
+    font-size: 1.35rem;
+    margin-bottom: 10px;
+  }
+
+  &__canvas {
+    float: left;
+    margin-right: 5px;
+  }
+
+  &__layer {
+    font-size: 1.05rem;
+  }
+}

--- a/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
@@ -56,7 +56,7 @@
                 {% endblock %}
                 {% block layertree_menu_select_style %}
                 {% if 'select_style' in configuration.menu %}
-                    <div class="layer-styles input-group mb-1">
+                    <div class="layer-styles input-group mb-1" data-menu-action="select_style">
                         <label class="input-group-text">{{ 'mb.core.layertree.label.select_style'|trans }}</label>
                         <select
                             class="select-layer-styles form-select"

--- a/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
@@ -26,39 +26,57 @@
           <span class="error-icon-wrapper"><i class="fas fa-triangle-exclamation"></i></span>
           <span class="loading-icon-wrapper"><i class="fas fa-spinner"></i></span>
           {% if configuration.menu is defined and configuration.menu %}
-          <span class="layer-menu-btn"><i class="fas fa-bars"></i></span>
-            <div class="layer-menu hidden">
-              <div class="text-end">
-                <span class="exit-button" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}"><i class="fa fas fa-xmark"></i></span>
-              </div>
-              {% if 'opacity' in configuration.menu %}
-                  <div class="layer-control-opacity layer-control-root-only">
-                    <div class="layer-opacity-bar layer-slider-bar" title="{{ "mb.core.layertree.label.opacity"|trans }}">
-                        <div class="layer-opacity-handle layer-slider-handle">100</div>
-                    </div>
-              </div>
-              {% endif %}
-              {% if 'dimension' in configuration.menu %}
-                  <div class="layer-control-dimensions layer-control-root-only">
-                      <div class="checkbox"><label><input type="checkbox" title="{{ 'mb.core.layertree.label.dimension_onoff' | trans  }}"/><span class="layer-dimension-title"></span></label></div>
-                      <div class="layer-dimension-bar layer-slider-bar" title="{{ "mb.core.layertree.label.dimension" |trans }}">
-                        <div class="layer-dimension-handle layer-slider-handle"></div>
-                      </div>
-                      <input type="text" class="layer-dimension-textfield" name="dimension-extent" title="{{ "mb.core.layertree.label.dimension" |trans }}"/>
+            {% block layertree_menu %}
+              <span class="layer-menu-btn"><i class="fas fa-bars"></i></span>
+              <div class="layer-menu hidden">
+                {% block layertree_menu_close %}
+                  <div class="text-end">
+                    <span class="exit-button" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}"><i class="fa fas fa-xmark"></i></span>
                   </div>
-              {% endif %}
-              <div class="text-end">
-                {% if 'zoomtolayer' in configuration.menu %}
-                <span class="layer-zoom fa fas fa-search hover-highlight-effect clickable" title="{{ 'mb.core.layertree.label.zoomtolayer'|trans }}"></span>
+                {% endblock %}
+                {% block layertree_menu_opacity %}
+                {% if 'opacity' in configuration.menu %}
+                    <div class="layer-control-opacity" data-menu-action="opacity">
+                      <div class="layer-opacity-bar layer-slider-bar" title="{{ "mb.core.layertree.label.opacity"|trans }}">
+                          <div class="layer-opacity-handle layer-slider-handle">100</div>
+                      </div>
+                </div>
                 {% endif %}
-                {% if 'metadata' in configuration.menu %}
-                <span class="layer-metadata fa far fa-file-alt fa-file-text-o hover-highlight-effect clickable" title="{{ 'mb.core.layertree.label.metadata'|trans }}"></span>
+                {% endblock %}
+                {% block layertree_menu_dimension %}
+                {% if 'dimension' in configuration.menu %}
+                    <div class="layer-control-dimensions" data-menu-action="dimension">
+                        <div class="checkbox"><label><input type="checkbox" title="{{ 'mb.core.layertree.label.dimension_onoff' | trans  }}"/><span class="layer-dimension-title"></span></label></div>
+                        <div class="layer-dimension-bar layer-slider-bar" title="{{ "mb.core.layertree.label.dimension" |trans }}">
+                          <div class="layer-dimension-handle layer-slider-handle"></div>
+                        </div>
+                        <input type="text" class="layer-dimension-textfield" name="dimension-extent" title="{{ "mb.core.layertree.label.dimension" |trans }}"/>
+                    </div>
                 {% endif %}
-                {% if 'layerremove' in configuration.menu %}
-                <span class="layer-remove-btn fa fas fa-circle-xmark hover-highlight-effect clickable" title="{{ 'mb.core.layertree.tooltip.removelayer'|trans }}"></span>
-                {% endif %}
-              </div>
-            </div>
+                {% endblock %}
+                <div class="text-end">
+                  {% block layertree_menu_zoomtolayer %}
+                  {% if 'zoomtolayer' in configuration.menu %}
+                  <span data-menu-action="zoomtolayer" class="layer-zoom fa fas fa-search hover-highlight-effect clickable" title="{{ 'mb.core.layertree.label.zoomtolayer'|trans }}"></span>
+                  {% endif %}
+                  {% endblock %}
+                  {% block layertree_menu_metadata %}
+                  {% if 'metadata' in configuration.menu %}
+                  <span data-menu-action="metadata" class="layer-metadata fa far fa-file-alt fa-file-text-o hover-highlight-effect clickable" title="{{ 'mb.core.layertree.label.metadata'|trans }}"></span>
+                  {% endif %}
+                  {% endblock %}
+                  {% block layertree_menu_layerremove %}
+                  {% if 'layerremove' in configuration.menu %}
+                  <span data-menu-action="layerremove" class="layer-remove-btn fa fas fa-circle-xmark hover-highlight-effect clickable" title="{{ 'mb.core.layertree.tooltip.removelayer'|trans }}"></span>
+                  {% endif %}
+                  {% endblock %}
+                  {% block layertree_menu_custom_textend %}
+                  {% endblock %}
+                </div>
+                {% block layertree_menu_custom %}
+                {% endblock %}
+                </div>
+              {% endblock %}
           {% endif %}
         </div>
         <ul class="layers"></ul>

--- a/src/Mapbender/FrameworkBundle/Component/UserInfoProvider.php
+++ b/src/Mapbender/FrameworkBundle/Component/UserInfoProvider.php
@@ -41,7 +41,7 @@ class UserInfoProvider
             );
         } else {
             return array(
-                'name' => $token->getUsername(),
+                'name' => $token->getUserIdentifier(),
                 'roles' => $token->getRoleNames(),
                 'isAnonymous' => false,
             );

--- a/src/Mapbender/PrintBundle/Component/CanvasLegend.php
+++ b/src/Mapbender/PrintBundle/Component/CanvasLegend.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Mapbender\PrintBundle\Component;
+
+class CanvasLegend {
+
+    private \GdImage $image;
+    protected string $font = __DIR__ . '/../../../../../config/MapbenderPrintBundle/fonts/OpenSans-Regular.ttf';
+
+    private int $offset = 15;
+    protected int $legendWidth = 300;
+    protected int $layerHeight = 25;
+    protected int $symbolHeight = 15;
+    protected int $symbolWidth = 35;
+
+    public function __construct(private array $layers) {
+        $this->image = imagecreatetruecolor($this->legendWidth, $this->offset + $this->layerHeight * count($this->layers));
+        $this->prepareCanvas();
+
+        foreach($this->layers as $layer) {
+            $this->addSubLayer($layer["title"], $layer["style"]);
+        }
+    }
+
+    function getImage(): \GdImage
+    {
+        return $this->image;
+    }
+
+    protected function addSubLayer(string $label, array $style) {
+        // Set fill color
+        $fillColor = $this->hexToRgb($style['fillColor']);
+        $fillOpacity = $style['fillOpacity'];
+        $fill = imagecolorallocatealpha($this->image, $fillColor['red'], $fillColor['green'], $fillColor['blue'], 127 * (1 - $fillOpacity));
+        imagefilledrectangle($this->image, 0, $this->offset, $this->symbolWidth, $this->offset + $this->symbolHeight, $fill);
+
+        // Set stroke color
+        if (isset($style['strokeColor']) && $style['strokeWidth'] > 0) {
+            $strokeColor = $this->hexToRgb($style['strokeColor']);
+            $strokeOpacity = $style['strokeOpacity'];
+            $stroke = imagecolorallocatealpha($this->image, $strokeColor['red'], $strokeColor['green'], $strokeColor['blue'], 127 * (1 - $strokeOpacity));
+            imagesetthickness($this->image, $style['strokeWidth']);
+            imagerectangle($this->image, 0, $this->offset, $this->symbolWidth - 1, $this->offset + $this->symbolHeight - 1, $stroke);
+        }
+
+        // Set font options and calculate text placement
+        $fontColor = $this->hexToRgb($style['fontColor']);
+        $fontSize = min(10, (int)$style['fontSize']);
+        $textColor = imagecolorallocate($this->image, $fontColor['red'], $fontColor['green'], $fontColor['blue']);
+
+        $textBox = imagettfbbox($fontSize, 0, $this->font, "Label");
+        $textWidth = abs($textBox[4] - $textBox[0]);
+        $textHeight = abs($textBox[5] - $textBox[1]);
+        $textX = ($this->symbolWidth - $textWidth) / 2;
+        $textY = ($this->symbolHeight + $textHeight) / 2;
+
+        // Draw label outline if needed
+        if (isset($style['labelOutlineWidth']) && $style['labelOutlineWidth'] > 0) {
+            $labelOutlineColor = $this->hexToRgb($style['labelOutlineColor']);
+            $outlineColor = imagecolorallocate($this->image, $labelOutlineColor['red'], $labelOutlineColor['green'], $labelOutlineColor['blue']);
+            $outlineWidth = $style['labelOutlineWidth'];
+            for ($x = -$outlineWidth; $x <= $outlineWidth; $x++) {
+                for ($y = -$outlineWidth; $y <= $outlineWidth; $y++) {
+                    imagettftext($this->image, $fontSize, 0, $textX + $x, $this->offset + $textY + $y, $outlineColor, $this->font, "Label");
+                }
+            }
+        }
+
+        // Draw the label
+        imagettftext($this->image, $fontSize, 0, $textX, $textY + $this->offset, $textColor, $this->font, "Label");
+
+        $black = imagecolorallocate($this->image, 0, 0, 0);
+        imagettftext($this->image, 12, 0, $this->symbolWidth + 10, $textY + $this->offset, $black, $this->font, $label);
+        $this->offset += $this->symbolHeight + 10;
+    }
+
+    private function hexToRgb($hex) {
+        $hex = str_replace("#", "", $hex);
+        if (strlen($hex) == 3) {
+            $r = hexdec(str_repeat(substr($hex, 0, 1), 2));
+            $g = hexdec(str_repeat(substr($hex, 1, 1), 2));
+            $b = hexdec(str_repeat(substr($hex, 2, 1), 2));
+        } else {
+            $r = hexdec(substr($hex, 0, 2));
+            $g = hexdec(substr($hex, 2, 2));
+            $b = hexdec(substr($hex, 4, 2));
+        }
+        return ['red' => $r, 'green' => $g, 'blue' => $b];
+    }
+
+    public function prepareCanvas(): void
+    {
+        $white = imagecolorallocate($this->image, 255, 255, 255);
+        imagefill($this->image, 0, 0, $white);
+    }
+}

--- a/src/Mapbender/PrintBundle/Component/LegendHandler.php
+++ b/src/Mapbender/PrintBundle/Component/LegendHandler.php
@@ -29,28 +29,18 @@ use Mapbender\PrintBundle\Component\Transport\ImageTransport;
  */
 class LegendHandler
 {
-    /** @var ImageTransport */
-    protected $imageTransport;
-    /** @var string */
-    protected $resourceDir;
-    /** @var PdfUtil */
-    protected $pdfUtil;
-    /** @var float */
-    protected $maxColumnWidthMm = 100.;
-    /** @var float */
-    protected $maxImageDpi = 96.;
-    /** @var string */
-    protected $legendPageFontName = 'Arial';
+    protected PdfUtil $pdfUtil;
+    protected float $maxColumnWidthMm = 100.;
+    protected float $maxImageDpi = 96.;
+    protected string $legendPageFontName = 'Arial';
 
-    /**
-     * @param ImageTransport $imageTransport
-     * @param string $resourceDir
-     * @param string $tempDir
-     */
-    public function __construct(ImageTransport $imageTransport, $resourceDir, $tempDir)
+    public function __construct(
+        protected ImageTransport $imageTransport,
+        protected string         $resourceDir,
+        ?string                   $tempDir,
+        protected string         $canvasLegendClass,
+    )
     {
-        $this->imageTransport = $imageTransport;
-        $this->resourceDir = $resourceDir;
         $this->pdfUtil = new PdfUtil($tempDir, 'mb_print_legend');
     }
 
@@ -93,14 +83,11 @@ class LegendHandler
     {
         $group = new LegendBlockGroup();
         foreach ($groupData as $key => $data) {
-            if (is_array($data)) {
-                $url = $data['url'];
-                $title = $data['layerName'];
-            } else {
-                $url = $data;
-                $title = $key;
-            }
-            $block = $this->prepareUrlBlock($title, $url);
+            $block = match($data['type']) {
+                'url' => $this->prepareUrlBlock($data['layerName'], $data['url']),
+                'style' => $this->prepareStyleBlock($data),
+                default => null,
+            };
             if ($block) {
                 $group->addBlock($block);
             }
@@ -187,12 +174,8 @@ class LegendHandler
     /**
      * Adds a new page to the PDF to render more legends. Also implicitly adds watermarks, if defined in the
      * template and job.
-     *
-     * @param PDF_Extensions|\FPDF $pdf $pdf
-     * @param Template|array $templateData
-     * @param array $jobData
      */
-    public function addPage($pdf, $templateData, $jobData)
+    public function addPage(PDF_Extensions|\FPDF $pdf, Template|array $templateData, array $jobData): void
     {
         if ($templateData['orientation'] == 'portrait') {
             $format = array($templateData['pageSize']['width'], $templateData['pageSize']['height']);
@@ -207,12 +190,7 @@ class LegendHandler
         $pdf->SetFont($this->legendPageFontName, 'B', $this->getLegendTitleFontSize(null, true));
     }
 
-    /**
-     * @param PDF_Extensions|\FPDF $pdf
-     * @param Template|array $templateData
-     * @param array $jobData
-     */
-    protected function addLegendPageImage($pdf, $templateData, $jobData)
+    protected function addLegendPageImage(PDF_Extensions|\FPDF $pdf, Template|array $templateData, array $jobData): void
     {
         if (empty($templateData['legendpage_image']) || empty($jobData['legendpage_image'])) {
             return;
@@ -229,19 +207,18 @@ class LegendHandler
         }
     }
 
-    /**
-     * @param string $title
-     * @param string $url
-     * @return LegendBlock|null
-     */
-    public function prepareUrlBlock($title, $url)
+    public function prepareStyleBlock(array $legendInfo): ?LegendBlock
+    {
+        /** @var CanvasLegend $canvasLegend */
+        $canvasLegend = new $this->canvasLegendClass($legendInfo["layers"]);
+        $image = $canvasLegend->getImage();
+        return $image ? new LegendBlock($image, $legendInfo['layerName']) : null;
+    }
+
+    public function prepareUrlBlock(string $title, string $url): ?LegendBlock
     {
         $image = $this->imageTransport->downloadImage($url);
-        if ($image) {
-            return new LegendBlock($image, $title);
-        } else {
-            return null;
-        }
+        return $image ? new LegendBlock($image, $title) : null;
     }
 
     /**

--- a/src/Mapbender/PrintBundle/Element/PrintClient.php
+++ b/src/Mapbender/PrintBundle/Element/PrintClient.php
@@ -8,7 +8,6 @@ use Mapbender\Component\Element\ElementHttpHandlerInterface;
 use Mapbender\Component\Element\TemplateView;
 use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
 use Mapbender\CoreBundle\Component\Source\UrlProcessor;
-use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Utils\ArrayUtil;
 use Mapbender\PrintBundle\Component\OdgParser;
@@ -51,15 +50,15 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
     protected $enableQueue;
 
     public function __construct(UrlGeneratorInterface $urlGenerator,
-                                FormFactoryInterface $formFactory,
+                                FormFactoryInterface  $formFactory,
                                 TokenStorageInterface $tokenStorage,
-                                UrlProcessor $sourceUrlProcessor,
-                                OdgParser $odgParser,
-                                /** @todo: elminate bridge service */
+                                UrlProcessor          $sourceUrlProcessor,
+                                OdgParser             $odgParser,
+        /** @todo: elminate bridge service */
                                 PrintServiceInterface $printService,
-                                PrintPluginHost $pluginRegistry,
-                                $memoryLimit,
-                                $enableQueue)
+                                PrintPluginHost       $pluginRegistry,
+                                                      $memoryLimit,
+                                                      $enableQueue)
     {
         $this->urlGenerator = $urlGenerator;
         $this->formFactory = $formFactory;
@@ -206,9 +205,9 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
     public function getClientConfiguration(Element $element)
     {
         return $element->getConfiguration() + array(
-            // NOTE: intl extension locale is runtime-controlled by Symfony to reflect framework configuration
-            'locale' => \locale_get_default(),
-        );
+                // NOTE: intl extension locale is runtime-controlled by Symfony to reflect framework configuration
+                'locale' => \locale_get_default(),
+            );
     }
 
     public function getView(Element $element)
@@ -238,9 +237,9 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
             'id' => $element->getId(),
             'title' => $element->getTitle(),
             'configuration' => $config + array(
-                'required_fields_first' => false,
-                'type' => 'dialog',
-            ),
+                    'required_fields_first' => false,
+                    'type' => 'dialog',
+                ),
         );
         if ($queueMode) {
             /**
@@ -450,35 +449,30 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
         return $url;
     }
 
-    /**
-     * @param array[] $legendDefs
-     * @return string[]
-     */
-    protected function prepareLegends($legendDefs)
+    protected function prepareLegends(array $legendDefs): array
     {
-        $legendDefsOut = array();
-        foreach ($legendDefs as $ix => $imageList) {
-            $legendDefsOut[$ix] = array();
-            foreach ($imageList as $imageListKey => $sourceLegendData) {
-                if (is_array($sourceLegendData)) {
-                    // New style arrays, fixes ~semi-random order from browser-specific JSON processing
-                    // $imageListKey is a numeric index, $sourceLegendData is an array with
-                    // * url
-                    // * sourceName
-                    // * layerName
-                    // * parentNames (string[])
-                    $legendDefsOut[$ix][$imageListKey] = array_replace($sourceLegendData, array(
-                        'url' => $this->sourceUrlProcessor->getInternalUrl($sourceLegendData['url']),
-                    ));
-                } else {
+        for ($ix = 0; $ix < count($legendDefs); $ix++) {
+            foreach ($legendDefs[$ix] as $imageListKey => $sourceLegendData) {
+                if (is_string($sourceLegendData)) {
                     // Old style title => url mapping. May go out of order depending on browser's and PHP's
                     // JSON processing
                     $internalUrl = $this->sourceUrlProcessor->getInternalUrl($sourceLegendData);
-                    $legendDefsOut[$ix][$imageListKey] = $internalUrl;
+                    $legendDefs[$ix][$imageListKey] = [
+                        'url' => $internalUrl,
+                        'type' => 'url',
+                        'layerName' => $imageListKey,
+                    ];
+                } elseif (is_array($sourceLegendData) && array_key_exists('url', $sourceLegendData)) {
+                    $internalUrl = $this->sourceUrlProcessor->getInternalUrl($sourceLegendData['url']);
+                    $legendDefs[$ix][$imageListKey]['url'] = $internalUrl;
+
+                    if (!array_key_exists('type', $sourceLegendData)) {
+                        $legendDefs[$ix][$imageListKey]['type'] = 'url';
+                    }
                 }
             }
-        };
-        return $legendDefsOut;
+        }
+        return $legendDefs;
     }
 
     /**
@@ -531,11 +525,11 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
      *
      * Unused param $user is provided for override methods, if you want to look into your
      * LDAP or something. This can have a multitude of types.
-     * @see AbstractToken::setUser()
-     *
      * @param \FOM\UserBundle\Entity\Group|mixed $group
      * @param UserInterface|object|string $user
      * @return array
+     * @see AbstractToken::setUser()
+     *
      */
     protected function getGroupSpecifics($group, $user)
     {
@@ -567,7 +561,7 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
      */
     private function replaceUrlPattern($url, $pattern, $dpi)
     {
-        if (!isset($pattern['replacement'][$dpi])){
+        if (!isset($pattern['replacement'][$dpi])) {
             return $url;
         }
 
@@ -582,7 +576,7 @@ class PrintClient extends AbstractElementService implements ConfigMigrationInter
      */
     private function addUrlPattern($url, $pattern, $dpi)
     {
-        if(!isset($pattern['default'][$dpi]))
+        if (!isset($pattern['default'][$dpi]))
             return $url;
 
         return $url . $pattern['default'][$dpi];

--- a/src/Mapbender/PrintBundle/Resources/config/services.xml
+++ b/src/Mapbender/PrintBundle/Resources/config/services.xml
@@ -29,6 +29,7 @@
         <parameter key="mapbender.print.temp_dir">%mapbender.imageexport.temp_dir%</parameter>
         <parameter key="mapbender.print.template_dir">%mapbender.print.resource_dir%/templates</parameter>
         <parameter key="mapbender.print.legend_handler.service.class">Mapbender\PrintBundle\Component\LegendHandler</parameter>
+        <parameter key="mapbender.print.canvas_legend.class">Mapbender\PrintBundle\Component\CanvasLegend</parameter>
         <parameter key="mapbender.print.template_parser.service.class">Mapbender\PrintBundle\Component\OdgParser</parameter>
         <parameter key="mapbender.print_plugin_host.service.class">Mapbender\PrintBundle\Component\Service\PrintPluginHost</parameter>
         <parameter key="mapbender.print.plugin.digitizer.class">Mapbender\PrintBundle\Component\Plugin\DigitizerPrintPlugin</parameter>

--- a/src/Mapbender/PrintBundle/Resources/config/services.xml
+++ b/src/Mapbender/PrintBundle/Resources/config/services.xml
@@ -110,6 +110,7 @@
             <argument type="service" id="mapbender.imageexport.image_transport.service" />
             <argument>%mapbender.print.resource_dir%</argument>
             <argument>%mapbender.print.temp_dir%</argument>
+            <argument>%mapbender.print.canvas_legend.class%</argument>
         </service>
         <service id="mapbender.print_plugin_host.service" class="%mapbender.print_plugin_host.service.class%">
         </service>

--- a/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
@@ -464,7 +464,6 @@
                     legends.unshift(sourceLegendList);
                 }
             }
-            console.log(legends);
             return legends;
         },
         /**

--- a/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/printclient.js
@@ -417,7 +417,7 @@
             var sources = this._getRasterSources();
             for (var i = 0; i < sources.length; ++i) {
                 var source = sources[i];
-                var rootLayer = source.configuration.children[0];
+                var rootLayer = source.getRootLayer();
                 var sourceName = source.configuration.title || (rootLayer && rootLayer.options.title) || '';
                 var leafInfo = Mapbender.Geo.SourceHandler.getExtendedLeafInfo(source, scale, this._getExportExtent());
                 var sourceLegendList = [];

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -238,7 +238,7 @@
                 });
             }
             // always activate root layer
-            var rootLayer = source.configuration.children[0];
+            var rootLayer = source.getRootLayer();
             rootLayer.options.treeOptions.selected = rootLayer.options.treeOptions.allow.selected;
             Mapbender.Util.SourceTree.iterateSourceLeaves(source, false, function(layer, offset, parents) {
                 var doActivate = activateAll;

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -193,7 +193,7 @@
                 sourceDef.id = sourceId;
                 // Need to pre-generate layer ids now because layertree visual updates need layer ids
                 Mapbender.Util.SourceTree.generateLayerIds(sourceDef);
-                sourceDef.wmsloader = true;
+                sourceDef.isDynamicSource = true;
                 this.activateLayersByName(sourceDef, options.layers || [], keepStates);
 
                 source = source || this.mbMap.model.addSourceFromConfig(sourceDef);

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -79,7 +79,8 @@ window.Mapbender = Mapbender || {};
         }
 
         createNativeLayers(srsName, mapOptions) {
-            return [Mapbender.mapEngine.createWmsLayer(this, mapOptions)];
+            this.nativeLayers = [Mapbender.mapEngine.createWmsLayer(this, mapOptions)];
+            return this.nativeLayers;
         }
 
         /**

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -10,10 +10,6 @@ window.Mapbender = Mapbender || {};
             return this.options.name;
         }
 
-        getSelected() {
-            return this.options.treeOptions.selected;
-        }
-
         setSelected(state) {
             this.options.treeOptions.selected = !!state;
         }

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -10,6 +10,16 @@ window.Mapbender = Mapbender || {};
             return this.options.name;
         }
 
+        getLegend() {
+            if (this.options.legend && this.options.legend.url) {
+                return {
+                    type: 'url',
+                    url: this.options.legend.url
+                };
+            }
+            return null;
+        }
+
         setSelected(state) {
             this.options.treeOptions.selected = !!state;
         }
@@ -83,7 +93,7 @@ window.Mapbender = Mapbender || {};
          * @return {SourceSettings}
          */
         getSettings() {
-            const selectedLayers = this.configuration.children[0].getSelectedList().map(function (layer) {
+            const selectedLayers = this.getRootLayer().getSelectedList().map(function (layer) {
                 return {
                     id: layer.getId(),
                     name: layer.getName(),

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -78,11 +78,6 @@ window.Mapbender = Mapbender || {};
             this._runtimeParams = ['LAYERS', 'STYLES', 'EXCEPTIONS', 'QUERY_LAYERS', 'INFO_FORMAT', '_OLSALT'];
         }
 
-        /**
-         * @param {String} srsName
-         * @param {Object} [mapOptions]
-         * @return {Array<Object>}
-         */
         createNativeLayers(srsName, mapOptions) {
             return [Mapbender.mapEngine.createWmsLayer(this, mapOptions)];
         }
@@ -122,8 +117,7 @@ window.Mapbender = Mapbender || {};
         }
 
         getSelected() {
-            // delegate to root layer
-            return this.configuration.children[0].getSelected();
+            return this.getRootLayer().getSelected();
         }
 
         refresh() {
@@ -134,10 +128,10 @@ window.Mapbender = Mapbender || {};
         }
 
         addParams(params) {
-            for (var i = 0; i < this.nativeLayers.length; ++i) {
+            for (let i = 0; i < this.nativeLayers.length; ++i) {
                 Mapbender.mapEngine.applyWmsParams(this.nativeLayers[i], params);
             }
-            var rtp = this._runtimeParams;
+            const rtp = this._runtimeParams;
             $.extend(this.customParams, Mapbender.Util.filter(params, function (value, key) {
                 return rtp.indexOf(('' + key).toUpperCase()) === -1;
             }));

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -46,8 +46,8 @@ window.Mapbender = Mapbender || {};
         constructor(definition) {
             super(definition);
             var sourceArg = this;
-            this.configuration.layers = (this.configuration.children[0].children || []).map((layerDef) => {
-                return Mapbender.SourceLayer.factory(layerDef, sourceArg, this.configuration.children[0]);
+            this.configuration.layers = (this.getRootLayer().children || []).map((layerDef) => {
+                return Mapbender.SourceLayer.factory(layerDef, sourceArg, this.getRootLayer());
             });
         }
 
@@ -89,13 +89,13 @@ window.Mapbender = Mapbender || {};
         }
 
         getSelected() {
-            const rootLayer = this.configuration.children[0];
+            const rootLayer = this.getRootLayer();
             return rootLayer && rootLayer.options.treeOptions.selected || false;
         }
 
         createNativeLayers(srsName, mapOptions) {
             const allLayers = this._getAllLayers();
-            const rootLayer = this.configuration.children[0];
+            const rootLayer = this.getRootLayer();
             rootLayer.children = allLayers;
 
             this.nativeLayers = allLayers.map((layerDef) => {
@@ -112,7 +112,7 @@ window.Mapbender = Mapbender || {};
         }
 
         updateEngine() {
-            const rootLayer = this.configuration.children[0];
+            const rootLayer = this.getRootLayer();
             const rootLayerVisibility = rootLayer.state.visibility;
 
             for (let i = 0; i < rootLayer.children.length; ++i) {
@@ -124,7 +124,7 @@ window.Mapbender = Mapbender || {};
         }
 
         _getAllLayers() {
-            return this.configuration.children[0].children.filter(function (l) {
+            return this.getRootLayer().children.filter(function (l) {
                 return l.options.treeOptions.allow.selected && l.options.treeOptions.selected;
             });
         }
@@ -160,7 +160,7 @@ window.Mapbender = Mapbender || {};
          */
         getPrintConfigs(bounds, scale, srsName) {
             var layerDef = this._selectCompatibleLayers(srsName)[0];
-            const rootLayer = this.configuration.children[0];
+            const rootLayer = this.getRootLayer();
             if (!rootLayer.state.visibility || !layerDef) {
                 return [];
             }
@@ -190,7 +190,7 @@ window.Mapbender = Mapbender || {};
 
         getLayerBounds(layerId, projCode, inheritFromParent) {
             let layerId_;
-            const rootLayer = this.configuration.children[0];
+            const rootLayer = this.getRootLayer();
             if (!layerId || layerId === rootLayer.options.id) {
                 const anyEnabledLayer = this._getAllLayers()[0];
                 if (!anyEnabledLayer) {
@@ -265,6 +265,16 @@ window.Mapbender = Mapbender || {};
                 extent_ = extent;
             }
             return Mapbender.Util.extentsIntersect(bounds, extent_);
+        }
+
+        getLegend() {
+            if (this.options.legend && this.options.legend.url) {
+                return {
+                    type: 'url',
+                    url: this.options.legend.url
+                };
+            }
+            return null;
         }
     }
 

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -46,7 +46,6 @@ window.Mapbender = Mapbender || {};
         constructor(definition) {
             super(definition);
             var sourceArg = this;
-            this.recreateOnSrsSwitch = true;
             this.configuration.layers = (this.configuration.children[0].children || []).map((layerDef) => {
                 return Mapbender.SourceLayer.factory(layerDef, sourceArg, this.configuration.children[0]);
             });
@@ -94,11 +93,6 @@ window.Mapbender = Mapbender || {};
             return rootLayer && rootLayer.options.treeOptions.selected || false;
         }
 
-        /**
-         * @param {String} srsName
-         * @param {Object} [mapOptions]
-         * @return {Array<Object>}
-         */
         createNativeLayers(srsName, mapOptions) {
             const allLayers = this._getAllLayers();
             const rootLayer = this.configuration.children[0];
@@ -155,11 +149,6 @@ window.Mapbender = Mapbender || {};
 
         _isCompatible(layer, projectionCode) {
             return (layer.options.treeOptions.allow.selected || layer.options.treeOptions.selected) && layer.selectMatrixSet(projectionCode);
-        }
-
-        getFeatureInfoLayers() {
-            console.warn("getFeatureInfoLayers not implemented for TMS / WMTS sources");
-            return [];
         }
 
         /**

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -245,10 +245,6 @@ window.Mapbender = Mapbender || {};
             return matches[0] || null;
         }
 
-        getSelected() {
-            return this.options.treeOptions.selected;
-        }
-
         isInScale(scale) {
             // HACK: always return true
             // @todo: implement properly

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -98,7 +98,7 @@ window.Mapbender = Mapbender || {};
             const rootLayer = this.configuration.children[0];
             rootLayer.children = allLayers;
 
-            return allLayers.map((layerDef) => {
+            this.nativeLayers = allLayers.map((layerDef) => {
                 layerDef.state.visibility = this._isCompatible(layerDef, srsName) && layerDef.options.treeOptions.selected;
                 try {
                     return this._layerFactory(layerDef, srsName);
@@ -108,6 +108,7 @@ window.Mapbender = Mapbender || {};
                     })
                 }
             });
+            return this.nativeLayers;
         }
 
         updateEngine() {

--- a/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.tms.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.tms.js
@@ -1,25 +1,20 @@
 window.Mapbender = Mapbender || {};
-window.Mapbender.TmsSource = (function() {
-    function TmsSource(definition) {
-        Mapbender.WmtsTmsBaseSource.apply(this, arguments);
-    }
-    TmsSource.prototype = Object.create(Mapbender.WmtsTmsBaseSource.prototype);
-    Mapbender.Source.typeMap['tms'] = TmsSource;
-    Object.assign(TmsSource.prototype, {
-        constructor: TmsSource,
-        _layerFactory: function(layer, srsName) {
+
+(function () {
+    Mapbender.TmsSource = class TmsSource extends Mapbender.WmtsTmsBaseSource {
+        _layerFactory(layer, srsName) {
             var matrixSet = layer.selectMatrixSet(srsName);
             var self = this;
             var gridOpts = {
                 origin: matrixSet.origin,
-                resolutions: matrixSet.tilematrices.map(function(tileMatrix) {
+                resolutions: matrixSet.tilematrices.map(function (tileMatrix) {
                     return self._getMatrixResolution(tileMatrix, srsName);
                 }),
                 extent: layer.getBounds(srsName, true)
             };
 
             var sourceOpts = {
-                tileUrlFunction: function(coord, ratio, projection) {
+                tileUrlFunction: function (coord, ratio, projection) {
                     return [
                         matrixSet.tilematrices[coord[0]].href.replace(/[/&?]*$/, ''),
                         '/', coord[1],
@@ -35,37 +30,29 @@ window.Mapbender.TmsSource = (function() {
                 source: new ol.source.XYZ(sourceOpts)
             };
             return new ol.layer.Tile(layerOpts);
-        },
+        }
+
         /**
          * @param {WmtsTileMatrix} tileMatrix
          * @param {String} srsName
          * @return {Number}
          * @private
          */
-        _getMatrixResolution: function(tileMatrix, srsName) {
+        _getMatrixResolution(tileMatrix, srsName) {
             // Yes, seriously, it's called scaleDenominator but it's the resolution
             // @todo: resolve backend config wording weirdness
             return tileMatrix.scaleDenominator;
-        },
-    });
-    return TmsSource;
-}());
-
-window.Mapbender.TmsLayer = (function() {
-    function TmsLayer(definition) {
-        Mapbender.WmtsTmsBaseSourceLayer.apply(this, arguments);
+        }
     }
-    TmsLayer.prototype = Object.create(Mapbender.WmtsTmsBaseSourceLayer.prototype);
-    Object.assign(TmsLayer.prototype, {
-        constructor: TmsLayer,
-        /**
-         * @param {String} srsName
-         * @return {string}
-         */
-        getPrintBaseUrl: function(srsName) {
+    Mapbender.Source.typeMap['tms'] = Mapbender.TmsSource;
+
+    Mapbender.TmsLayer = class TmsLayer extends Mapbender.WmtsTmsBaseSourceLayer {
+        /* @param {String} srsName
+        * @return {string}
+        */
+        getPrintBaseUrl(srsName) {
             return [this.options.tileUrls[0], this.source.configuration.version, '/', this.options.identifier].join('');
-        },
-    });
-    Mapbender.SourceLayer.typeMap['tms'] = TmsLayer;
-    return TmsLayer;
+        }
+    }
+    Mapbender.SourceLayer.typeMap['tms'] = Mapbender.TmsLayer;
 }());


### PR DESCRIPTION
Sources now use native ES6 classes instead of prototype pseudo-classes. This means, for custom sources, you
must also use this syntax now. Refer to the [new docs entry](sources/sources.md) for details.

The following has changed apart from the class syntax:
- several methods that were already present in the WMSSource have been moved to the abstract Mapbender.Source
- new event `mbmapsourcelayersreordered` that fires when the layer order within a source is moved. In earlier versions, `mbmapsourcemoved` was called then.
- `Mapbender.Source.wmsloader` renamed to `Mapbender.Source.isDynamicSource`

A layer's legend can now also be a style definition instead of a plain url. If you handle legend urls, adapt accordingly (see [documentation]((sources/sources.md)) for new syntax):
- In mapbender.element.legend.js:  New methods `createLegendForLayer`, `createLegendForStyle`
- In LegendHandler.php: New method `prepareStyleBlock`
- New parameter `mapbender.print.canvas_legend.class` defaulting to `Mapbender\PrintBundle\Component\CanvasLegend` for the rendering class for custom styled legends

The layer tree menu option handling has been changed:
- New method `Mapbender.SourceLayer.getSupportedMenuOptions` that should be overridden by sources, was handled in the LayerTree element until now
- Menu item markup now require the `data-menu-action` attribute
- New method in the layertree element for easier overriding: `_initMenuAction`

The following methods are removed:
- `Mapbender.Geo.SourceHandler.isLayerInScale`: Use `layer.isInScale`
- `Mapbender.Geo.SourceHandler.isLayerWithinBounds`: Use `layer.intersectsExtent`. The method requires an srsname which can be obtained using `Mapbender.Model.getCurrentProjectionCode()`
- `Mapbender.Source.initializeLayers()`: Use `Mapbender.Source.createNativeLayers()`