### PR TITLE
Do not offer style selection for groups

### DIFF
--- a/src/Mapbender/CoreBundle/Form/Type/InstanceLayerStyleChoiceType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/InstanceLayerStyleChoiceType.php
@@ -28,11 +28,13 @@ class InstanceLayerStyleChoiceType extends AbstractType
                 $layer = $options['layer'];
                 $arrStyles = $layer->getSourceItem()->getStyles(true);
                 $styleOpt = array('default' => '');
-                foreach ($arrStyles as $style) {
-                    if(strtolower($style->getName()) !== 'default') {
-                        $styleOpt[$style->getTitle()] = $style->getName();
-                    }
+                if (!$layer->getSublayer()->count()) {
+                    foreach ($arrStyles as $style) {
+                        if(strtolower($style->getName()) !== 'default') {
+                            $styleOpt[$style->getTitle()] = $style->getName();
+                        }
 
+                    }
                 }
                 return $styleOpt;
             },

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/source.js
@@ -697,7 +697,7 @@ window.Mapbender = Mapbender || {};
             if (this.hasBounds()) {
                 supported.push('zoomtolayer');
             }
-            if (this.options.availableStyles && this.options.availableStyles.length > 1) {
+            if (this.options.availableStyles && this.options.availableStyles.length > 1 && !this.children.length) {
                 supported.push('select_style');
             }
             return supported;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_input.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_input.scss
@@ -14,7 +14,7 @@ $inputFocusBorderColor: lighten($ciColor, 20%) !default;
   padding: 5px;
 }
 
-.input, input {
+.input, input, select, .select {
     &[disabled], &[readonly] {
         color: lighten($inputForegroundColor, 40%);
         background-color: var(--bs-secondary-bg);
@@ -22,11 +22,21 @@ $inputFocusBorderColor: lighten($ciColor, 20%) !default;
         pointer-events: none;
     }
 
-  &::placeholder {
-    color: inherit;
-    opacity: 0.55;
-  }
+    &::placeholder {
+        color: inherit;
+        opacity: 0.55;
+    }
 }
+
+select[readonly] + .dropdownValue {
+    color: lighten($inputForegroundColor, 40%) !important;
+    background-color: var(--bs-secondary-bg) !important;
+}
+
+.dropdown[readonly] {
+    pointer-events: none;
+}
+
 textarea.form-control {
    min-height: 150px;
 }

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/dropdown.js
@@ -80,6 +80,12 @@ $(function () {
         }
 
         var dropdownList = $(".dropdownList", this);
+        if ($select.attr('readonly')) {
+            $(this).attr('readonly', 'readonly');
+            if ($select.attr('title')) {
+                $(this).parent().attr('title', $select.attr('title'));
+            }
+        }
         if (dropdownList.children().length === 0) {
             $('option', $select).each(function (i, e) {
                 var node = $('<li>');

--- a/src/Mapbender/WmsBundle/Form/EventListener/FieldSubscriber.php
+++ b/src/Mapbender/WmsBundle/Form/EventListener/FieldSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Mapbender\WmsBundle\Form\EventListener;
 
+use Mapbender\CoreBundle\Form\Type\InstanceLayerStyleChoiceType;
 use Mapbender\WmsBundle\Entity\WmsInstanceLayer;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -34,12 +35,19 @@ class FieldSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $form
-            ->add('style', 'Mapbender\CoreBundle\Form\Type\InstanceLayerStyleChoiceType', array(
-                'label' => 'Style',
-                'layer' => $event->getData(),
-                'required' => false,
-            ))
-        ;
+        $layer = $event->getData();
+        $options = array(
+            'label' => 'Style',
+            'layer' => $layer,
+            'required' => false,
+        );
+        if ($layer->getSublayer()->count() > 0) {
+            $options['attr'] = [
+                'readonly' => true,
+                'title' => 'mb.wms.wmsloader.repo.instancelayerform.style_leafs_only'
+            ];
+        }
+
+        $form->add('style', InstanceLayerStyleChoiceType::class, $options);
     }
 }

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
@@ -133,7 +133,8 @@ mb:
               title: ID
               description: 'Instance Layer Id in From: SourceId-SourceLayerId/InstanceId-InstanceLayerId'
             layersname: Name
-            style: Style
+            style: Stil
+          style_leafs_only: 'Mapbender untersützt individuelle Stile nicht für Gruppen'
       class:
         title: 'WMS laden'
         description: 'Lädt einen WMS per getCapabilities-Request'

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
@@ -134,6 +134,7 @@ mb:
               description: 'Instance Layer Id in the from of: SourceId-SourceLayerId/InstanceId-InstanceLayerId'
             layersname: 'Layer''s Name'
             style: Style
+          style_leafs_only: 'Mapbender supports individual styles only for layers, not groups'
       class:
         title: 'WMS loader'
         description: 'Loads a WMS via the getCapabilities-Request'


### PR DESCRIPTION
follow-up PR to #1636 

Mapbender requests styles only for individual layers, not for groups. Switching the style for groups was possible before but had no effect. This PR disables switching the style for groups (both backend and frontend) and shows a message on hover in the backend that switching styles in only possible on leaf level. 