### PR TITLE
[PrintClient] Various improvements in LegendHandler 

### DIFF
--- a/src/Mapbender/PrintBundle/Component/Legend/LegendBlock.php
+++ b/src/Mapbender/PrintBundle/Component/Legend/LegendBlock.php
@@ -14,7 +14,7 @@ class LegendBlock extends GdCanvas implements LegendBlockContainer
     protected $rendered = false;
 
     /**
-     * @param resource $image GDish
+     * @param \GdImage $image GDish
      * @param string $title
      */
     public function __construct($image, $title)

--- a/src/Mapbender/PrintBundle/Component/LegendHandler.php
+++ b/src/Mapbender/PrintBundle/Component/LegendHandler.php
@@ -243,6 +243,11 @@ class LegendHandler
         $fontStyle = $region?->getFontStyle() ?: FontStyle::defaultFactory();
         return $fontStyle->getSize();
     }
+    
+    public function getLegendPageFont(): string
+    {
+        return $this->legendPageFontName;
+    }
 
     protected function measureLegendBlock(
         LegendBlock          $block,

--- a/src/Mapbender/PrintBundle/Component/LegendHandler.php
+++ b/src/Mapbender/PrintBundle/Component/LegendHandler.php
@@ -100,7 +100,7 @@ class LegendHandler
     }
 
     /**
-     * @param PDF_Extensions|\FPDF $pdf $pdf
+     * @param PDF_Extensions $pdf $pdf
      * @param TemplateRegion $region
      * @param LegendBlockContainer[] $blockGroups
      * @param bool $allowPageBreaks
@@ -115,6 +115,7 @@ class LegendHandler
         $y = $pageMargins['y'];
         $titleFontSize = $this->getLegendTitleFontSize($region);
         $currentColumnMaxWidth = 0;
+        $pdf->SetFont($this->getLegendPageFont(), 'B', $titleFontSize);
 
         foreach ($blockGroups as $group) {
             foreach ($group->getBlocks() as $block) {
@@ -151,7 +152,8 @@ class LegendHandler
                 // print title text
                 $pdf->SetXY($x + $region->getOffsetX(), $y + $region->getOffsetY());
                 $text = mb_convert_encoding($block->getTitle(), 'ISO-8859-1', 'UTF-8');
-                $pdf->MultiCell($measures['width'], $measures['lineHeight'], $text, 0, 'L');
+                // add a fraction of a mm because otherwise floating point arithmetic may cause an unnecessary line break
+                $pdf->MultiCell($measures['width'] + 0.00001, $measures['lineHeight'], $text, 0, 'L');
 
                 // print image
                 $this->pdfUtil->addImageToPdf($pdf, $block->resource,

--- a/src/Mapbender/PrintBundle/Component/PDF_Extensions.php
+++ b/src/Mapbender/PrintBundle/Component/PDF_Extensions.php
@@ -24,32 +24,28 @@ class PDF_Extensions extends Fpdi
     }
 
 
-    function TextWithDirection($x, $y, $txt, $direction='R')
+    function TextWithDirection($x, $y, $txt, $direction = 'R')
     {
-        if ($direction=='R')
-            $s=sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 1, 0, 0, 1, $x*$this->k, ($this->h-$y)*$this->k, $this->_escape($txt));
-        elseif ($direction=='L')
-            $s=sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', -1, 0, 0, -1, $x*$this->k, ($this->h-$y)*$this->k, $this->_escape($txt));
-        elseif ($direction=='U')
-            $s=sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 0, 1, -1, 0, $x*$this->k, ($this->h-$y)*$this->k, $this->_escape($txt));
-        elseif ($direction=='D')
-            $s=sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 0, -1, 1, 0, $x*$this->k, ($this->h-$y)*$this->k, $this->_escape($txt));
+        if ($direction == 'R')
+            $s = sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 1, 0, 0, 1, $x * $this->k, ($this->h - $y) * $this->k, $this->_escape($txt));
+        elseif ($direction == 'L')
+            $s = sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', -1, 0, 0, -1, $x * $this->k, ($this->h - $y) * $this->k, $this->_escape($txt));
+        elseif ($direction == 'U')
+            $s = sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 0, 1, -1, 0, $x * $this->k, ($this->h - $y) * $this->k, $this->_escape($txt));
+        elseif ($direction == 'D')
+            $s = sprintf('BT %.2F %.2F %.2F %.2F %.2F %.2F Tm (%s) Tj ET', 0, -1, 1, 0, $x * $this->k, ($this->h - $y) * $this->k, $this->_escape($txt));
         else
-            $s=sprintf('BT %.2F %.2F Td (%s) Tj ET', $x*$this->k, ($this->h-$y)*$this->k, $this->_escape($txt));
+            $s = sprintf('BT %.2F %.2F Td (%s) Tj ET', $x * $this->k, ($this->h - $y) * $this->k, $this->_escape($txt));
         if ($this->ColorFlag)
-            $s='q '.$this->TextColor.' '.$s.' Q';
+            $s = 'q ' . $this->TextColor . ' ' . $s . ' Q';
         $this->_out($s);
     }
 
     /**
      * Returns number of lines required for rendering given $text in a MultiCell
      * with given $width.
-     *
-     * @param string $text
-     * @param float $width
-     * @return int
      */
-    public function getMultiCellTextHeight($text, $width)
+    public function getMultiCellTextHeight(string $text, int|float $width): int
     {
         /** @var static|\FPDF $tempPdf */
         $tempPdf = new static();

--- a/src/Mapbender/PrintBundle/Component/PDF_Extensions.php
+++ b/src/Mapbender/PrintBundle/Component/PDF_Extensions.php
@@ -56,4 +56,9 @@ class PDF_Extensions extends Fpdi
         $tempPdf->MultiCell($width, 1, $text);
         return $tempPdf->GetY();
     }
+
+    public function GetStringWidth($s): float
+    {
+        return parent::GetStringWidth($s) + 2*$this->cMargin;
+    }
 }

--- a/src/Mapbender/PrintBundle/Component/TemplateRegion.php
+++ b/src/Mapbender/PrintBundle/Component/TemplateRegion.php
@@ -143,10 +143,10 @@ class TemplateRegion implements \ArrayAccess
     public function offsetGet($offset): mixed
     {
         return match ($offset) {
-            'x' => $this->offsets[0],
-            'y' => $this->offsets[1],
-            'width' => $this->width,
-            'height' => $this->height,
+            'x' => $this->getOffsetX(),
+            'y' => $this->getOffsetY(),
+            'width' => $this->getWidth(),
+            'height' => $this->getHeight(),
             'font' => $this->style->getFontName(),
             'fontsize' => $this->style->getSize(),
             'color' => $this->style->getColor(),

--- a/src/Mapbender/PrintBundle/Component/Transport/ImageTransport.php
+++ b/src/Mapbender/PrintBundle/Component/Transport/ImageTransport.php
@@ -28,7 +28,7 @@ class ImageTransport
      *
      * @param string $url
      * @param float $opacity in [0;1]
-     * @return resource|null GDish
+     * @return ?\GdImage GDish
      */
     public function downloadImage($url, $opacity=1.0)
     {


### PR DESCRIPTION
### New method `measureLegendBlock`
This is mostly improving developer experience. The measuring of a legend block (title, image and overall width/height) and the actual PDF rendering are separated. This was implemented for a client project, where the legend should only be printed on the map page if it fits on the page entirely.

### Correctly handle multi-line headings
The title width calculation now respects the page margins.

![grafik](https://github.com/user-attachments/assets/267ee5dc-9281-43d4-8705-4bb17337df6a)
Left: before, right: after

### Smaller default margins between legend blocks
Until now, the default margins were very big, creating a huge unnecessary amount of whitespace on the legend page. This was reduced.

![grafik](https://github.com/user-attachments/assets/4ec24c41-0f43-469d-aa1a-810186cbba38)
Left: before, right: after

### Automatically adjust graphic size when it's too big for a column
If a single legend graphic was too big even if it's the only image in  a column it was cropped off. Now, it gets scaled down to fit on the page.

![grafik](https://github.com/user-attachments/assets/4f780766-fc87-44f1-8633-e3de33fcd681)
Left: before, right: after

### Add option for dynamic column widths
Column widths in the legend were fixed until now (variable `$maxColumnWidthMm` within the LegendHandler). This PR adds a new option `dynamicColumnSizes` to the LegendHandler that adds a non-default option to adapt column widths depending on the content.

![grafik](https://github.com/user-attachments/assets/3aebc816-4133-446d-b9e7-59f381f79ebf)
Left: dynamicColumnSizes = false (widths fixed to 10cm), Right: dynamicColumnSizes = true


To enable this feature, you need to overwrite the LegendHandler in your client project:

`parameters.yaml`:
```yaml
parameters:
   mapbender.print.legend_handler.service.class: App\Component\Print\LegendHandler
```

`LegendHandler.php`:
```php
<?php

namespace App\Component\Print;

class LegendHandler extends \Mapbender\PrintBundle\Component\LegendHandler
{

    public function __construct(
        #[Autowire(service: 'mapbender.imageexport.image_transport.service')] ImageTransport $imageTransport,
        #[Autowire('mapbender.print.resource_dir')] string                                   $resourceDir,
        #[Autowire('mapbender.print.temp_dir')] ?string                                      $tmpDir,
        #[Autowire('mapbender.print.canvas_legend.class')] ?string                           $canvasLegendClass
    )
    {
        parent::__construct($imageTransport, $resourceDir, $tmpDir, $canvasLegendClass);
        $this->dynamicColumnSizes = true;
    }
}
```

### Make margin between legend title and graphic configurable
Until now, there was no gap between legend title and legend graphic. This is now configurable in the LegendHandler.

![grafik](https://github.com/user-attachments/assets/f506adfa-47f6-4f2a-b44c-ecb400736b6b)
Left: no margin (old behaviour), right: 2mm margin between title and graphic.

Adjusting this feature also requires overwriting the LegendHandler, specifically the array key `title_to_image` within the `getMargins` method:

`parameters.yaml`:
```yaml
parameters:
   mapbender.print.legend_handler.service.class: App\Component\Print\LegendHandler
```

`LegendHandler.php`:
```php
<?php

namespace App\Component\Print;

use Mapbender\PrintBundle\Component\TemplateRegion;

class LegendHandler extends \Mapbender\PrintBundle\Component\LegendHandler
{
    protected function getMargins(TemplateRegion $region): array
    {
        return [
            ...parent::getMargins($region),
            'title_to_image' => 2, //mm
        ];
    }
}
```
