### PR TITLE
Fix WMTS sources with tile size other than 256px were not rendered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Features:
 * [WMSLoader] Added option to customise feature info format when adding wms via mb-action link ([PR#1653](https://github.com/mapbender/mapbender/pull/1653))
 
 Bugfixes:
-* [WMTS] Fix WMTS sources with a TileSize other than 256px were not rendered correctly ([#PR1663](https://github.com/mapbender/mapbender/pull/1663))
+* [WMTS] WMTS sources with a TileSize other than 256px and/or individual origins per TileMatrix were not rendered correctly ([#PR1663](https://github.com/mapbender/mapbender/pull/1663))
 * [POI] Fix application crash when poi label is empty ([PR#1649](https://github.com/mapbender/mapbender/pull/1649))
 * [LayerTree] Added source layers with children did not show up in the layer tree ([PR#1637](https://github.com/mapbender/mapbender/pull/1637))
 * [LayerTree] Update layer title after changing source ([PR#1660](https://github.com/mapbender/mapbender/pull/1660))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 * [WMSLoader] Added option to customise feature info format when adding wms via mb-action link ([PR#1653](https://github.com/mapbender/mapbender/pull/1653))
 
 Bugfixes:
+* [WMTS] Fix WMTS sources with a TileSize other than 256px were not rendered correctly ([#PR1663](https://github.com/mapbender/mapbender/pull/1663))
 * [POI] Fix application crash when poi label is empty ([PR#1649](https://github.com/mapbender/mapbender/pull/1649))
 * [LayerTree] Added source layers with children did not show up in the layer tree ([PR#1637](https://github.com/mapbender/mapbender/pull/1637))
 * [LayerTree] Update layer title after changing source ([PR#1660](https://github.com/mapbender/mapbender/pull/1660))

--- a/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.wmts.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.wmts.js
@@ -2,20 +2,18 @@
     window.Mapbender = Mapbender || {};
     window.Mapbender.WmtsSource = class WmtsSource extends Mapbender.WmtsTmsBaseSource {
         _layerFactory(layer, srsName) {
-            var matrixSet = layer.selectMatrixSet(srsName);
-            var self = this;
-            var gridOpts = {
+            const matrixSet = layer.selectMatrixSet(srsName);
+            const fallbackTileSize = Array.isArray(matrixSet.tileSize) ? matrixSet.tileSize[0] : 256;
+
+            const gridOpts = {
                 origin: matrixSet.origin,
-                resolutions: matrixSet.tilematrices.map(function (tileMatrix) {
-                    return self._getMatrixResolution(tileMatrix, srsName);
-                }),
-                matrixIds: matrixSet.tilematrices.map(function (matrix) {
-                    return matrix.identifier;
-                }),
-                extent: layer.getBounds(srsName, true)
+                resolutions: matrixSet.tilematrices.map((tileMatrix) => this._getMatrixResolution(tileMatrix, srsName)),
+                matrixIds: matrixSet.tilematrices.map((matrix) => matrix.identifier),
+                tileSizes: matrixSet.tilematrices.map((matrix) => matrix.tileWidth ?? fallbackTileSize),
+                extent: layer.getBounds(srsName, true),
             };
 
-            var sourceOpts = {
+            const sourceOpts = {
                 version: this.configuration.version,
                 requestEncoding: 'REST',
                 urls: layer.options.tileUrls.map(function (tileUrlTemplate) {
@@ -24,7 +22,7 @@
                 projection: srsName,
                 tileGrid: new ol.tilegrid.WMTS(gridOpts)
             };
-            var layerOpts = {
+            const layerOpts = {
                 opacity: this.configuration.options.opacity,
                 source: new ol.source.WMTS(sourceOpts)
             };

--- a/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.wmts.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/mapbender.geosource.wmts.js
@@ -6,7 +6,7 @@
             const fallbackTileSize = Array.isArray(matrixSet.tileSize) ? matrixSet.tileSize[0] : 256;
 
             const gridOpts = {
-                origin: matrixSet.origin,
+                origins: matrixSet.tilematrices.map((matrix) => matrix.topLeftCorner ?? matrixSet.origin),
                 resolutions: matrixSet.tilematrices.map((tileMatrix) => this._getMatrixResolution(tileMatrix, srsName)),
                 matrixIds: matrixSet.tilematrices.map((matrix) => matrix.identifier),
                 tileSizes: matrixSet.tilematrices.map((matrix) => matrix.tileWidth ?? fallbackTileSize),


### PR DESCRIPTION
Pass WMTS tile size to TileGrid constructor (default tile size of 256px was assumed)