### PR TITLE
[WmsLoader] Add basic auth to legend urls for protected WMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 * [LayerTree] Added source layers with children did not show up in the layer tree ([PR#1637](https://github.com/mapbender/mapbender/pull/1637))
 * [LayerTree] Update layer title after changing source ([PR#1660](https://github.com/mapbender/mapbender/pull/1660))
 * [BaseSourceSwitcher] Submenu is closed as soon as the mouse pointer moves out of the menu ([#PR1644](https://github.com/mapbender/mapbender/pull/1644))
+* [WMSLoader] For protected WMS, the user data was not added to legend requests ([#PR1667](https://github.com/mapbender/mapbender/pull/1667))
 * Global permission "delete users" was not evaluated (only root users could delete users) ([PR#1646](https://github.com/mapbender/mapbender/pull/1646))
 
 Other:

--- a/src/Mapbender/CoreBundle/Entity/SourceInstance.php
+++ b/src/Mapbender/CoreBundle/Entity/SourceInstance.php
@@ -162,4 +162,9 @@ abstract class SourceInstance extends SourceInstanceAssignment
     {
         return (string)$this->getId();
     }
+
+    public function isProtectedDynamicWms(): bool
+    {
+        return !$this->getId() && ($this->getSource()->getUsername() || \preg_match('#//[^/]+@#', $this->getSource()->getOriginUrl()));
+    }
 }


### PR DESCRIPTION
For protected WMS, the basic auth data was not added to GetLegendGraphic requests, since the legend urls is loaded directly from the Capabilities and there, the basic auth data is of course not added. 

This PR manually adds the basic auth data to the legend urls by injecting them afterwards.

see internal ticket 8930 