### PR TITLE
[SearchRouter] Compare extents to features in EPSG:4326 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 * [POI] Fix application crash when poi label is empty ([PR#1649](https://github.com/mapbender/mapbender/pull/1649))
 * [LayerTree] Added source layers with children did not show up in the layer tree ([PR#1637](https://github.com/mapbender/mapbender/pull/1637))
 * [LayerTree] Update layer title after changing source ([PR#1660](https://github.com/mapbender/mapbender/pull/1660))
+* [SearchRouter] Searching for data stored in a non-global SRS (like UTM32) when map extent is in a global SRS did not always yield all results ([PR#1669](https://github.com/mapbender/mapbender/pull/1669))
 * [BaseSourceSwitcher] Submenu is closed as soon as the mouse pointer moves out of the menu ([#PR1644](https://github.com/mapbender/mapbender/pull/1644))
 * Global permission "delete users" was not evaluated (only root users could delete users) ([PR#1646](https://github.com/mapbender/mapbender/pull/1646))
 

--- a/src/Mapbender/CoreBundle/Component/SQLSearchEngine.php
+++ b/src/Mapbender/CoreBundle/Component/SQLSearchEngine.php
@@ -226,9 +226,9 @@ class SQLSearchEngine
      */
     protected function getBoundsExpression(QueryBuilder $qb, $geomReference, $extent, $srsName, array $config)
     {
-        // per default, the map extent is compared to a feature by converting both to EPSG:3857 (WGS84).
+        // per default, the map extent is compared to a feature by converting both to EPSG:4326 (WGS84).
         // comparing in a non-global SRS (like UTM32) can result in errors when comparing it to an extent defined
-        // in a global CRS. This may reduce performance, so the transformation to EPSG:3857 can be disabled
+        // in a global CRS. This may reduce performance, so the transformation to EPSG:4326 can be disabled
         // by passing noTransform:true to class_options
         $noTransform = isset($config['class_options']['noTransform']) && $config['class_options']['noTransform'];
 
@@ -238,8 +238,8 @@ class SQLSearchEngine
         );
         $srsId = $this->srsIdFromName($srsName);
         $box = 'ST_SetSRID(ST_MakeBox2D(' . implode(', ', $boxPoints) . '), ' . $qb->createNamedParameter($srsId) . ')';
-        $transformedBox = $noTransform ? "ST_Transform({$box}, ST_Srid({$geomReference}))" : "ST_Transform($box, 3857)";
-        return $noTransform ? "$transformedBox && $geomReference" : "$transformedBox && ST_Transform($geomReference, 3857)";
+        $transformedBox = $noTransform ? "ST_Transform({$box}, ST_Srid({$geomReference}))" : "ST_Transform($box, 4326)";
+        return $noTransform ? "$transformedBox && $geomReference" : "$transformedBox && ST_Transform($geomReference, 4326)";
     }
 
     /**


### PR DESCRIPTION
Per default, the map extent is now compared to a feature by converting both to EPSG:4326 (WGS84).
Comparing in a non-global SRS (like UTM32) can result in errors when comparing it to an extent defined in a global CRS. This may reduce performance, so the transformation to EPSG:4326 can be disabled by passing `noTransform:true` to `class_options`.

see internal ticket 9356