### PR TITLE
Support data-label attribute in feature info highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 * [Routing] Added Routing element ([PR#1655](https://github.com/mapbender/mapbender/pull/1655))
 * [LayerTree] Allow de-/activation of a layer via clicking the layername ([PR#1641](https://github.com/mapbender/mapbender/pull/1641))
 * [WMSLoader] Added option to customise feature info format when adding wms via mb-action link ([PR#1653](https://github.com/mapbender/mapbender/pull/1653))
+* [FeatureInfo] Support labels in FeatureInfo-Highlighting ([PR#1670](https://github.com/mapbender/mapbender/pull/1670))
 
 Bugfixes:
 * [WMTS] WMTS sources with a TileSize other than 256px and/or individual origins per TileMatrix were not rendered correctly ([#PR1663](https://github.com/mapbender/mapbender/pull/1663))

--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -75,6 +75,10 @@ class FeatureInfo extends AbstractElementService
             'strokeColorHover' => 'rgba(255,0,0,0.7)',
             'strokeWidthDefault' => 1,
             'strokeWidthHover' => 3,
+            'fontColorDefault' => '#000000',
+            'fontColorHover' => '#000000',
+            'fontSizeDefault' => 12,
+            'fontSizeHover' => 12,
         );
     }
 

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -58,16 +58,22 @@ class FeatureInfoAdminType extends AbstractType
             ->add('defaultStyle', PaintType::class, array(
                 'label' => 'mb.core.admin.featureinfo.label.default_group',
                 'inherit_data' => true,
+                'hasFont' => true,
                 'fieldNameFillColor' => 'fillColorDefault',
                 'fieldNameStrokeColor' => 'strokeColorDefault',
                 'fieldNameStrokeWidth' => 'strokeWidthDefault',
+                'fieldNameFontColor' => 'fontColorDefault',
+                'fieldNameFontSize' => 'fontSizeDefault',
             ))
             ->add('hoverStyle', PaintType::class, array(
                 'label' => 'mb.core.admin.featureinfo.label.hover_group',
                 'inherit_data' => true,
+                'hasFont' => true,
                 'fieldNameFillColor' => 'fillColorHover',
                 'fieldNameStrokeColor' => 'strokeColorHover',
                 'fieldNameStrokeWidth' => 'strokeWidthHover',
+                'fieldNameFontColor' => 'fontColorHover',
+                'fieldNameFontSize' => 'fontSizeHover',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Resources/public/element/featureinfo-highlighting.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/featureinfo-highlighting.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return {
                 srid: node.getAttribute('data-srid'),
                 wkt: node.getAttribute('data-geometry'),
+                label: node.getAttribute('data-label'),
                 id: featureIdFromElement(node)
             };
         });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -404,14 +404,16 @@
                 stroke: this.options.strokeColorHover || this.options.fillColorHover || settingsDefault.stroke,
                 strokeWidth: this.options.strokeWidthHover,
             };
-            var defaultStyle = this.processStyle_(settingsDefault, false);
-            var hoverStyle = this.processStyle_(settingsHover, true);
-            hoverStyle.setZIndex(1);
+
+            const self = this;
             return function (feature) {
-                return [feature.get('hover') && hoverStyle || defaultStyle];
+                return [feature.get('hover')
+                    ? self.processStyle_(settingsHover, true, feature)
+                    : self.processStyle_(settingsDefault, false, feature)
+                ];
             }
         },
-        processStyle_: function (settings, hover) {
+        processStyle_: function (settings, hover, feature) {
             var fillRgba = Mapbender.StyleUtil.parseCssColor(settings.fill);
             var strokeRgba = Mapbender.StyleUtil.parseCssColor(settings.stroke);
             var strokeWidth = parseInt(settings.strokeWidth);
@@ -424,7 +426,16 @@
                 stroke: strokeWidth && new ol.style.Stroke({
                     color: strokeRgba,
                     width: strokeWidth
-                })
+                }),
+                text: strokeWidth && new ol.style.Text({
+                    font: '24px Arial',
+                    stroke: new ol.style.Stroke({
+                        color: strokeRgba,
+                        width: strokeWidth
+                    }),
+                    text: feature.get("label"),
+                }),
+                zIndex: hover ? 1 : undefined,
             });
         },
         _postMessage: function (message) {
@@ -447,6 +458,7 @@
                 var feature = Mapbender.Model.parseWktFeature(featureData.wkt, featureData.srid);
                 feature.setId(featureData.id);
                 feature.set('sourceId', data.sourceId);
+                feature.set('label', featureData.label);
                 return feature;
             });
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.featureInfo.js
@@ -10,6 +10,10 @@
             highlighting: false,
             fillColorDefault: 'rgba(255,165,0,0.4)',
             fillColorHover: 'rgba(255,0,0,0.7)',
+            fontColorDefault: '#000000',
+            fontSizeDefault: 12,
+            fontColorHover: '#000000',
+            fontSizeHover: 12,
             maxCount: 100,
             width: 700,
             height: 500
@@ -398,11 +402,15 @@
                 fill: this.options.fillColorDefault,
                 stroke: this.options.strokeColorDefault || this.options.fillColorDefault,
                 strokeWidth: this.options.strokeWidthDefault,
+                fontColor: this.options.fontColorDefault || this.options.strokeColorDefault,
+                fontSize: this.options.fontSizeDefault,
             };
             var settingsHover = {
                 fill: this.options.fillColorHover || settingsDefault.fill,
                 stroke: this.options.strokeColorHover || this.options.fillColorHover || settingsDefault.stroke,
                 strokeWidth: this.options.strokeWidthHover,
+                fontColor: this.options.fontColorHover || this.options.strokeColorHover || settingsDefault.fontColor,
+                fontSize: this.options.fontSizeHover || settingsDefault.fontSize,
             };
 
             const self = this;
@@ -428,10 +436,9 @@
                     width: strokeWidth
                 }),
                 text: strokeWidth && new ol.style.Text({
-                    font: '24px Arial',
-                    stroke: new ol.style.Stroke({
-                        color: strokeRgba,
-                        width: strokeWidth
+                    font: parseInt(settings.fontSize) + 'px sans-serif',
+                    fill: new ol.style.Fill({
+                        color: settings.fontColor,
                     }),
                     text: feature.get("label"),
                 }),


### PR DESCRIPTION
In addition to data-geometry and data-srid the new attribute data-label is read from a feature in the feature info html (QGIS: maptip). 

It can be styled using the new options 
- `fontColorDefault` (default: #000000)
- `fontColorHover` (default: #000000)
- `fontSizeDefault` (default: 12)
- `fontSizeHover` (default: 12)


see internal ticket 7433