### PR TITLE
Fix transport type and Solr-Search

### DIFF
--- a/src/Mapbender/RoutingBundle/Component/RoutingDriver/OsrmDriver.php
+++ b/src/Mapbender/RoutingBundle/Component/RoutingDriver/OsrmDriver.php
@@ -45,7 +45,8 @@ class OsrmDriver extends RoutingDriver
         $service = ($config['service']) ?: 'route';
         $version = ($config['version']) ?: 'v1';
         $profile = (!empty($requestParams['vehicle'])) ? $requestParams['vehicle'] : 'car';
-        $url = trim($config['url'], '/') . '/' . $service . '/' . $version . '/' . $profile . '/';
+        $profile = 'routed-' . $profile;
+        $url = trim($config['url'], '/') . '/' . $profile . '/' . $service . '/' . $version . '/driving/';
         $coordinates = [];
 
         foreach ($requestParams['points'] as $point) {

--- a/src/Mapbender/RoutingBundle/Component/SearchDriver/SolrDriver.php
+++ b/src/Mapbender/RoutingBundle/Component/SearchDriver/SolrDriver.php
@@ -61,7 +61,7 @@ class SolrDriver {
             // check SplitPattern
             if (isset($configuration['token_regex'])) {
                 $splitPattern = $configuration['token_regex'];
-                $q = preg_replace($splitPattern, ' ', $q);
+                $q = preg_replace('/' . $splitPattern . '/', ' ', $q);
             }
 
             $tokens = explode(" ", $q);
@@ -73,16 +73,16 @@ class SolrDriver {
                     continue;
                 }
 
-                $query .= preg_replace($searchPattern, $replacePattern, $term);
+                $query .= preg_replace('/' . $searchPattern . '/', $replacePattern, $term);
             }
 
-            $query = '*' . trim($query,$replacePattern) . '*';
+            $query = trim($query,$replacePattern);
         } else {
             // check if isset 'token_regex'/ Replace-Pattern
             // not set then take Default[^a-zA-Z0-9äöüÄÖÜß] as Pattern
             if (isset($configuration['token_regex'])) {
                 $pattern = $configuration['token_regex'];
-                $q = preg_replace($pattern, ' ', $q);
+                $q = preg_replace('/' . $pattern . '/', ' ', $q);
             } else {
                 $q = preg_replace("/[^a-zA-Z0-9äöüÄÖÜß]/", ' ', $q);
             }
@@ -95,17 +95,8 @@ class SolrDriver {
                     $q = preg_replace('/\s+/', $pattern, $q);
                 }
             }
-
-            // Split with " "-Delimter to 2 Words für SQLR-Query
-            // Example= 'Anne Frank' => '*Anne*+*Frank*'
-            foreach(explode(' ', $q) as $term) {
-                if ($term == '') {
-                    continue;
-                }
-                $query .= ' *' . $term . '*';
-            }
         }
 
-        return trim($query);
+        return trim($q);
     }
 }


### PR DESCRIPTION
This pull request fixes ...

- ... the usage of different transport types - such as car, bike, foot - for the OSRM-Search
- ... the usage of german umlaut in the solr search 

It also adds support for nested placeholders to access the response object of the solr search, e.g. `${nested.attribute.path}`