### PR TITLE
Fix/routing

### DIFF
--- a/src/Mapbender/RoutingBundle/Element/Routing.php
+++ b/src/Mapbender/RoutingBundle/Element/Routing.php
@@ -93,10 +93,10 @@ class Routing extends AbstractElementService
             'routingConfig' => [
                 'osrm' => [
                     'url' => 'https://',
-                    'attribution' => 'Daten © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>-Mitwirkende
-  (<a href="https://opendatacommons.org/licenses/odbl/index.html">ODbL</a>), <a
-  href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, <a
-  href="https://openstreetmap.org/fixthemap">mitmachen/Fehler melden</a>',
+                    'attribution' => 'Daten © <a href="https://www.openstreetmap.org/copyright" class="link-primary">OpenStreetMap</a>-Mitwirkende
+  (<a href="https://opendatacommons.org/licenses/odbl/index.html" class="link-primary">ODbL</a>), <a
+  href="https://creativecommons.org/licenses/by-sa/2.0/" class="link-primary">CC-BY-SA</a>, <a
+  href="https://openstreetmap.org/fixthemap" class="link-primary">mitmachen/Fehler melden</a>',
                 ],
             ],
             'searchConfig' => [

--- a/src/Mapbender/RoutingBundle/Element/Routing.php
+++ b/src/Mapbender/RoutingBundle/Element/Routing.php
@@ -93,6 +93,10 @@ class Routing extends AbstractElementService
             'routingConfig' => [
                 'osrm' => [
                     'url' => 'https://',
+                    'attribution' => 'Daten © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>-Mitwirkende
+  (<a href="https://opendatacommons.org/licenses/odbl/index.html">ODbL</a>), <a
+  href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, <a
+  href="https://openstreetmap.org/fixthemap">mitmachen/Fehler melden</a>',
                 ],
             ],
             'searchConfig' => [
@@ -131,6 +135,7 @@ class Routing extends AbstractElementService
             'title' => $element->getTitle(),
             'transportationModes' => $this->getTransportationModes($element),
             'allowIntermediatePoints' => $config['allowIntermediatePoints'],
+            'attribution' => $config['routingConfig']['osrm']['attribution'],
         ];
         return $view;
     }

--- a/src/Mapbender/RoutingBundle/Element/Type/RoutingAdminType.php
+++ b/src/Mapbender/RoutingBundle/Element/Type/RoutingAdminType.php
@@ -4,6 +4,7 @@ namespace Mapbender\RoutingBundle\Element\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -320,6 +321,11 @@ class RoutingAdminType extends AbstractType
                     'mb.routing.backend.dialog.input.yes' => 'true',
                 ],
                 'property_path' => '[routingConfig][osrm][steps]',
+            ])
+            ->add('osrmAttribution', TextareaType::class, [
+                'required' => false,
+                'label' => 'mb.routing.backend.dialog.label.osrm.attribution',
+                'property_path' => '[routingConfig][osrm][attribution]',
             ])
         ;
     }

--- a/src/Mapbender/RoutingBundle/Resources/public/mapbender.element.routing.js
+++ b/src/Mapbender/RoutingBundle/Resources/public/mapbender.element.routing.js
@@ -228,6 +228,7 @@
             }
             this._emptyPoints();
             $('.mb-routing-location-points > .intermediatePoints', this.element).remove();
+            $('.attribution', this.element).addClass('d-none');
             $('.mb-routing-info', this.element).addClass('d-none').html('');
             $('.mb-routing-instructions', this.element).html('');
             $('.mb-element-map').css('cursor', 'auto');
@@ -274,6 +275,7 @@
                     Mapbender.error(response.error.message);
                 } else {
                     this._renderRoute(response.featureCollection);
+                    this._showAttribution();
                     this._showRouteInfo(response.routeInfo);
                     this._showRouteInstructions(response.routingInstructions);
                 }
@@ -649,6 +651,10 @@
             }
             $table.append($tbody);
             $instructionsDiv.append($table);
+        },
+
+        _showAttribution: function () {
+            $('.attribution', this.element).removeClass('d-none');
         }
     });
 })(jQuery);

--- a/src/Mapbender/RoutingBundle/Resources/translations/messages.de.yml
+++ b/src/Mapbender/RoutingBundle/Resources/translations/messages.de.yml
@@ -110,6 +110,7 @@ mb:
             annotations: Anmerkungen
             overview: Übersicht
             continueStraight: direkt weitermachen
+            attribution: Attribuierung
           gh:
             titel: GraphHopper
             key: API-Schlüssel

--- a/src/Mapbender/RoutingBundle/Resources/translations/messages.en.yml
+++ b/src/Mapbender/RoutingBundle/Resources/translations/messages.en.yml
@@ -110,6 +110,7 @@ mb:
             annotations: Annotations
             overview: Overview
             continueStraight: continue Straight
+            attribution: Attribution
           gh:
             titel: GraphHopper
             key: API key

--- a/src/Mapbender/RoutingBundle/Resources/views/Element/routing.html.twig
+++ b/src/Mapbender/RoutingBundle/Resources/views/Element/routing.html.twig
@@ -54,9 +54,11 @@
     {% endif %}
 </div>
 <div class="clear"></div>
-<div class="attribution form-text d-none mt-3">
-    {{ attribution|raw }}
-</div>
+{% if attribution is not empty %}
+    <div class="attribution form-text d-none mt-3">
+        {{ attribution|raw }}
+    </div>
+{% endif %}
 <div class="mb-routing-results">
     <div class="mb-routing-info alert alert-info d-none mt-3"></div>
     <div class="mb-routing-instructions"></div>

--- a/src/Mapbender/RoutingBundle/Resources/views/Element/routing.html.twig
+++ b/src/Mapbender/RoutingBundle/Resources/views/Element/routing.html.twig
@@ -39,7 +39,7 @@
 </form>
 <div class="right">
     <button id="resetRoute" class="btn btn-light" type="button" title="{{ 'mb.routing.frontend.dialog.label.clearroute' | trans }}">
-        <i class="fa-solid fa-rotate-left"></i>
+        <i class="far fa-trash-can"></i>
     </button>
     <button id="swapPoints" class="btn btn-primary" type="button" title="{{ 'mb.routing.frontend.dialog.label.flippoints' | trans }}">
         <i class="fa-solid fa-arrow-right-arrow-left fa-rotate-90"></i>
@@ -54,6 +54,9 @@
     {% endif %}
 </div>
 <div class="clear"></div>
+<div class="attribution form-text d-none mt-3">
+    {{ attribution|raw }}
+</div>
 <div class="mb-routing-results">
     <div class="mb-routing-info alert alert-info d-none mt-3"></div>
     <div class="mb-routing-instructions"></div>

--- a/src/Mapbender/RoutingBundle/Resources/views/ElementAdmin/routing.html.twig
+++ b/src/Mapbender/RoutingBundle/Resources/views/ElementAdmin/routing.html.twig
@@ -66,6 +66,7 @@
         {# alternative Routes are not yet implemented: #}
         {# form_row(form.configuration.osrmAlternatives) #}
         {{ form_row(form.configuration.osrmSteps) }}
+        {{ form_row(form.configuration.osrmAttribution) }}
     </div>
 </div>
 


### PR DESCRIPTION
Adds attribution for OSRM-Routing
Code snippet for OSRM-Attribution:
```
Daten © <a href="https://www.openstreetmap.org/copyright" class="link-primary">OpenStreetMap</a>-Mitwirkende
  (<a href="https://opendatacommons.org/licenses/odbl/index.html" class="link-primary">ODbL</a>), <a
  href="https://creativecommons.org/licenses/by-sa/2.0/" class="link-primary">CC-BY-SA</a>, <a
  href="https://openstreetmap.org/fixthemap" class="link-primary">mitmachen/Fehler melden</a>
```