### PR TITLE
Fix order of elements in application config

### DIFF
--- a/src/Mapbender/ManagerBundle/Controller/ElementController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ElementController.php
@@ -284,6 +284,7 @@ class ElementController extends ApplicationControllerBase
         $higherWeightCriteria = Criteria::create()
             ->where(Criteria::expr()->eq('region', $element->getRegion()))
             ->andWhere(Criteria::expr()->gt('weight', $element->getWeight()))
+            ->andWhere(Criteria::expr()->eq('application', $application))
         ;
         $higherWeightElements = $this->getRepository()->matching($higherWeightCriteria);
         foreach ($higherWeightElements as $otherElement) {


### PR DESCRIPTION
This error occurs when an element is deleted in an application. The order of the elements is then changed in ALL other applications.

The only thing missing was a where clause for the current application.

see also internal ticket 9071