### PR TITLE
Fix jqueryui hidden-accessible class

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/jqueryui_minimal.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/jqueryui_minimal.scss
@@ -67,3 +67,9 @@
         margin-left: -0.5em; // != base theme -8px (not font-size responsive)
     }
 }
+
+/* Really hide the element that is intended to be hidden, but leave it accessible for screenreaders */
+.ui-helper-hidden-accessible {
+    position: absolute;
+    left: -9999px;
+}


### PR DESCRIPTION
Fixes the jqueryui class 'ui-helper-hidden-accessible'. 
Currently the div element with this class is not really hidden.

Steps to reproduce:
- open app with a simple search element
- deactivate background layer
- use the search
-> results are displayed in the top left corner (maybe behind the toolbar)

internal ticket: 9825