### PR TITLE
[Security] Make global permission extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bugfixes:
 Other:
 * Sources now use native ES6 classes instead of prototype pseudo-classes. Easier API for custom layer tree menu items and legends. ([PR#1635](https://github.com/mapbender/mapbender/pull/1635), [PR#1639](https://github.com/mapbender/mapbender/pull/1639), [PR#1662](https://github.com/mapbender/mapbender/pull/1662))
 * [Manager] Provide detailed information in all "delete"-dialogs ([PR#1631](https://github.com/mapbender/mapbender/pull/1631)) 
+* [Security] Make global permission extendable ([PR#1693](https://github.com/mapbender/mapbender/pull/1693)) 
 * Translation improvements ([PR#1654](https://github.com/mapbender/mapbender/pull/1654))
 
 ## v4.0.3

--- a/docs/security/permission-system.md
+++ b/docs/security/permission-system.md
@@ -92,6 +92,51 @@ And further down after checking if the form is submitted and valid:
 $this->permissionManager->savePermissions($myEntity, $form->get('security')->getData());
 ```
 
+## Adding global permissions
+If you want to add an installation-wide permission that is not dependent on a single resource, create a class implementing the `FOM\UserBundle\Security\Permission\GlobalPermissionProvider` interface.
+
+The interface has two methods that need to implemented:
+- `getCategories()`: Returns the permission categories you want to add to the list that appears when navigating to Security / Global Permissions.
+  can be left empty if you only want to extend a category that already exists.  
+  The keys should be unique string aliases for the category, the values translation keys for the human-readable values.
+- `getPermissions()`: Returns the actual permissions you want to add. The keys are unique (unique across all categories!) string aliases,
+  the values should be an array with the following keys:
+  - `category`: The alias for the category this permission should be added to
+  - `cssClass` (optional, default 'success'): The css class the permission should get when displayed in the backend (background color)
+  - `label`: The translation label that is displayed in the backend
+  - `help` (optional): The translation label for the popup with additional information that is shown after clicking the help icon in the backend.
+
+Example:
+
+```php
+class QueryBuilderPermissionProvider implements GlobalPermissionProvider
+{
+    const CATEGORY_NAME = "query_builder";
+    const PERMISSION_CREATE = "qb_create";
+    const PERMISSION_EDIT = "qb_edit";
+
+    public function getCategories(): array
+    {
+        return [self::CATEGORY_NAME => 'query_builder'];
+    }
+
+    public function getPermissions(): array
+    {
+        return [
+            self::PERMISSION_CREATE => [
+                'category' => self::CATEGORY_NAME,
+                'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
+                'help' => 'mb.querybuilder.permission.create',
+            ],
+            self::PERMISSION_EDIT => [
+                'category' => self::CATEGORY_NAME,
+                'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
+                'help' => 'mb.querybuilder.permission.edit',
+            ],
+        ];
+    }
+}
+```
 
 ## Yaml Applications
 Yaml application's security is also stated in the yaml file, therefore the regular PermissionManager can't be used. 

--- a/docs/security/permission-system.md
+++ b/docs/security/permission-system.md
@@ -103,8 +103,8 @@ The interface has two methods that need to implemented:
   the values should be an array with the following keys:
   - `category`: The alias for the category this permission should be added to
   - `cssClass` (optional, default 'success'): The css class the permission should get when displayed in the backend (background color)
-  - `label`: The translation label that is displayed in the backend
-  - `help` (optional): The translation label for the popup with additional information that is shown after clicking the help icon in the backend.
+
+For localisation, use the keys `fom.security.resource.installation.<alias>` resp. `fom.security.resource.installation.<alias>_help` for the help text.
 
 Example:
 
@@ -126,12 +126,10 @@ class QueryBuilderPermissionProvider implements GlobalPermissionProvider
             self::PERMISSION_CREATE => [
                 'category' => self::CATEGORY_NAME,
                 'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
-                'help' => 'mb.querybuilder.permission.create',
             ],
             self::PERMISSION_EDIT => [
                 'category' => self::CATEGORY_NAME,
                 'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
-                'help' => 'mb.querybuilder.permission.edit',
             ],
         ];
     }

--- a/docs/security/permission-system.md
+++ b/docs/security/permission-system.md
@@ -93,7 +93,7 @@ $this->permissionManager->savePermissions($myEntity, $form->get('security')->get
 ```
 
 ## Adding global permissions
-If you want to add an installation-wide permission that is not dependent on a single resource, create a class implementing the `FOM\UserBundle\Security\Permission\GlobalPermissionProvider` interface.
+If you want to add an installation-wide permission that is not dependent on a single resource, create a class implementing the `FOM\UserBundle\Security\Permission\GlobalPermissionProvider` interface and tag it with `fom.security.global_permission`.
 
 The interface has two methods that need to implemented:
 - `getCategories()`: Returns the permission categories you want to add to the list that appears when navigating to Security / Global Permissions.
@@ -109,6 +109,7 @@ For localisation, use the keys `fom.security.resource.installation.<alias>` resp
 Example:
 
 ```php
+#[AutoconfigureTag('fom.security.global_permission')
 class QueryBuilderPermissionProvider implements GlobalPermissionProvider
 {
     const CATEGORY_NAME = "query_builder";
@@ -134,6 +135,14 @@ class QueryBuilderPermissionProvider implements GlobalPermissionProvider
         ];
     }
 }
+```
+
+If you don't use Autowiring, you need to add the tag definition in XML, for example:
+
+```xml
+<service id="mb.querybuilder.permission_provider" class="Mapbender\QueryBuilderBundle\Permission\QueryBuilderPermissionProvider">
+    <tag name="fom.security.global_permission" />
+</service>
 ```
 
 ## Yaml Applications

--- a/src/FOM/UserBundle/Controller/PermissionController.php
+++ b/src/FOM/UserBundle/Controller/PermissionController.php
@@ -14,27 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PermissionController extends AbstractController
 {
-    public function __construct(protected PermissionManager $permissionManager)
+    public function __construct(
+        protected PermissionManager          $permissionManager,
+        protected ResourceDomainInstallation $installationPermissions,
+    )
     {
-    }
-
-    public const CATEGORY_APPLICATION = "applications";
-    public const CATEGORY_SOURCES = "sources";
-    public const CATEGORY_PERMISSIONS = "permissions";
-    public const CATEGORY_USERS = "users";
-    public const CATEGORY_GROUPS = "groups";
-    public const CATEGORY_API = "api";
-
-    public static function categoryList(): array
-    {
-        return [
-            self::CATEGORY_APPLICATION => "mb.terms.application.plural",
-            self::CATEGORY_SOURCES => "mb.terms.source.plural",
-            self::CATEGORY_PERMISSIONS => "fom.user.userbundle.classes.permissions",
-            self::CATEGORY_USERS => "fom.user.userbundle.classes.users",
-            self::CATEGORY_GROUPS => "fom.user.userbundle.classes.groups",
-            self::CATEGORY_API => "fom.user.userbundle.classes.api",
-        ];
     }
 
     /**
@@ -46,42 +30,10 @@ class PermissionController extends AbstractController
     {
         $this->denyAccessUnlessGranted(ResourceDomainInstallation::ACTION_MANAGE_PERMISSION);
 
-        $actions = match ($category) {
-            self::CATEGORY_APPLICATION => [
-                ResourceDomainInstallation::ACTION_CREATE_APPLICATIONS,
-                ResourceDomainInstallation::ACTION_VIEW_ALL_APPLICATIONS,
-                ResourceDomainInstallation::ACTION_EDIT_ALL_APPLICATIONS,
-                ResourceDomainInstallation::ACTION_DELETE_ALL_APPLICATIONS,
-                ResourceDomainInstallation::ACTION_OWN_ALL_APPLICATIONS
-            ],
-            self::CATEGORY_SOURCES => [
-                ResourceDomainInstallation::ACTION_VIEW_SOURCES,
-                ResourceDomainInstallation::ACTION_CREATE_SOURCES,
-                ResourceDomainInstallation::ACTION_REFRESH_SOURCES,
-                ResourceDomainInstallation::ACTION_EDIT_FREE_INSTANCES,
-                ResourceDomainInstallation::ACTION_DELETE_SOURCES,
-            ],
-            self::CATEGORY_PERMISSIONS => [
-                ResourceDomainInstallation::ACTION_MANAGE_PERMISSION
-            ],
-            self::CATEGORY_USERS => [
-                ResourceDomainInstallation::ACTION_VIEW_USERS,
-                ResourceDomainInstallation::ACTION_CREATE_USERS,
-                ResourceDomainInstallation::ACTION_EDIT_USERS,
-                ResourceDomainInstallation::ACTION_DELETE_USERS,
-            ],
-            self::CATEGORY_GROUPS => [
-                ResourceDomainInstallation::ACTION_VIEW_GROUPS,
-                ResourceDomainInstallation::ACTION_CREATE_GROUPS,
-                ResourceDomainInstallation::ACTION_EDIT_GROUPS,
-                ResourceDomainInstallation::ACTION_DELETE_GROUPS,
-            ],
-            self::CATEGORY_API => [
-                ResourceDomainInstallation::ACTION_ACCESS_API,
-                ResourceDomainInstallation::ACTION_UPLOAD_FILES,
-            ],
-            default => throw $this->createNotFoundException("Invalid category $category")
-        };
+        $actions = $this->installationPermissions->getPermissions($category);
+        if (empty($actions)) {
+            throw $this->createNotFoundException("Invalid category $category");
+        }
 
         $form = $this->createForm(FormType::class, null, array(
             'label' => false,
@@ -113,7 +65,7 @@ class PermissionController extends AbstractController
         return $this->render('@FOMUser/Permission/edit.html.twig', array(
             'class' => $category,
             'form' => $form->createView(),
-            'permission_class' => self::categoryList()[$category],
+            'permission_class' => $this->installationPermissions->getCategoryList()[$category],
         ));
     }
 

--- a/src/FOM/UserBundle/Controller/SecurityController.php
+++ b/src/FOM/UserBundle/Controller/SecurityController.php
@@ -21,6 +21,7 @@ class SecurityController
                                 protected AuthorizationCheckerInterface $authorizationChecker,
                                 protected \Twig\Environment             $twig,
                                 protected string                        $userEntityClass,
+                                protected ResourceDomainInstallation    $installationPermissions,
     )
     {
     }
@@ -39,7 +40,7 @@ class SecurityController
         }
         $vars = array(
             'grants' => $grants,
-            'permission_categories' => PermissionController::categoryList(),
+            'permission_categories' => $this->installationPermissions->getCategoryList(),
             'users' => $grants['users'] ? $this->managerRegistry->getRepository(User::class)->findAll() : [],
             'groups' => $grants['groups'] ? $this->managerRegistry->getRepository(Group::class)->findAll() : [],
         );

--- a/src/FOM/UserBundle/Resources/config/controllers.xml
+++ b/src/FOM/UserBundle/Resources/config/controllers.xml
@@ -37,11 +37,13 @@
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="twig" />
             <argument>%fom.user_entity%</argument>
+            <argument type="service" id="fom.security.resource_domain.installation" />
         </service>
         <service id="FOM\UserBundle\Controller\PermissionController"
                  class="FOM\UserBundle\Controller\PermissionController"
                  public="true">
             <argument type="service" id="fom.security.permission_manager" />
+            <argument type="service" id="fom.security.resource_domain.installation" />
             <tag name="container.service_subscriber" />
             <call method="setContainer">
                 <argument type="service" id="Psr\Container\ContainerInterface" />

--- a/src/FOM/UserBundle/Resources/config/services.xml
+++ b/src/FOM/UserBundle/Resources/config/services.xml
@@ -87,6 +87,8 @@
         <service id="fom.security.resource_domain.installation"
                  class="FOM\UserBundle\Security\Permission\ResourceDomainInstallation">
             <tag name="fom.security.resource_domain" priority="1" />
+            <!-- will contain all services tagged with "fom.security.global_permission", sorted by priority -->
+            <argument type="collection" />
         </service>
 
         <service id="fom.security.subject_domain.public"

--- a/src/FOM/UserBundle/Resources/views/Group/list.html.twig
+++ b/src/FOM/UserBundle/Resources/views/Group/list.html.twig
@@ -17,7 +17,9 @@
       {% for group in groups|sort((a,b) => a.title|lower <=> b.title|lower) %}
       <tr class="filterItem">
         <td>
-          <a href="{{ path('fom_user_group_edit', {'id': group.id}) }}" title="{{ 'fom.user.group.index.edit_group' | trans }} {{ group.title }}">{{ group.title }}</a>
+          {% if is_granted(constant('FOM\\UserBundle\\Security\\Permission\\ResourceDomainInstallation::ACTION_EDIT_GROUPS')) %}
+            <a href="{{ path('fom_user_group_edit', {'id': group.id}) }}" title="{{ 'fom.user.group.index.edit_group' | trans }} {{ group.title }}">{{ group.title }}</a>
+          {% else %}{{ group.title }}{% endif %}
         </td>
         <td>{{ group.description }}</td>
         <td class="iconColumn">

--- a/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
+++ b/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
@@ -12,7 +12,7 @@ interface GlobalPermissionProvider
     public function getCategories(): array;
 
     /**
-     * returns all permission groups for this provider
+     * returns all permissions for this provider
      * @return array keys: unique string aliases for the permission. values: array with the keys `group` (string alias for
      * the category, see self::getCategories), `cssClass` (optional): see AbstractResourceDomain::getCssClassForAction, `label`: translation label,
      * `help` (optional): translation label for help text

--- a/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
+++ b/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FOM\UserBundle\Security\Permission;
+
+interface GlobalPermissionProvider
+{
+    /**
+     * returns all permission categories for this provider
+     * @return array keys: unique string aliases for the category. values: translation keys with a human-readable value
+     * @example ["digitizer" => "mb.digitizer.permission.category"]
+     */
+    public function getCategories(): array;
+
+    /**
+     * returns all permission groups for this provider
+     * @return array keys: unique string aliases for the permission. values: array with the keys `group` (string alias for
+     * the category, see self::getCategories), `cssClass` (optional): see AbstractResourceDomain::getCssClassForAction, `label`: translation label,
+     * `help` (optional): translation label for help text
+     * @example ["digitizer.create" => [
+     *     "category": "digitizer",
+     *     "cssClass": AbstractResourceDomain::CSS_CLASS_WARNING,
+     *     "label": "mb.digitizer.permission.create",
+     *     "help": "mb.digitizer.permission.create_help",
+     * ]]
+     */
+    public function getPermissions(): array;
+}

--- a/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
+++ b/src/FOM/UserBundle/Security/Permission/GlobalPermissionProvider.php
@@ -14,13 +14,10 @@ interface GlobalPermissionProvider
     /**
      * returns all permissions for this provider
      * @return array keys: unique string aliases for the permission. values: array with the keys `group` (string alias for
-     * the category, see self::getCategories), `cssClass` (optional): see AbstractResourceDomain::getCssClassForAction, `label`: translation label,
-     * `help` (optional): translation label for help text
+     * the category, see self::getCategories), `cssClass` (optional): see AbstractResourceDomain::getCssClassForAction
      * @example ["digitizer.create" => [
      *     "category": "digitizer",
      *     "cssClass": AbstractResourceDomain::CSS_CLASS_WARNING,
-     *     "label": "mb.digitizer.permission.create",
-     *     "help": "mb.digitizer.permission.create_help",
      * ]]
      */
     public function getPermissions(): array;

--- a/src/FOM/UserBundle/Security/Permission/ResourceDomainInstallation.php
+++ b/src/FOM/UserBundle/Security/Permission/ResourceDomainInstallation.php
@@ -112,111 +112,86 @@ class ResourceDomainInstallation extends AbstractResourceDomain
         return [
             self::ACTION_CREATE_APPLICATIONS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.create_applications',
                 'category' => self::CATEGORY_APPLICATION,
             ],
             self::ACTION_VIEW_ALL_APPLICATIONS => [
                 'cssClass' => self::CSS_CLASS_SUCCESS,
-                'label' => 'fom.security.resource.installation.view_all_applications',
-                'help' => 'fom.security.resource.installation.view_all_applications_help',
                 'category' => self::CATEGORY_APPLICATION,
             ],
             self::ACTION_EDIT_ALL_APPLICATIONS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.edit_all_applications',
-                'help' => 'fom.security.resource.installation.edit_all_applications_help',
                 'category' => self::CATEGORY_APPLICATION,
             ],
             self::ACTION_DELETE_ALL_APPLICATIONS => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.delete_all_applications',
-                'help' => 'fom.security.resource.installation.delete_all_applications_help',
                 'category' => self::CATEGORY_APPLICATION,
             ],
             self::ACTION_OWN_ALL_APPLICATIONS => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.own_all_applications',
-                'help' => 'fom.security.resource.installation.own_all_applications_help',
                 'category' => self::CATEGORY_APPLICATION,
             ],
             self::ACTION_VIEW_SOURCES => [
                 'cssClass' => self::CSS_CLASS_SUCCESS,
-                'label' => 'fom.security.resource.installation.view_sources',
                 'category' => self::CATEGORY_SOURCES,
             ],
             self::ACTION_CREATE_SOURCES => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.create_sources',
                 'category' => self::CATEGORY_SOURCES,
             ],
             self::ACTION_REFRESH_SOURCES => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.refresh_sources',
                 'category' => self::CATEGORY_SOURCES,
             ],
             self::ACTION_EDIT_FREE_INSTANCES => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.edit_free_instances',
                 'category' => self::CATEGORY_SOURCES,
             ],
             self::ACTION_DELETE_SOURCES => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.delete_sources',
                 'category' => self::CATEGORY_SOURCES,
             ],
             self::ACTION_MANAGE_PERMISSION => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.manage_permissions',
                 'category' => self::CATEGORY_PERMISSIONS,
             ],
             self::ACTION_VIEW_USERS => [
                 'cssClass' => self::CSS_CLASS_SUCCESS,
-                'label' => 'fom.security.resource.installation.view_users',
                 'category' => self::CATEGORY_USERS,
             ],
             self::ACTION_CREATE_USERS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.create_users',
                 'category' => self::CATEGORY_USERS,
             ],
             self::ACTION_EDIT_USERS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.edit_users',
                 'category' => self::CATEGORY_USERS,
             ],
             self::ACTION_DELETE_USERS => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.delete_users',
                 'category' => self::CATEGORY_USERS,
             ],
             self::ACTION_VIEW_GROUPS => [
                 'cssClass' => self::CSS_CLASS_SUCCESS,
-                'label' => 'fom.security.resource.installation.view_groups',
                 'category' => self::CATEGORY_GROUPS,
             ],
             self::ACTION_CREATE_GROUPS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.create_groups',
                 'category' => self::CATEGORY_GROUPS,
             ],
             self::ACTION_EDIT_GROUPS => [
                 'cssClass' => self::CSS_CLASS_WARNING,
-                'label' => 'fom.security.resource.installation.edit_groups',
                 'category' => self::CATEGORY_GROUPS,
             ],
             self::ACTION_DELETE_GROUPS => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.delete_groups',
                 'category' => self::CATEGORY_GROUPS,
             ],
             self::ACTION_ACCESS_API => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.access_api',
                 'category' => self::CATEGORY_API,
             ],
             self::ACTION_UPLOAD_FILES => [
                 'cssClass' => self::CSS_CLASS_DANGER,
-                'label' => 'fom.security.resource.installation.upload_files',
                 'category' => self::CATEGORY_API,
             ],
         ];

--- a/src/FOM/UserBundle/Security/Permission/ResourceDomainInstallation.php
+++ b/src/FOM/UserBundle/Security/Permission/ResourceDomainInstallation.php
@@ -2,8 +2,6 @@
 
 namespace FOM\UserBundle\Security\Permission;
 
-use Doctrine\ORM\QueryBuilder;
-
 class ResourceDomainInstallation extends AbstractResourceDomain
 {
     const SLUG = "installation";
@@ -35,6 +33,31 @@ class ResourceDomainInstallation extends AbstractResourceDomain
     const ACTION_ACCESS_API = "access_api";
     const ACTION_UPLOAD_FILES = "upload_files";
 
+    public const CATEGORY_APPLICATION = "applications";
+    public const CATEGORY_SOURCES = "sources";
+    public const CATEGORY_PERMISSIONS = "permissions";
+    public const CATEGORY_USERS = "users";
+    public const CATEGORY_GROUPS = "groups";
+    public const CATEGORY_API = "api";
+
+    protected array $categoryList;
+    protected array $permissionList;
+
+
+    /**
+     * @param GlobalPermissionProvider[] $globalPermissionProviders
+     */
+    public function __construct(array $globalPermissionProviders)
+    {
+        $this->categoryList = $this->defaultGroups();
+        $this->permissionList = $this->defaultPermissions();
+
+        foreach ($globalPermissionProviders as $provider) {
+            $this->categoryList += $provider->getCategories();
+            $this->permissionList += $provider->getPermissions();
+        }
+    }
+
     public function getSlug(): string
     {
         return self::SLUG;
@@ -48,57 +71,154 @@ class ResourceDomainInstallation extends AbstractResourceDomain
 
     public function getActions(): array
     {
-        return [
-            self::ACTION_CREATE_APPLICATIONS,
-            self::ACTION_VIEW_ALL_APPLICATIONS,
-            self::ACTION_EDIT_ALL_APPLICATIONS,
-            self::ACTION_DELETE_ALL_APPLICATIONS,
-            self::ACTION_OWN_ALL_APPLICATIONS,
-            self::ACTION_VIEW_SOURCES,
-            self::ACTION_CREATE_SOURCES,
-            self::ACTION_REFRESH_SOURCES,
-            self::ACTION_EDIT_FREE_INSTANCES,
-            self::ACTION_DELETE_SOURCES,
-            self::ACTION_MANAGE_PERMISSION,
-            self::ACTION_VIEW_USERS,
-            self::ACTION_CREATE_USERS,
-            self::ACTION_EDIT_USERS,
-            self::ACTION_DELETE_USERS,
-            self::ACTION_VIEW_GROUPS,
-            self::ACTION_CREATE_GROUPS,
-            self::ACTION_EDIT_GROUPS,
-            self::ACTION_DELETE_GROUPS,
-            self::ACTION_ACCESS_API,
-            self::ACTION_UPLOAD_FILES,
-        ];
+        return array_keys($this->permissionList);
     }
 
     public function getCssClassForAction(string $action): string
     {
-        return match ($action) {
-            self::ACTION_EDIT_ALL_APPLICATIONS,
-            self::ACTION_CREATE_APPLICATIONS,
-            self::ACTION_CREATE_USERS,
-            self::ACTION_CREATE_GROUPS,
-            self::ACTION_CREATE_SOURCES,
-            self::ACTION_EDIT_USERS,
-            self::ACTION_EDIT_GROUPS,
-            self::ACTION_REFRESH_SOURCES,
-            self::ACTION_EDIT_FREE_INSTANCES => self::CSS_CLASS_WARNING,
-            self::ACTION_DELETE_ALL_APPLICATIONS,
-            self::ACTION_OWN_ALL_APPLICATIONS,
-            self::ACTION_MANAGE_PERMISSION,
-            self::ACTION_DELETE_SOURCES,
-            self::ACTION_DELETE_USERS,
-            self::ACTION_ACCESS_API,
-            self::ACTION_UPLOAD_FILES,
-            self::ACTION_DELETE_GROUPS => self::CSS_CLASS_DANGER,
-            default => self::CSS_CLASS_SUCCESS,
-        };
+        return $this->permissionList[$action]['cssClass'] ?? self::CSS_CLASS_SUCCESS;
     }
 
     function getTranslationPrefix(): string
     {
         return "fom.security.resource.installation";
+    }
+
+
+    public function getCategoryList(): array
+    {
+        return $this->categoryList;
+    }
+
+    public function getPermissions(string $category): array
+    {
+        return array_keys(array_filter($this->permissionList, fn($permission) => $permission['category'] === $category));
+    }
+
+    protected function defaultGroups(): array
+    {
+        return [
+            self::CATEGORY_APPLICATION => "mb.terms.application.plural",
+            self::CATEGORY_SOURCES => "mb.terms.source.plural",
+            self::CATEGORY_PERMISSIONS => "fom.user.userbundle.classes.permissions",
+            self::CATEGORY_USERS => "fom.user.userbundle.classes.users",
+            self::CATEGORY_GROUPS => "fom.user.userbundle.classes.groups",
+            self::CATEGORY_API => "fom.user.userbundle.classes.api",
+        ];
+    }
+
+    protected function defaultPermissions(): array
+    {
+        return [
+            self::ACTION_CREATE_APPLICATIONS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.create_applications',
+                'category' => self::CATEGORY_APPLICATION,
+            ],
+            self::ACTION_VIEW_ALL_APPLICATIONS => [
+                'cssClass' => self::CSS_CLASS_SUCCESS,
+                'label' => 'fom.security.resource.installation.view_all_applications',
+                'help' => 'fom.security.resource.installation.view_all_applications_help',
+                'category' => self::CATEGORY_APPLICATION,
+            ],
+            self::ACTION_EDIT_ALL_APPLICATIONS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.edit_all_applications',
+                'help' => 'fom.security.resource.installation.edit_all_applications_help',
+                'category' => self::CATEGORY_APPLICATION,
+            ],
+            self::ACTION_DELETE_ALL_APPLICATIONS => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.delete_all_applications',
+                'help' => 'fom.security.resource.installation.delete_all_applications_help',
+                'category' => self::CATEGORY_APPLICATION,
+            ],
+            self::ACTION_OWN_ALL_APPLICATIONS => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.own_all_applications',
+                'help' => 'fom.security.resource.installation.own_all_applications_help',
+                'category' => self::CATEGORY_APPLICATION,
+            ],
+            self::ACTION_VIEW_SOURCES => [
+                'cssClass' => self::CSS_CLASS_SUCCESS,
+                'label' => 'fom.security.resource.installation.view_sources',
+                'category' => self::CATEGORY_SOURCES,
+            ],
+            self::ACTION_CREATE_SOURCES => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.create_sources',
+                'category' => self::CATEGORY_SOURCES,
+            ],
+            self::ACTION_REFRESH_SOURCES => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.refresh_sources',
+                'category' => self::CATEGORY_SOURCES,
+            ],
+            self::ACTION_EDIT_FREE_INSTANCES => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.edit_free_instances',
+                'category' => self::CATEGORY_SOURCES,
+            ],
+            self::ACTION_DELETE_SOURCES => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.delete_sources',
+                'category' => self::CATEGORY_SOURCES,
+            ],
+            self::ACTION_MANAGE_PERMISSION => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.manage_permissions',
+                'category' => self::CATEGORY_PERMISSIONS,
+            ],
+            self::ACTION_VIEW_USERS => [
+                'cssClass' => self::CSS_CLASS_SUCCESS,
+                'label' => 'fom.security.resource.installation.view_users',
+                'category' => self::CATEGORY_USERS,
+            ],
+            self::ACTION_CREATE_USERS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.create_users',
+                'category' => self::CATEGORY_USERS,
+            ],
+            self::ACTION_EDIT_USERS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.edit_users',
+                'category' => self::CATEGORY_USERS,
+            ],
+            self::ACTION_DELETE_USERS => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.delete_users',
+                'category' => self::CATEGORY_USERS,
+            ],
+            self::ACTION_VIEW_GROUPS => [
+                'cssClass' => self::CSS_CLASS_SUCCESS,
+                'label' => 'fom.security.resource.installation.view_groups',
+                'category' => self::CATEGORY_GROUPS,
+            ],
+            self::ACTION_CREATE_GROUPS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.create_groups',
+                'category' => self::CATEGORY_GROUPS,
+            ],
+            self::ACTION_EDIT_GROUPS => [
+                'cssClass' => self::CSS_CLASS_WARNING,
+                'label' => 'fom.security.resource.installation.edit_groups',
+                'category' => self::CATEGORY_GROUPS,
+            ],
+            self::ACTION_DELETE_GROUPS => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.delete_groups',
+                'category' => self::CATEGORY_GROUPS,
+            ],
+            self::ACTION_ACCESS_API => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.access_api',
+                'category' => self::CATEGORY_API,
+            ],
+            self::ACTION_UPLOAD_FILES => [
+                'cssClass' => self::CSS_CLASS_DANGER,
+                'label' => 'fom.security.resource.installation.upload_files',
+                'category' => self::CATEGORY_API,
+            ],
+        ];
     }
 }

--- a/src/Mapbender/FrameworkBundle/DependencyInjection/Compiler/RegisterGlobalPermissionDomainsPass.php
+++ b/src/Mapbender/FrameworkBundle/DependencyInjection/Compiler/RegisterGlobalPermissionDomainsPass.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Mapbender\FrameworkBundle\DependencyInjection\Compiler;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterGlobalPermissionDomainsPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function __construct(protected string $indexId)
+    {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $globalPermissions = $this->findAndSortTaggedServices('fom.security.global_permission', $container);
+        $container->getDefinition($this->indexId)
+            ->replaceArgument(0, $globalPermissions)
+        ;
+    }
+}

--- a/src/Mapbender/FrameworkBundle/MapbenderFrameworkBundle.php
+++ b/src/Mapbender/FrameworkBundle/MapbenderFrameworkBundle.php
@@ -6,6 +6,7 @@ namespace Mapbender\FrameworkBundle;
 
 use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterApplicationTemplatesPass;
 use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterElementServicesPass;
+use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterGlobalPermissionDomainsPass;
 use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterIconPackagesPass;
 use Mapbender\FrameworkBundle\DependencyInjection\Compiler\RegisterPermissionDomainsPass;
 use Symfony\Component\Config\FileLocator;
@@ -34,8 +35,11 @@ class MapbenderFrameworkBundle extends Bundle
         // Forward available icon packages to icon index
         /** @see \Mapbender\FrameworkBundle\Component\IconIndex */
         $container->addCompilerPass(new RegisterIconPackagesPass('mapbender.icon_index'));
+
         /** @see \FOM\UserBundle\Security\Permission\PermissionManager */
         $container->addCompilerPass(new RegisterPermissionDomainsPass('fom.security.permission_manager'));
+        /** @see \FOM\UserBundle\Security\Permission\ResourceDomainInstallation */
+        $container->addCompilerPass(new RegisterGlobalPermissionDomainsPass('fom.security.resource_domain.installation'));
     }
 
     public function getContainerExtension(): ?ExtensionInterface


### PR DESCRIPTION
If you want to add an installation-wide permission that is not dependent on a single resource, create a class implementing the `FOM\UserBundle\Security\Permission\GlobalPermissionProvider` interface and tag it with `fom.security.global_permission`.

The interface has two methods that need to implemented:
- `getCategories()`: Returns the permission categories you want to add to the list that appears when navigating to Security / Global Permissions.
  can be left empty if you only want to extend a category that already exists.  
  The keys should be unique string aliases for the category, the values translation keys for the human-readable values.
- `getPermissions()`: Returns the actual permissions you want to add. The keys are unique (unique across all categories!) string aliases,
  the values should be an array with the following keys:
  - `category`: The alias for the category this permission should be added to
  - `cssClass` (optional, default 'success'): The css class the permission should get when displayed in the backend (background color)

For localisation, use the keys `fom.security.resource.installation.<alias>` resp. `fom.security.resource.installation.<alias>_help` for the help text.

Example:

```php
#[AutoconfigureTag('fom.security.global_permission')
class QueryBuilderPermissionProvider implements GlobalPermissionProvider
{
    const CATEGORY_NAME = "query_builder";
    const PERMISSION_CREATE = "qb_create";
    const PERMISSION_EDIT = "qb_edit";

    public function getCategories(): array
    {
        return [self::CATEGORY_NAME => 'query_builder'];
    }

    public function getPermissions(): array
    {
        return [
            self::PERMISSION_CREATE => [
                'category' => self::CATEGORY_NAME,
                'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
            ],
            self::PERMISSION_EDIT => [
                'category' => self::CATEGORY_NAME,
                'cssClass' => AbstractResourceDomain::CSS_CLASS_WARNING,
            ],
        ];
    }
}
```


if you don't use Autowiring, you need to add the tag definition in XML, for example:

```xml
<service id="mb.querybuilder.permission_provider" class="Mapbender\QueryBuilderBundle\Permission\QueryBuilderPermissionProvider">
    <tag name="fom.security.global_permission" />
</service>
```