### PR TITLE
[ApiBundle] Add new options for wms:assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Features:
 * [Manager] Cloning of elements enabled ([#PR1705](https://github.com/mapbender/mapbender/pull/1705))
 * Support HTML5-compliant data-mb-action attributes alongside mb-action ([#PR1712](https://github.com/mapbender/mapbender/pull/1712))
 ## next bugfix release
+* [API] Add new options to mapbender:wms:assign command and /api/wms/assign request ([#1720](https://github.com/mapbender/mapbender/pull/1720))
 * Fix users could not modify their own profile ([#1695](https://github.com/mapbender/mapbender/issues/1695), [PR#1696](https://github.com/mapbender/mapbender/pull/1696)) 
 * [ShareUrl] Fix selected layers not encoded correctly ([#1697](https://github.com/mapbender/mapbender/issues/1697), [PR#1698](https://github.com/mapbender/mapbender/pull/1698)) 
 
@@ -20,7 +21,6 @@ Features:
 * [FeatureInfo] Support labels in FeatureInfo-Highlighting ([PR#1670](https://github.com/mapbender/mapbender/pull/1670))
 * [ApplicationSwitcher] Allow reordering applications by drag and drop in manager ([PR#1666](https://github.com/mapbender/mapbender/pull/1666))
 * [POI] Add option to minimize and completely remove POI popup ([#1273](https://github.com/mapbender/mapbender/issues/1273), [PR#1673](https://github.com/mapbender/mapbender/pull/1673))
-* [API] Add new options to mapbender:wms:assign command and /api/wms/assign request ([#1720](https://github.com/mapbender/mapbender/pull/1720))
 
 Bugfixes:
 * Fix order of elements within an application could get lost ([#PR1682](https://github.com/mapbender/mapbender/pull/1682))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Features:
 * [FeatureInfo] Support labels in FeatureInfo-Highlighting ([PR#1670](https://github.com/mapbender/mapbender/pull/1670))
 * [ApplicationSwitcher] Allow reordering applications by drag and drop in manager ([PR#1666](https://github.com/mapbender/mapbender/pull/1666))
 * [POI] Add option to minimize and completely remove POI popup ([#1273](https://github.com/mapbender/mapbender/issues/1273), [PR#1673](https://github.com/mapbender/mapbender/pull/1673))
+* [API] Add new options to mapbender:wms:assign command and /api/wms/assign request ([#1720](https://github.com/mapbender/mapbender/pull/1720))
 
 Bugfixes:
 * Fix order of elements within an application could get lost ([#PR1682](https://github.com/mapbender/mapbender/pull/1682))

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -283,6 +283,41 @@ class CommandController extends AbstractController
                 in: 'query',
                 required: false,
                 schema: new OA\Schema(type: 'mixed', example: "main")
+            ),
+            new OA\Parameter(
+                name: 'format',
+                description: 'Sets the format for the GetMap-request, such as image/png',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'image/png')
+            ),
+            new OA\Parameter(
+                name: 'infoformat',
+                description: 'Sets the format for the FeatureInfo, such as text/html',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'text/html')
+            ),
+            new OA\Parameter(
+                name: 'proxy',
+                description: 'Decides if a proxy is used or not (one of true|false). Defaults to "false"',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'boolean', example: true)
+            ),
+            new OA\Parameter(
+                name: 'tiled',
+                description: 'Decides if the GetMap-requests are returned tiled or not (one of true|false). Defaults to "false"',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'boolean', example: true)
+            ),
+            new OA\Parameter(
+                name: 'layerorder',
+                description: 'Sets the layerorder to either standard or reverse (one of standard|reverse). Defaults to "standard"',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'standard')
             )
         ],
         responses: [
@@ -327,6 +362,11 @@ class CommandController extends AbstractController
             'application' => $application,
             'source' => $source,
             'layerset' => $layerset,
+            '--format' => $request->get('format'),
+            '--infoformat' => $request->get('infoformat'),
+            '--proxy' => $request->get('proxy'),
+            '--tiled' => $request->get('tiled'),
+            '--layerorder' => $request->get('layerorder'),
             '-v' => true, // Ignore PHP deprecated messages to reduce the output
         ];
 

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -9,7 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -268,7 +268,7 @@ class CommandController extends AbstractController
                 description: 'id or slug of the application',
                 in: 'query',
                 required: true,
-                schema: new OA\Schema(type: 'mixed', example: "mapbender_user")
+                schema: new OA\Schema(example: "mapbender_user", oneOf: [new OA\Schema(type: 'string'), new OA\Schema(type: 'integer')])
             ),
             new OA\Parameter(
                 name: 'source',

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -293,7 +293,7 @@ class CommandController extends AbstractController
             ),
             new OA\Parameter(
                 name: 'infoformat',
-                description: 'Sets the format for the FeatureInfo, such as text/html',
+                description: 'Sets the format for the FeatureInfo-request, such as text/html',
                 in: 'query',
                 required: false,
                 schema: new OA\Schema(type: 'string', example: 'text/html')

--- a/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
+++ b/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
@@ -418,7 +418,7 @@ class SourceInstanceController extends ApplicationControllerBase
         return $repository;
     }
 
-    public function createNewSourceInstance(Application $application, int $sourceId, int $layersetId, ObjectManager $entityManager): SourceInstance
+    public function createNewSourceInstance(Application $application, int $sourceId, int $layersetId, ObjectManager $entityManager, $options = []): SourceInstance
     {
         $layerset = $this->requireLayerset($layersetId, $application);
         /** @var Source|null $source */
@@ -432,6 +432,21 @@ class SourceInstanceController extends ApplicationControllerBase
 
         $newInstance->setWeight(0);
         $newInstance->setLayerset($layerset);
+        if (!empty($options['format']) && in_array($options['format'], $source->getGetMap()->getFormats())) {
+            $newInstance->setFormat($options['format']);
+        }
+        if (!empty($options['infoformat']) && in_array($options['infoformat'], $source->getGetFeatureInfo()->getFormats())) {
+            $newInstance->setInfoFormat($options['infoformat']);
+        }
+        if (!empty($options['proxy']) && $options['proxy'] === 'true') {
+            $newInstance->setProxy(true);
+        }
+        if (!empty($options['tiled']) && $options['tiled'] === 'true') {
+            $newInstance->setTiled(true);
+        }
+        if (!empty($options['layerorder']) && in_array($options['layerorder'], ['standard', 'reverse'])) {
+            $newInstance->setLayerOrder($options['layerorder']);
+        }
         $layerset->getInstances()->add($newInstance);
 
         $entityManager->persist($application);

--- a/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
+++ b/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -39,6 +40,11 @@ class SourceAssignCommand extends AbstractSourceCommand
             ->addArgument(self::ARGUMENT_APPLICATION, InputArgument::REQUIRED, "id or slug of the application")
             ->addArgument(self::ARGUMENT_SOURCE, InputArgument::REQUIRED, "id of the wms source")
             ->addArgument(self::ARGUMENT_LAYERSET, InputArgument::OPTIONAL, "id or name of the layerset. Defaults to 'main' or the first layerset in the application.")
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Sets the format for the GetMap-request, such as image/png', null)
+            ->addOption('infoformat', 'i', InputOption::VALUE_OPTIONAL, 'Sets the format for the FeatureInfo, such as text/html', null)
+            ->addOption('proxy', 'p', InputOption::VALUE_OPTIONAL, 'Decides if a proxy is used or not (one of true|false)', null)
+            ->addOption('tiled', 't', InputOption::VALUE_OPTIONAL, 'Decides if the GetMap-requests are returned tiled or not (one of true|false)', null)
+            ->addOption('layerorder', 'l', InputOption::VALUE_OPTIONAL, 'Sets the layerorder to either standard or reverse (one of standard|reverse)', null)
         ;
     }
 
@@ -54,7 +60,7 @@ class SourceAssignCommand extends AbstractSourceCommand
 
         $sourceId = $input->getArgument(self::ARGUMENT_SOURCE);
 
-        $this->sourceInstanceController->createNewSourceInstance($application, $sourceId, $layerset->getId(), $this->getEntityManager());
+        $this->sourceInstanceController->createNewSourceInstance($application, $sourceId, $layerset->getId(), $this->getEntityManager(), $input->getOptions());
         $io->success("New source instance added.");
         return Command::SUCCESS;
     }

--- a/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
+++ b/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
@@ -41,7 +41,7 @@ class SourceAssignCommand extends AbstractSourceCommand
             ->addArgument(self::ARGUMENT_SOURCE, InputArgument::REQUIRED, "id of the wms source")
             ->addArgument(self::ARGUMENT_LAYERSET, InputArgument::OPTIONAL, "id or name of the layerset. Defaults to 'main' or the first layerset in the application.")
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Sets the format for the GetMap-request, such as image/png', null)
-            ->addOption('infoformat', 'i', InputOption::VALUE_OPTIONAL, 'Sets the format for the FeatureInfo, such as text/html', null)
+            ->addOption('infoformat', 'i', InputOption::VALUE_OPTIONAL, 'Sets the format for the FeatureInfo-request, such as text/html', null)
             ->addOption('proxy', 'p', InputOption::VALUE_OPTIONAL, 'Decides if a proxy is used or not (one of true|false)', null)
             ->addOption('tiled', 't', InputOption::VALUE_OPTIONAL, 'Decides if the GetMap-requests are returned tiled or not (one of true|false)', null)
             ->addOption('layerorder', 'l', InputOption::VALUE_OPTIONAL, 'Sets the layerorder to either standard or reverse (one of standard|reverse)', null)


### PR DESCRIPTION
- Adds new options to the mapbender:wms:assign command and the  /api/wms/assign api-request 
- see internal #10243

New options are
- --format
- --infoformat
- --proxy
- --tiled
- --layerorder

get information via

`bin/console mapbender:wms:assign --help`