### PR TITLE
[Routing] Fix routing in popup-dialog

### DIFF
--- a/src/Mapbender/RoutingBundle/Resources/public/mapbender.element.routing.js
+++ b/src/Mapbender/RoutingBundle/Resources/public/mapbender.element.routing.js
@@ -73,8 +73,6 @@
             }
             this._clearRoute();
             this.isActive = false;
-            this.olMap.removeLayer(this.markerLayer);
-            this.olMap.removeLayer(this.routingLayer);
             this.callback ? this.callback.call() : this.callback;
         },
 


### PR DESCRIPTION
Fixes no route and marker displayed when search is repeated. -> Happens when routing is configured in the popup-dialog.
see internal issue #10311