### PR TITLE
[WmsLoader] Fix missing option layers when loading WMS the default way

### DIFF
--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -206,14 +206,16 @@
                 // Need to pre-generate layer ids now because layertree visual updates need layer ids
                 Mapbender.Util.SourceTree.generateLayerIds(sourceDef);
                 sourceDef.isDynamicSource = true;
-                // deactivate root layer, when no layer is selected
-                if (options.layers.length === 0) {
-                    sourceDef.configuration.children[0].options.treeOptions.selected = false;
+                if (options.hasOwnProperty('layers')) {
+                    // deactivate root layer, when no layer is selected
+                    if (options.layers.length === 0) {
+                        sourceDef.configuration.children[0].options.treeOptions.selected = false;
+                    }
+                    sourceDef.configuration.children[0].children.forEach(layer => {
+                        var allActive = options.layers.indexOf('_all') !== -1;
+                        layer.options.treeOptions.selected = (options.layers.indexOf(layer.options.name) !== -1) || allActive;
+                    });
                 }
-                sourceDef.configuration.children[0].children.forEach(layer => {
-                    var allActive = options.layers.indexOf('_all') !== -1;
-                    layer.options.treeOptions.selected = (options.layers.indexOf(layer.options.name) !== -1) || allActive;
-                });
                 source = source || this.mbMap.model.addSourceFromConfig(sourceDef);
             }
             return source || null;


### PR DESCRIPTION
After fixing #1718 WMS could not be loaded the default way anymore, due to the missing property key `layers`.
see internal issue #10302