### PR TITLE
[API] Fix controller response if console command throws an error

### DIFF
--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -445,17 +445,24 @@ class CommandController extends AbstractController
         $output = new BufferedOutput();
 
         try {
-            $application->run($input, $output);
+            $exitCode = $application->run($input, $output);
             $commandOutput = $output->fetch();
 
             if (isset($inputArgs['--json']) && $inputArgs['--json']) {
                 $commandOutput = json_decode($commandOutput, true);
             }
 
-            return new JsonResponse([
-                'success' => true,
-                'message' => $commandOutput,
-            ]);
+            if ($exitCode === 0) {
+                return new JsonResponse([
+                    'success' => true,
+                    'message' => $commandOutput,
+                ]);
+            } else {
+                return new JsonResponse([
+                    'success' => false,
+                    'error' => $commandOutput,
+                ], $exitCode);
+            }
         } catch (\Exception $e) {
             return new JsonResponse([
                 'success' => false,


### PR DESCRIPTION
The response of the console command was not correctly taken into account in the response of the controller, i.e. if the console command responded with an error 404, for example, the controller still reported 'success' => true.

see internal ticket 10603