### PR TITLE
[API] Fix controller response status code

### DIFF
--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -461,7 +461,8 @@ class CommandController extends AbstractController
                 return new JsonResponse([
                     'success' => false,
                     'error' => $commandOutput,
-                ], 500);
+                ], array_key_exists($exitCode, JsonResponse::$statusTexts) ? $exitCode : JsonResponse::HTTP_INTERNAL_SERVER_ERROR
+                );
             }
         } catch (\Exception $e) {
             return new JsonResponse([

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -461,7 +461,7 @@ class CommandController extends AbstractController
                 return new JsonResponse([
                     'success' => false,
                     'error' => $commandOutput,
-                ], $exitCode);
+                ], 500);
             }
         } catch (\Exception $e) {
             return new JsonResponse([


### PR DESCRIPTION
Another small fix here, because we cannot (always) use the console command's exit code as the controller's response code. This only works if the console command returns 404, which happens in some cases.