### PR TITLE
Fix app config when using WMS without legendUrl via proxy

### DIFF
--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceService.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceService.php
@@ -439,6 +439,9 @@ class WmsSourceService extends SourceService
         if (is_array($layerConfig['options']['availableStyles'])) {
             foreach ($layerConfig['options']['availableStyles'] as $style) {
                 /** @var $style Style */
+                if (!$style->getLegendUrl()) {
+                    continue;
+                }
                 $resource = $style->getLegendUrl()->getOnlineResource();
                 $url = $resource->getHref();
                 if ($sourceInstance->isProtectedDynamicWms() && !$sourceInstance->getSource()->getUsername()) {


### PR DESCRIPTION
WMS that dont have a LegendURL in their style definition prevent the application from starting when they are loaded via the OWSProxy. 
Solution: we skip the proxifyUrl function for these WMS

see internal ticket 10701 for example WMS