### PR TITLE
Support point geometries in feature info highlighting

### DIFF
--- a/src/Mapbender/CoreBundle/Element/FeatureInfo.php
+++ b/src/Mapbender/CoreBundle/Element/FeatureInfo.php
@@ -75,6 +75,8 @@ class FeatureInfo extends AbstractElementService
             'strokeColorHover' => 'rgba(255,0,0,0.7)',
             'strokeWidthDefault' => 1,
             'strokeWidthHover' => 3,
+            'pointRadiusDefault' => 7,
+            'pointRadiusHover' => 9,
             'fontColorDefault' => '#000000',
             'fontColorHover' => '#000000',
             'fontSizeDefault' => 12,

--- a/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/FeatureInfoAdminType.php
@@ -59,21 +59,25 @@ class FeatureInfoAdminType extends AbstractType
                 'label' => 'mb.core.admin.featureinfo.label.default_group',
                 'inherit_data' => true,
                 'hasFont' => true,
+                'hasPointRadius' => true,
                 'fieldNameFillColor' => 'fillColorDefault',
                 'fieldNameStrokeColor' => 'strokeColorDefault',
                 'fieldNameStrokeWidth' => 'strokeWidthDefault',
                 'fieldNameFontColor' => 'fontColorDefault',
                 'fieldNameFontSize' => 'fontSizeDefault',
+                'fieldNamePointRadius' => 'pointRadiusDefault',
             ))
             ->add('hoverStyle', PaintType::class, array(
                 'label' => 'mb.core.admin.featureinfo.label.hover_group',
                 'inherit_data' => true,
                 'hasFont' => true,
+                'hasPointRadius' => true,
                 'fieldNameFillColor' => 'fillColorHover',
                 'fieldNameStrokeColor' => 'strokeColorHover',
                 'fieldNameStrokeWidth' => 'strokeWidthHover',
                 'fieldNameFontColor' => 'fontColorHover',
                 'fieldNameFontSize' => 'fontSizeHover',
+                'fieldNamePointRadius' => 'pointRadiusHover',
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Element/Type/PaintType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/PaintType.php
@@ -39,12 +39,14 @@ class PaintType extends AbstractType
                 'hasStroke' => true,
                 'hasFill' => true,
                 'hasFont' => false,
+                'hasPointRadius' => false,
 
                 'fieldNameFillColor' => 'fillColor',
                 'fieldNameStrokeColor' => 'strokeColor',
                 'fieldNameStrokeWidth' => 'strokeWidth',
                 'fieldNameFontColor' => 'fontColor',
                 'fieldNameFontSize' => 'fontSize',
+                'fieldNamePointRadius' => 'pointRadius',
                 'fillColorHelp' => null,
                 'strokeColorHelp' => null,
                 'strokeWidthHelp' => null,
@@ -96,6 +98,15 @@ class PaintType extends AbstractType
                 'attr' => ['min' => 1],
                 'help' => $options['fontSizeHelp'],
                 'constraints' => [new Constraints\Range(['min' => 1])],
+            ], $this->trans));
+        }
+
+        if ($options['hasPointRadius']) {
+            $builder->add($options['fieldNamePointRadius'], NumberType::class, $this->createInlineHelpText([
+                'required' => false,
+                'label' => 'mb.core.admin.featureinfo.label.point_radius_px',
+                'attr' => ['min' => 0, 'inputmode' => 'numeric'],
+                'constraints' => [new Constraints\Range(['min' => 0])],
             ], $this->trans));
         }
 

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -497,6 +497,7 @@ mb:
           stroke_width_px: 'Linienstärke (Pixel)'
           fontColor: Schriftfarbe
           fontSize: Schriftgröße
+          point_radius_px: 'Radius (für Punktgeometrien)'
       printclient:
         label:
           rotatable: Drehbar

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -497,6 +497,7 @@ mb:
           stroke_width_px: 'Stroke width (pixels)'
           fontColor: 'Font color'
           fontSize: 'Font size'
+          point_radius_px: 'Radius (for point geometries)'
       printclient:
         label:
           rotatable: Rotatable

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
@@ -492,6 +492,7 @@ mb:
           stroke_width_px: 'Ancho del contorno (píxeles)'
           fontColor: 'Color de fuente'
           fontSize: 'Tamaño de fuente'
+          point_radius_px: 'Radio (para geometrías de puntos)'
       printclient:
         label:
           rotatable: Giratorio

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
@@ -280,6 +280,7 @@ mb:
           stroke_width_px: 'Largeur du contour (pixels)'
           fontColor: 'Couleur de la police'
           fontSize: 'Taille de la police'
+          point_radius_px: 'Rayon (pour géométries de points)'
       printclient:
         label:
           rotatable: Pivotable

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
@@ -492,6 +492,7 @@ mb:
           stroke_width_px: 'Larghezza del tratto (pixel)'
           fontColor: 'Colore del carattere'
           fontSize: 'Dimensiona del carattere'
+          point_radius_px: 'Raggio (per geometrie di punti)'
       printclient:
         label:
           rotatable: Ruotabile

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
@@ -280,6 +280,7 @@ mb:
           stroke_width_px: 'Randbreedte (pixels)'
           fontColor: 'Tekstkleur'
           fontSize: 'Tekstgrootte'
+          point_radius_px: 'Straal (voor puntgeometrieën)'
       printclient:
         label:
           rotatable: Roteerbaar

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
@@ -492,6 +492,7 @@ mb:
           stroke_width_px: 'Largura do traçado (pixels)'
           fontColor: Cor da fonte
           fontSize: Tamanho da fonte
+          point_radius_px: 'Raio (para geometrias de pontos)'
       printclient:
         label:
           rotatable: Girável

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
@@ -493,6 +493,7 @@ mb:
           stroke_width_px: 'Толщина линии (Pixel)'
           fontColor: 'Цвет шрифта'
           fontSize: 'Размер шрифта'
+          point_radius_px: 'Радиус (для точечных геометрий)'
       printclient:
         label:
           rotatable: Поворачиваемые

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
@@ -271,6 +271,7 @@ mb:
           printResult: '"Yazdır" düğmesini göster'
           onlyvalid: Sadece geçerli olan
           highlighting: null
+          point_radius_px: 'Yarıçap (nokta geometrileri için)'
       printclient:
         label:
           rotatable: Döndürülebilir

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
@@ -343,6 +343,7 @@ mb:
           strokeColor: Колір штрихування
           opacity_pct: Непрозорість (%)
           stroke_width_px: Ширина штриха(пікселі)
+          point_radius_px: 'Радіус (для точкових геометрій)'
       printclient:
         label:
           autoopen: Автовідкриття


### PR DESCRIPTION
Feature info highlighting did not work with point geometries (there were workarounds like using ST_Buffer and returning a polygon as the item's geometry in the WMS server's feature info).

After this PR, point geometries are directly supported for feature info highlighting. It uses the same color/width configuration for stroke and fill. In addition, additional configuration options `pointRadiusDefault` and `pointRadiusHover` are introduced for the point's radius in pixels.