### PR TITLE
Support definition of WMTS/TMS sources in YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## next feature release
 Features:
 * Support Vector Tiles (using Mapbox Style JSONs) as new data source ([#PR1748](https://github.com/mapbender/mapbender/pull/1748))
-* Support defining WMTS sources in YAML applications ([#PR1754](https://github.com/mapbender/mapbender/pull/1754))
+* Support defining WMTS/TMS sources in YAML applications ([#PR1754](https://github.com/mapbender/mapbender/pull/1754))
 * [Manager] Cloning of elements enabled ([#PR1705](https://github.com/mapbender/mapbender/pull/1705))
 * Accessibility: Buttons, control elements and elements in the sidepane can be accessed by clicking the tab key and triggered with the enter key ([PR#1742](https://github.com/mapbender/mapbender/pull/1742), [PR#1751](https://github.com/mapbender/mapbender/pull/1751))
 * Accessibility: IDs are no longer used in HTML for Mapbender elements ([#PR1750](https://github.com/mapbender/mapbender/pull/1750))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next feature release
 Features:
 * Support Vector Tiles (using Mapbox Style JSONs) as new data source ([#PR1748](https://github.com/mapbender/mapbender/pull/1748))
+* Support defining WMTS sources in YAML applications ([#PR1754](https://github.com/mapbender/mapbender/pull/1754))
 * [Manager] Cloning of elements enabled ([#PR1705](https://github.com/mapbender/mapbender/pull/1705))
 * Accessibility: Buttons, control elements and elements in the sidepane can be accessed by clicking the tab key and triggered with the enter key ([PR#1742](https://github.com/mapbender/mapbender/pull/1742), [PR#1751](https://github.com/mapbender/mapbender/pull/1751))
 * Accessibility: IDs are no longer used in HTML for Mapbender elements ([#PR1750](https://github.com/mapbender/mapbender/pull/1750))

--- a/src/Mapbender/ManagerBundle/Component/ExportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ExportHandler.php
@@ -25,11 +25,7 @@ class ExportHandler extends ExchangeHandler
     {
         gc_enable();
         parent::__construct($em);
-        $em
-            ->getConnection()
-            ->getConfiguration()
-            ->setSQLLogger(null)
-        ;
+        $em->getConnection()->getConfiguration()->setSQLLogger(null);
     }
 
     /**

--- a/src/Mapbender/ManagerBundle/Component/ExportHandler.php
+++ b/src/Mapbender/ManagerBundle/Component/ExportHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mapbender\ManagerBundle\Component;
 
 use Doctrine\Common\Collections\Collection;
@@ -27,7 +28,8 @@ class ExportHandler extends ExchangeHandler
         $em
             ->getConnection()
             ->getConfiguration()
-            ->setSQLLogger(null);
+            ->setSQLLogger(null)
+        ;
     }
 
     /**
@@ -181,7 +183,11 @@ class ExportHandler extends ExchangeHandler
             } elseif ($subObject instanceof Collection) {
                 $data[$fieldName] = array();
                 foreach ($subObject as $item) {
-                    $data[$fieldName][] = $this->handleObject($exportPool, $item);
+                    try {
+                        $data[$fieldName][] = $this->handleObject($exportPool, $item);
+                    } catch (UnpersistedEntity $e) {
+                        // ignore
+                    }
                 }
             } else {
                 try {
@@ -196,7 +202,7 @@ class ExportHandler extends ExchangeHandler
         $exportPool->addEntry($classMeta->getName(), $identValues, $data, true);
         gc_collect_cycles();
         return $referenceData;
-   }
+    }
 
     /**
      * @param AbstractObjectHelper $classInfo

--- a/src/Mapbender/WmsBundle/Component/Wms/SourceInstanceFactory.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/SourceInstanceFactory.php
@@ -193,13 +193,13 @@ class SourceInstanceFactory extends \Mapbender\CoreBundle\Component\Source\Sourc
     protected function layerFromConfig(WmsSource $source, array $data, ?WmsLayerSource $parent = null, int $order = 0): WmsLayerSource
     {
         $layer = new WmsLayerSource();
-        $minScale = !isset($data["minScale"]) ? null : $data["minScale"];
-        $maxScale = !isset($data["maxScale"]) ? null : $data["maxScale"];
+        $minScale = $data["minScale"] ?? null;
+        $maxScale = $data["maxScale"] ?? null;
         $layer
             ->setPriority($order)
             ->setSource($source)
             ->setScale(new MinMax($minScale, $maxScale))
-            ->setTitle(!isset($data['title']) ? '' : $data['title'])
+            ->setTitle($data['title'] ?? '')
         ;
         if (!empty($data['name'])) {
             $layer->setName($data['name']);

--- a/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
@@ -97,7 +97,7 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
             $layerIndex++;
         }
         $tmsIndex = 0;
-        foreach($source->getTilematrixsets() as $set) {
+        foreach ($source->getTilematrixsets() as $set) {
             $set->setId("{$id}_$tmsIndex");
             $tmsIndex++;
         }

--- a/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
@@ -76,6 +76,8 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
         $instance->setOpacity($data['opacity'] ?? 100);
         $instance->setProxy($data['proxy'] ?? false);
 
+        $this->applyLayerInfo($data, $instance->getRootlayer());
+
         $hasLayerInfo = isset($data['layers']) && is_array($data['layers']);
 
         // Layer hierarchy is usually created by the database, do it manually for YAML applications
@@ -169,7 +171,11 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
             return;
         }
         $layerData = $data['layers'][$identifier];
+        $this->applyLayerInfo($layerData, $layer);
+    }
 
+    private function applyLayerInfo(array $layerData, WmtsInstanceLayer $layer): void
+    {
         if (isset($layerData['title'])) {
             $layer->setTitle($layerData['title']);
         }
@@ -178,7 +184,7 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
         }
         $layer->setToggle($layerData['toggle'] ?? true);
         $layer->setAllowtoggle($layerData['allowToggle'] ?? true);
-        $layer->setSelected($layerData['selected'] ?? true);
+        $layer->setSelected($layerData['selected'] ?? $layerData['visible'] ?? true);
         $layer->setActive($layerData['active'] ?? true);
         $layer->setAllowselected($layerData['allowSelected'] ?? true);
         $layer->setAllowinfo($layerData['allowInfo'] ?? true);

--- a/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
@@ -162,12 +162,13 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
         }
     }
 
-    private function applyLayerDataFromYaml(array $data, mixed $layer): void
+    private function applyLayerDataFromYaml(array $data, WmtsInstanceLayer $layer): void
     {
-        if (!isset($data['layers'][$layer->getSourceItem()->getIdentifier()])) {
+        $identifier = $layer->getSourceItem()->getIdentifier();
+        if (!isset($data['layers'][$identifier])) {
             return;
         }
-        $layerData = $data['layers'][$layer->getSourceItem()->getIdentifier()];
+        $layerData = $data['layers'][$identifier];
 
         if (isset($layerData['title'])) {
             $layer->setTitle($layerData['title']);

--- a/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
@@ -9,20 +9,23 @@ use Doctrine\ORM\EntityManagerInterface;
 use Mapbender\CoreBundle\Component\Source\SourceInstanceFactory;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Entity\SourceInstance;
-use Mapbender\WmtsBundle\Entity\WmtsInstance;
-use Mapbender\WmtsBundle\Entity\WmtsInstanceLayer;
-use Mapbender\WmtsBundle\Entity\WmtsLayerSource;
-use Mapbender\WmtsBundle\Entity\WmtsSource;
 use Mapbender\ManagerBundle\Component\Exception\ImportException;
 use Mapbender\ManagerBundle\Component\Exchange\EntityHelper;
 use Mapbender\ManagerBundle\Component\Exchange\EntityPool;
 use Mapbender\ManagerBundle\Component\Exchange\ImportState;
 use Mapbender\ManagerBundle\Component\ImportHandler;
+use Mapbender\ManagerBundle\Form\Model\HttpOriginModel;
+use Mapbender\WmtsBundle\Component\Wmts\Loader;
+use Mapbender\WmtsBundle\Entity\WmtsInstance;
+use Mapbender\WmtsBundle\Entity\WmtsInstanceLayer;
+use Mapbender\WmtsBundle\Entity\WmtsLayerSource;
+use Mapbender\WmtsBundle\Entity\WmtsSource;
 
 abstract class InstanceFactoryCommon extends SourceInstanceFactory
 {
     public function __construct(
         protected EntityManagerInterface $entityManager,
+        protected Loader                 $loader,
     )
     {
     }
@@ -59,7 +62,40 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
 
     public function fromConfig(array $data, string $id): SourceInstance
     {
-        throw new \RuntimeException("Yaml-defined Wmts sources not implemented");
+        $formData = new HttpOriginModel();
+        $formData->setOriginUrl($data['url'] ?? null);
+        $formData->setPassword($data['password'] ?? null);
+        $formData->setUsername($data['username'] ?? null);
+        $source = $this->loader->loadSource($formData);
+        $source->setId($id);
+
+        $instance = $this->createInstance($source);
+        $instance->setId($id);
+        $instance->setBasesource($data['basesource'] ?? $data['isBaseSource'] ?? false);
+        $instance->setOpacity($data['opacity'] ?? 100);
+        $instance->setProxy($data['proxy'] ?? false);
+
+        $layerIndex = 0;
+        $hasLayerInfo = isset($data['layers']) && is_array($data['layers']);
+
+        // Layer hierarchy is usually created by the database, do it manually for YAML applications
+        // also, apply layer settings from the YAML config
+        foreach ($instance->getLayers() as $layer) {
+            if ($hasLayerInfo) {
+                $this->applyLayerDataFromYaml($data, $layer);
+            }
+
+            if ($layer->getParent() !== null) {
+                $layer->getParent()->addSublayer($layer);
+                $instance->removeLayer($layer);
+            }
+        }
+        // set ids (also usually handled by the database)
+        foreach ($instance->getLayers() as $layer) {
+            $this->setLayerId($layer, "{$id}_$layerIndex");
+            $layerIndex++;
+        }
+        return $instance;
     }
 
     public function matchInstanceToPersistedSource(ImportState $importState, array $data, EntityPool $entityPool): bool
@@ -107,5 +143,37 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
             }
         }
         return true;
+    }
+
+    private function setLayerId(WmtsInstanceLayer $layer, string $id): void
+    {
+        $layer->setId($id);
+        $subLayerIndex = 0;
+        foreach ($layer->getSublayer() as $subLayer) {
+            $this->setLayerId($subLayer, "{$id}_$subLayerIndex");
+            $subLayerIndex++;
+        }
+    }
+
+    private function applyLayerDataFromYaml(array $data, mixed $layer): void
+    {
+        if (!isset($data['layers'][$layer->getSourceItem()->getIdentifier()])) {
+            return;
+        }
+        $layerData = $data['layers'][$layer->getSourceItem()->getIdentifier()];
+
+        if (isset($layerData['title'])) {
+            $layer->setTitle($layerData['title']);
+        }
+        if (isset($layerData['priority'])) {
+            $layer->setPriority($layerData['priority']);
+        }
+        $layer->setToggle($layerData['toggle'] ?? true);
+        $layer->setAllowtoggle($layerData['allowToggle'] ?? true);
+        $layer->setSelected($layerData['selected'] ?? true);
+        $layer->setActive($layerData['active'] ?? true);
+        $layer->setAllowselected($layerData['allowSelected'] ?? true);
+        $layer->setAllowinfo($layerData['allowInfo'] ?? true);
+        $layer->setInfo($layerData['info'] ?? true);
     }
 }

--- a/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/InstanceFactoryCommon.php
@@ -66,6 +66,7 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
         $formData->setOriginUrl($data['url'] ?? null);
         $formData->setPassword($data['password'] ?? null);
         $formData->setUsername($data['username'] ?? null);
+        /** @var WmtsSource $source */
         $source = $this->loader->loadSource($formData);
         $source->setId($id);
 
@@ -75,7 +76,6 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
         $instance->setOpacity($data['opacity'] ?? 100);
         $instance->setProxy($data['proxy'] ?? false);
 
-        $layerIndex = 0;
         $hasLayerInfo = isset($data['layers']) && is_array($data['layers']);
 
         // Layer hierarchy is usually created by the database, do it manually for YAML applications
@@ -91,9 +91,15 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
             }
         }
         // set ids (also usually handled by the database)
+        $layerIndex = 0;
         foreach ($instance->getLayers() as $layer) {
             $this->setLayerId($layer, "{$id}_$layerIndex");
             $layerIndex++;
+        }
+        $tmsIndex = 0;
+        foreach($source->getTilematrixsets() as $set) {
+            $set->setId("{$id}_$tmsIndex");
+            $tmsIndex++;
         }
         return $instance;
     }
@@ -148,6 +154,7 @@ abstract class InstanceFactoryCommon extends SourceInstanceFactory
     private function setLayerId(WmtsInstanceLayer $layer, string $id): void
     {
         $layer->setId($id);
+        $layer->getSourceItem()->setId($id);
         $subLayerIndex = 0;
         foreach ($layer->getSublayer() as $subLayer) {
             $this->setLayerId($subLayer, "{$id}_$subLayerIndex");

--- a/src/Mapbender/WmtsBundle/Entity/HttpTileSource.php
+++ b/src/Mapbender/WmtsBundle/Entity/HttpTileSource.php
@@ -91,12 +91,10 @@ abstract class HttpTileSource extends HttpParsedSource
         return $source;
     }
 
-    /**
-     * @param string $version
-     */
-    public function setVersion($version)
+    public function setVersion(string $version): self
     {
         $this->version = $version;
+        return $this;
     }
 
     /**

--- a/src/Mapbender/WmtsBundle/Entity/TileMatrixSet.php
+++ b/src/Mapbender/WmtsBundle/Entity/TileMatrixSet.php
@@ -60,6 +60,12 @@ class TileMatrixSet implements MutableUrlTarget
         return $this->id;
     }
 
+    public function setId($id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
     /**
      *
      * @return HttpTileSource

--- a/src/Mapbender/WmtsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmtsBundle/Resources/config/services.xml
@@ -29,7 +29,8 @@
 		<service id="mapbender.source.wmts.instance_factory"
 				 class="Mapbender\WmtsBundle\Component\InstanceFactoryWmts"
 		         lazy="true">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
+            <argument type="service" id="mapbender.importer.source.wmts.service" />
         </service>
 		<service id="mapbender.imageexport.renderer.wmts" class="%mapbender.imageexport.renderer.wmts.class%">
 		  <argument type="service" id="mapbender.imageexport.image_transport.service" />
@@ -42,7 +43,7 @@
 		<service id="mapbender.importer.source.wmts.service"
 				 class="Mapbender\WmtsBundle\Component\Wmts\Loader"
 				 lazy="true">
-			<argument type="service" id="doctrine.orm.default_entity_manager" />
+			<argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
 			<argument type="service" id="mapbender.http_transport.service" />
 			<argument type="service" id="mapbender.xmlvalidator.service" />
 		</service>
@@ -52,7 +53,8 @@
 		<service id="mapbender.source.tms.instance_factory"
 				 class="Mapbender\WmtsBundle\Component\InstanceFactoryTms"
 				 lazy="true">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
+            <argument type="service" id="mapbender.importer.source.wmts.service" />
         </service>
 	</services>
 </container>

--- a/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
+++ b/src/Mapbender/WmtsBundle/Resources/public/geosource-base.js
@@ -96,7 +96,7 @@ window.Mapbender = Mapbender || {};
         }
 
         createNativeLayers(srsName, mapOptions) {
-            const allLayers = this._getAllLayers();
+            const allLayers = this.getRootLayer().children;
             const rootLayer = this.getRootLayer();
             rootLayer.children = allLayers;
 
@@ -151,7 +151,8 @@ window.Mapbender = Mapbender || {};
         }
 
         _isCompatible(layer, projectionCode) {
-            return (layer.options.treeOptions.allow.selected || layer.options.treeOptions.selected) && layer.selectMatrixSet(projectionCode);
+            const compat = (layer.options.treeOptions.allow.selected || layer.options.treeOptions.selected) && layer.selectMatrixSet(projectionCode);
+            return !!compat;
         }
 
         /**


### PR DESCRIPTION
So far, only WMS sources could be configured in YAML applications. Along with VectorTiles sources introduced in version 4.2, this PR also enables WMTS and TMS sources to be configured using YAML.

It supports the following fields:
- `type`: must be __wmts__ or __tms__
- `url`: URL to the service's Get capability XML. Note that to obtain the TileMatrices this document will be downloaded for every page view (unlike for database WMTS sources, where this information is cached in the database)
- `title`: The source title as displayed in the layer tree
- `basesource` (alias: `isBaseSource`): boolean value if the source should be treated as a base source
- `opacity`: int 0 (fully transparent)-100 (fully opaque) 
- `selected` (alias: `visible`): initial selected state of the root layer. (default: true)
- `allowSelected`: can the user change state of the root layer in the layertree? If selected and allowSelected are both false, the layer is ignored. (default: true)
- `toggle`: initial folder state of the root layer in the layer tree (default: true = folder is expanded)
- `allowToggle`: can the user collapse/expand the root layer? (default: true)
- `layers`: optional object to modify individual sublayers. The key should be the value of the `<ows:Identifier>` attribute in the GetCapabilities document (for WMTS) or the url suffix of the layer for TMS. For example, if The URL of the Capability document is _https://osm-demo.wheregroup.com/tms/1.0.0/_ and the layer's href in the TileMap tag is defined as _https://osm-demo.wheregroup.com/tms/1.0.0/osm/webmercator_, the layer key will be _osm/webmercator_.   
   The value is an object with the following settings:
  - `title` : The layer title as displayed in the layer tree
  - `active`: if false, the layer is ignored and won't be available in the application at all (default: true)
  - `selected` (alias: `visible`): initial selected state of the layer. (default: true)
  - `allowSelected`: can the user change state in the layertree? If selected and allowSelected are both false, the layer is ignored, as if active was set to false. (default: true)


### Sample YAML application using a WMTS source

```yaml
parameters:
    applications:
        wmts_yaml:
            title: WMTS Demo YAML
            published: true
            template:  Mapbender\CoreBundle\Template\Fullscreen
            layersets:
                background themes:
                    selected: true
                    basemap_wmts:
                        type: wmts
                        title: Basemap WMTS
                        basesource: false
                        opacity: 100
                        url: https://basemap.de/dienste/wmts_capabilities_web_raster.xml
                        layers:
                            # Layer ID from the WMTS capabilities (<ows:Identifier>)
                            de_basemapde_web_raster_grau:
                              title: Basemap Grau
                              active: true # if false, the layer is ignored (default: true)
                              selected: false # initial state of the layer. (default: true)
                              allowSelected: true # can the user change state in the layertree? If selected and allowSelected are both false, the layer is ignored. (default: true)
                            de_basemapde_web_raster_farbe:
                              title: Basemap Farbe
            elements:
                content:
                    map:
                        class: Mapbender\CoreBundle\Element\Map
                        layersets: [themes,background themes]
                        srs: EPSG:3857
                        extents:
                            # Freiburg
                            start: [866322.89,6102554.89,881937.85,6112331.21]
                            max: [-20037508.34278924,-20037508.34278924,20037508.34278924,20037508.34278924]
                        scales: [50000000,25000000,10000000,5000000,1000000,500000,100000,50000,25000,10000,7500,5000,2500,1000,500]
                        otherSrs: ["EPSG:25832","EPSG:25833","EPSG:31466","EPSG:31467","EPSG:3857"]
                    zoombar:
                        class: Mapbender\CoreBundle\Element\ZoomBar
                        target: map
                        anchor: right-top
                        draggable: false
                    scalebar:
                        class: Mapbender\CoreBundle\Element\ScaleBar
                        target: map
                        anchor: 'right-bottom'
                        maxWidth: 200
                        units: km
                        screenType: desktop
                sidepane:
                    layertree:
                        class: Mapbender\CoreBundle\Element\Layertree
```