### PR TITLE
Improve performance for applications with many layers - Backend Part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 
 Other:
 * Data Sources handling refactored to simplify adding new sources ([#PR1745](https://github.com/mapbender/mapbender/pull/1745))
+* Improved performance for applications with many layers ([#PR1744](https://github.com/mapbender/mapbender/pull/1744), [#PR1756](https://github.com/mapbender/mapbender/pull/1756))
 * Removed Popup2 ([#PR1713](https://github.com/mapbender/mapbender/pull/1713))
 * Fixed typo for imageexport-related services and parameters (imaage -> image) ([#PR1745](https://github.com/mapbender/mapbender/pull/1745))
 

--- a/src/Mapbender/CoreBundle/Component/Source/SourceInstanceConfigGenerator.php
+++ b/src/Mapbender/CoreBundle/Component/Source/SourceInstanceConfigGenerator.php
@@ -56,4 +56,14 @@ abstract class SourceInstanceConfigGenerator implements SourceInstanceInformatio
     {
         return false;
     }
+
+    /**
+     * Can be used to preload source instances, e.g. to avoid doctrine
+     * lazy loading producing many separate queries
+     * @param SourceInstance[] $sourceInstances
+     */
+    public function preload(array $sourceInstances): void
+    {
+        // No-op by default, can be overridden to preload data for the application.
+    }
 }

--- a/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
+++ b/src/Mapbender/CoreBundle/Component/Source/Tunnel/InstanceTunnelService.php
@@ -142,15 +142,17 @@ class InstanceTunnelService
     }
 
     /**
-     * @param WmsInstanceLayer|SourceInstanceItem $instanceLayer
+     * @param array|SourceInstanceItem $instanceLayer
      * @return string
      */
-    public function generatePublicLegendUrl(SourceInstanceItem $instanceLayer)
+    public function generatePublicLegendUrl(SourceInstanceItem|array $instanceLayer, ?SourceInstance $sourceInstance)
     {
-        $sourceInstance = $instanceLayer->getSourceInstance();
+        if (!$sourceInstance && $instanceLayer instanceof  SourceInstanceItem) {
+            $sourceInstance = $instanceLayer->getSourceInstance();
+        }
         return $this->router->generate($this->legendTunnelRouteName, array(
             'instanceId' => $sourceInstance->getId(),
-            'layerId' => $instanceLayer->getId(),
+            'layerId' => is_array($instanceLayer) ? $instanceLayer['id'] : $instanceLayer->getId(),
         ));
     }
 

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -199,6 +199,7 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="mapbender.element_filter" />
             <argument type="service" id="mapbender.source.typedirectory.service" />
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
             <argument type="service" id="mapbender.source.url_processor.service" />
             <argument type="service" id="router" />
             <argument type="service" id="assets._default_package" />

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -381,7 +381,7 @@ class WmsInstanceLayer extends SourceInstanceItem
             return $sourceItemScale;
         }
         $parent = $this->getParent();
-        return $parent ? $parent->getMinScale(true) : null;
+        return $parent?->getMinScale(true);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstanceLayer.php
@@ -115,10 +115,6 @@ class WmsInstanceLayer extends SourceInstanceItem
         if ($this->maxScale == INF) {
             $this->maxScale = null;
         }
-        if (!$this->sublayer->count() && ($this->toggle !== null || $this->allowtoggle !== null)) {
-            $this->setToggle(null);
-            $this->setAllowtoggle(null);
-        }
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsLayerSource.php
@@ -472,29 +472,31 @@ class WmsLayerSource extends SourceItem implements ContainingKeyword, MutableUrl
 
     /**
      * Get styles incl. from parent WmsLayerSource (OGC WMS
-     * Implemantation Specification)
+     * Implementation Specification)
      * @param bool $inherit to also return style objects from parent layer(s)
      *
      * @return Style[]
      */
     public function getStyles($inherit = false)
     {
-        if ($inherit && $this->getParent() !== null) {
-            $styles = array_values($this->getParent()->getStyles(true) ?? []);
-            // ignore title&name combinations that are present both in the parent and in the child
-            foreach ($this->styles as $childStyle) {
-                foreach ($styles as $parentStyle) {
-                    if ($parentStyle->getTitle() === $childStyle->getTitle()
-                        && $parentStyle->getName() === $childStyle->getTitle()) {
-                        continue 2;
-                    }
-                }
-                $styles[] = $childStyle;
-            }
-            return $styles;
-        } else {
+        if (!$inherit || $this->getParent() === null) {
             return $this->styles;
         }
+
+        /** @var Style[] $styles */
+        $styles = array_values($this->getParent()->getStyles(true) ?? []);
+        // ignore title&name combinations that are present both in the parent and in the child
+        foreach ($this->styles as $childStyle) {
+            /** @var Style $childStyle */
+            foreach ($styles as $parentStyle) {
+                if ($parentStyle->getTitle() === $childStyle->getTitle()
+                    && $parentStyle->getName() === $childStyle->getName()) {
+                    continue 2;
+                }
+            }
+            $styles[] = $childStyle;
+        }
+        return $styles;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -36,6 +36,7 @@
         <service id="mapbender.source.wms.config_generator" class="%mapbender.source.wms.config_generator.class%">
             <argument type="service" id="mapbender.source.url_processor.service" />
             <argument type="service" id="security.token_storage" />
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument>%wms.default_layer_order%</argument>
         </service>
         <service id="mapbender.source.wms.instance_factory" class="%mapbender.source.wms.instance_factory.class%">


### PR DESCRIPTION
This is a follow-up to #1744.

Having many layers in an application significantly slowed down loading time, on the one hand in the frontend when generating the layer tree, but also in the backend when creating the application config.

It was discovered, that for resolving sublayers, doctrine makes a separate database call for every single instance layer. Also, using the xdebug profiling tool, it was discovered that doctrine's hydration of the individual database objects takes a lot of time (~30% of the whole processing time), specifically hydrating WmsInstanceLayers. 

As a consequence, the WmsSourceInstanceConfigGenerator was refactored to avoid hydrating objects for each layer but instead have a single database call returning an array with the data. 
The downside is that some code needs to be duplicated and the code is less readable and less object-oriented. However, the performance boost is huge. 

The table illustrates the performance metrics in an exemplary application having 944 instance layers in the application. Each time, the application config was called 100 times.

|                           | **before refactoring**           | **after refactoring**           |
|---------------------------|:-------------------------------:|:-------------------------------:|
| **Individual database calls** | 1331                          | 216                             |
| **Min**                   | 1133.146 ms                     | 510.181 ms                      |
| **Max**                   | 1634.287 ms                     | 833.666 ms                      |
| **Median**                | 1225.509 ms                     | 561.619 ms                      |
| **Stddev**                | 78.099 ms                       | 38.960 ms                       |


