### PR TITLE
 Implement auto refresh functionality for wms 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 * Accessibility: Buttons, control elements and elements in the sidepane can be accessed by clicking the tab key and triggered with the enter key ([PR#1742](https://github.com/mapbender/mapbender/pull/1742), [PR#1751](https://github.com/mapbender/mapbender/pull/1751))
 * Accessibility: IDs are no longer used in HTML for Mapbender elements ([#PR1750](https://github.com/mapbender/mapbender/pull/1750))
 * [FeatureInfo] Support point geometries in feature info highlighting ([#PR1747](https://github.com/mapbender/mapbender/pull/1747))
+* [WMS] Add auto-refresh functionality (e.g. for services visualising sensor data) ([#PR1759](https://github.com/mapbender/mapbender/pull/1759))
 
 Other:
 * Data Sources handling refactored to simplify adding new sources ([#PR1745](https://github.com/mapbender/mapbender/pull/1745))

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -101,6 +101,7 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
             'dimensions' => $this->getDimensionsConfiguration($sourceInstance),
             'buffer' => $buffer,
             'ratio' => $ratio,
+            'refreshInterval' => $sourceInstance->getRefreshInterval(),
             'layerOrder' => $sourceInstance->getLayerOrder(),
         );
     }

--- a/src/Mapbender/WmsBundle/Component/Wms/SourceInstanceFactory.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/SourceInstanceFactory.php
@@ -86,6 +86,7 @@ class SourceInstanceFactory extends \Mapbender\CoreBundle\Component\Source\Sourc
             ->setOpacity(!isset($data['opacity']) ? 100 : $data['opacity'])
             ->setTiled(!isset($data['tiled']) ? false : $data['tiled'])
             ->setBasesource(!isset($data['isBaseSource']) ? true : $data['isBaseSource'])
+            ->setRefreshInterval($data['refreshInterval'] ?? null)
         ;
         if (!empty($data['layerorder'])) {
             $instance->setLayerOrder($data['layerorder']);

--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -67,6 +67,9 @@ class WmsInstance extends SourceInstance implements SupportsOpacity, SupportsPro
     #[ORM\Column(type: 'decimal', scale: 2, options: ['default' => '1.25'])]
     protected $ratio = 1.25;
 
+    #[ORM\Column(name: 'refresh_interval', type: 'integer', nullable: true, options: ['default' => null])]
+    protected ?int $refreshInterval = null;
+
     const LAYER_ORDER_TOP_DOWN  = 'standard';
     const LAYER_ORDER_BOTTOM_UP = 'reverse';
 
@@ -410,6 +413,16 @@ class WmsInstance extends SourceInstance implements SupportsOpacity, SupportsPro
     public function getSource()
     {
         return $this->source;
+    }
+
+    public function getRefreshInterval(): ?int
+    {
+        return $this->refreshInterval;
+    }
+
+    public function setRefreshInterval(?int $refreshInterval): void
+    {
+        $this->refreshInterval = $refreshInterval;
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
+++ b/src/Mapbender/WmsBundle/Form/Type/WmsInstanceInstanceLayersType.php
@@ -2,21 +2,29 @@
 
 namespace Mapbender\WmsBundle\Form\Type;
 
+use Mapbender\CoreBundle\Element\Type\MapbenderTypeTrait;
+use Mapbender\ManagerBundle\Form\Type\SourceInstanceLayerCollectionType;
 use Mapbender\WmsBundle\Entity\WmsInstance;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class WmsInstanceInstanceLayersType extends AbstractType
 {
-    /** @var bool */
-    protected $exposeLayerOrder;
+    use MapbenderTypeTrait;
 
     /**
      * @param bool $exposeLayerOrder to expose layer order controls; from parameter mapbender.preview.layer_order.wms
      */
-    public function __construct($exposeLayerOrder = false)
+    public function __construct(
+        protected bool $exposeLayerOrder = false,
+        protected TranslatorInterface $translator)
     {
-        $this->exposeLayerOrder = $exposeLayerOrder;
     }
 
     public function getParent(): string
@@ -49,41 +57,46 @@ class WmsInstanceInstanceLayersType extends AbstractType
         }
 
         $builder
-            ->add('format', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            ->add('format', ChoiceType::class, array(
                 'choices' => $getMapFormatChoices,
                 'required' => true,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.format',
             ))
-            ->add('infoformat', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            ->add('infoformat', ChoiceType::class, array(
                 'choices' => $featureInfoFormatChoices,
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.infoformat',
             ))
-            ->add('exceptionformat', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            ->add('exceptionformat', ChoiceType::class, array(
                 'choices' => $exceptionFormatChoices,
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.exceptionformat',
             ))
-            ->add('transparency', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('transparency', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.transparency',
             ))
-            ->add('tiled', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+            ->add('tiled', CheckboxType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.tiled',
             ))
-            ->add('ratio', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
+            ->add('ratio', NumberType::class, array(
                 'required' => false,
                 'scale' => 2,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.ratio',
             ))
-            ->add('buffer', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', array(
+            ->add('buffer', IntegerType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.buffer',
             ))
+            ->add('refreshInterval', IntegerType::class, $this->createInlineHelpText(array(
+                'required' => false,
+                'label' => 'mb.wms.wmsloader.repo.instance.label.refresh_interval',
+                'help' => 'mb.wms.wmsloader.repo.instance.label.refresh_interval_help',
+            ), $this->translator))
         ;
         if ($source->getDimensions()) {
-            $builder->add('dimensions', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            $builder->add('dimensions', CollectionType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.dimensions',
                 'entry_type' => 'Mapbender\WmsBundle\Form\Type\DimensionInstType',
@@ -97,7 +110,7 @@ class WmsInstanceInstanceLayersType extends AbstractType
             ));
         }
         $builder
-            ->add('vendorspecifics', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            ->add('vendorspecifics', CollectionType::class, array(
                 'required' => false,
                 'label' => 'mb.wms.wmsloader.repo.instance.label.vendorspecifics',
                 'entry_type' => 'Mapbender\WmsBundle\Form\Type\VendorSpecificType',
@@ -107,7 +120,7 @@ class WmsInstanceInstanceLayersType extends AbstractType
                     'by_reference' => false,
                 ),
             ))
-            ->add('layers', 'Mapbender\ManagerBundle\Form\Type\SourceInstanceLayerCollectionType', array(
+            ->add('layers', SourceInstanceLayerCollectionType::class, array(
                 'entry_type' => 'Mapbender\WmsBundle\Form\Type\WmsInstanceLayerType',
                 'label' => 'mb.wms.wmsloader.repo.instance.label.layers',
                 'entry_options' => array(
@@ -122,7 +135,7 @@ class WmsInstanceInstanceLayersType extends AbstractType
                 $translationKey = "mb.wms.wmsloader.repo.instance.label.layerorder.$validChoice";
                 $layerOrderChoices[$translationKey] = $validChoice;
             }
-            $builder->add('layerOrder', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            $builder->add('layerOrder', ChoiceType::class, array(
                 'choices' => $layerOrderChoices,
                 'required' => true,
                 'auto_initialize' => true,

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -46,6 +46,7 @@
         <!-- servicy form type for wms instances; required to inject other services / params -->
         <service id="mapbender.sourceinstance.wms.form" class="Mapbender\WmsBundle\Form\Type\WmsInstanceInstanceLayersType">
             <argument>%mapbender.preview.layer_order.wms%</argument>
+            <argument type="service" id="translator" />
             <tag name="form.type" />
         </service>
         <service id="mapbender.init_db_handler.prune_invalid_wms_sources" class="Mapbender\WmsBundle\EventHandler\InitDb\PruneInvalidWmsSourcesHandler">

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -81,8 +81,9 @@ window.Mapbender = Mapbender || {};
             // ... but we will not remember the following ~standard WMS params the same way
             this._runtimeParams = ['LAYERS', 'STYLES', 'EXCEPTIONS', 'QUERY_LAYERS', 'INFO_FORMAT', '_OLSALT'];
 
-            if (this.options.refreshInterval) {
-                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshInterval * 1000);
+            if (this.options.refreshInterval && this.options.refreshInterval > 0) {
+                this.options.refreshIntervalMs = this.options.refreshInterval * 1000;
+                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshIntervalMs);
             }
         }
 
@@ -156,14 +157,14 @@ window.Mapbender = Mapbender || {};
         }
 
         refresh() {
-            if (this.refreshIntervalCode) clearTimeout(this.refreshIntervalCode)
+            if (this.refreshIntervalCode) clearTimeout(this.refreshIntervalCode);
             var cacheBreakParams = {
                 _OLSALT: Math.random()
             };
             this.addParams(cacheBreakParams);
 
-            if (this.options.refreshInterval) {
-                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshInterval * 1000);
+            if (this.options.refreshIntervalMs) {
+                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshIntervalMs);
             }
         }
 

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -80,6 +80,10 @@ window.Mapbender = Mapbender || {};
 
             // ... but we will not remember the following ~standard WMS params the same way
             this._runtimeParams = ['LAYERS', 'STYLES', 'EXCEPTIONS', 'QUERY_LAYERS', 'INFO_FORMAT', '_OLSALT'];
+
+            if (this.options.refreshInterval) {
+                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshInterval * 1000);
+            }
         }
 
         createNativeLayers(srsName, mapOptions) {
@@ -152,10 +156,15 @@ window.Mapbender = Mapbender || {};
         }
 
         refresh() {
+            if (this.refreshIntervalCode) clearTimeout(this.refreshIntervalCode)
             var cacheBreakParams = {
                 _OLSALT: Math.random()
             };
             this.addParams(cacheBreakParams);
+
+            if (this.options.refreshInterval) {
+                this.refreshIntervalCode = setTimeout(() => this.refresh(), this.options.refreshInterval * 1000);
+            }
         }
 
         addParams(params) {

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.de.yaml
@@ -41,14 +41,16 @@ mb:
             ratio: BBOX-Faktor
             buffer: Kachel-Puffer
             layerorder: Layer-Reihenfolge
-            layerorder.standard: 'Standard'
-            layerorder.reverse: 'QGIS'
+            layerorder.standard: Standard
+            layerorder.reverse: QGIS
             exceptionformat: Fehler-Format
             infoformat: 'Format der GetFeatureInfo-Anfrage'
             format: 'Format der GetMap-Anfrage'
             dimensions: Dimensions
             vendorspecifics: 'Benutzerdefinierte Parameter'
             layers: Ebenen
+            refresh_interval: 'Aktualisierungsintervall [s]'
+            refresh_interval_help: 'Falls gesetzt und nicht 0, wird der Dienst automatisch im angegebenen Intervall (in Sekunden) aktualisiert.'
           vendorspecific:
             label: 'Vendor specific'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.en.yaml
@@ -49,6 +49,8 @@ mb:
             dimensions: Dimensions
             vendorspecifics: 'Vendor specific parameters'
             layers: Layers
+            refresh_interval: 'Update interval [s]'
+            refresh_interval_help: 'If set and not 0, the service will automatically update at the specified interval (in seconds).'
           vendorspecific:
             label: 'Vendor specifics'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.es.yaml
@@ -41,14 +41,16 @@ mb:
             ratio: 'BBOX factor'
             buffer: 'Tile buffer'
             layerorder: 'Orden de capas'
-            layerorder.standard: 'estándar'
+            layerorder.standard: estándar
             layerorder.reverse: QGIS
             exceptionformat: 'Formato de excepción'
             infoformat: 'Formato de la solicitud GetFeatureInfo'
             format: 'Formato de la solicitud GetMap'
-            dimensions: 'Dimensiones'
+            dimensions: Dimensiones
             vendorspecifics: 'Parámetros específicos de vendor'
-            layers: 'Capas'
+            layers: Capas
+            refresh_interval: 'Intervalo de actualización [s]'
+            refresh_interval_help: 'Si se establece y no es 0, el servicio se actualizará automáticamente en el intervalo especificado (en segundos).'
           vendorspecific:
             label: 'Vendor specífico'
         preview:
@@ -88,13 +90,13 @@ mb:
             extent: Extensión
             dataurl: 'URL de los datos'
             featurelisturl: 'URL de Featurelist'
-        instancelayerform:
+        instancelayerform: null
       class:
         title: 'Cargar WMS'
         description: 'Carga un WMS via getCapabilities-Request'
       admin:
         label:
-            splitlayers: 'Separar las capas'
+          splitlayers: 'Separar las capas'
     repository:
       parser:
         couldnotparse: 'No se puede analizar el documento XML.'
@@ -112,7 +114,7 @@ mb:
         useconditions:
           title: 'Condiciones de uso'
       popup:
-        title: 'Metadatos'
+        title: Metadatos
     repo:
       instance:
         label:
@@ -150,6 +152,6 @@ mb:
     vendorspecifictype:
       admin:
         vstype: 'Tipo de parámetro'
-        name: 'Nombre'
+        name: Nombre
         default: 'Valor predeterminado'
-        hidden: 'Oculto'
+        hidden: Oculto

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.fr.yaml
@@ -4,9 +4,9 @@ mb:
       dialog:
         label:
           example: Exemple
-          wmsurl: URL du service
-          wmsuser: Nom d'utilisateur
-          wmspass: Mot de passe
+          wmsurl: 'URL du service'
+          wmsuser: 'Nom d''utilisateur'
+          wmspass: 'Mot de passe'
       error:
         load: 'WMSLoader: Impossible de chrager les WMS capabilities!'
       repo:
@@ -15,10 +15,10 @@ mb:
             formats: Formats
         view:
           label:
-            onlineresource: Ressource en ligne
-            exceptionformats: Formats d'exception
+            onlineresource: 'Ressource en ligne'
+            exceptionformats: 'Formats d''exception'
             fees: Frais
-            accessconstraints: Contraintes d'accès
+            accessconstraints: 'Contraintes d''accès'
           message:
             cautionscalehint: 'Attention: Le calcul de l''échelle est potentiellement limité par la résolution de ScaleHint dans le service WMS version 1.1.1'
         instance:
@@ -38,13 +38,15 @@ mb:
             reorder: Réorganiser
             allow: permettre
             'on': 'on'
-            ratio: BBOX factor
-            buffer: Tampon de la tuile
+            ratio: 'BBOX factor'
+            buffer: 'Tampon de la tuile'
+            refresh_interval: 'Intervalle de mise à jour [s]'
+            refresh_interval_help: 'Si défini et différent de 0, le service sera automatiquement mis à jour à l’intervalle spécifié (en secondes).'
           vendorspecific:
-            label: Vendor specific
+            label: 'Vendor specific'
         preview:
           title:
-            servicerepository: Répertoire du service
+            servicerepository: 'Répertoire du service'
           label:
             load: Charger
         layer:
@@ -62,40 +64,40 @@ mb:
             boundingbox: BoundingBox
             srs: SRS
             styles: Styles
-            legendurl: URL de la légende
+            legendurl: 'URL de la légende'
             scale: Échelle
             min: Min
             max: Max
             scalehint: Scalehint
             attribution: Attribution
-            onlineresource: Online Resource
-            logourl: URL du logo
+            onlineresource: 'Online Resource'
+            logourl: 'URL du logo'
             identifier: Identifier
             authority: Authorité
             url: URL
             value: Valeur
-            metadataurl: URL des métadonnées
+            metadataurl: 'URL des métadonnées'
             dimension: Dimension
             extent: Étendue
-            dataurl: URL des données
-            featurelisturl: URL du featurelist
+            dataurl: 'URL des données'
+            featurelisturl: 'URL du featurelist'
       class:
-        title: Chargeur de WMS
-        description: Charge un service WMS via une requête 'getCapabilities'
+        title: 'Chargeur de WMS'
+        description: 'Charge un service WMS via une requête ''getCapabilities'''
       admin:
         label:
-          splitlayers: Séparer les couches
+          splitlayers: 'Séparer les couches'
     repository:
       parser:
-        couldnotparse: Impossible d'analyser CapabilitiesDocument
-        not_supported_document: Le CapabilitiesDocument n'est pas supporté
-        not_supported_version: La version du service WMS n'est pas supportée
+        couldnotparse: 'Impossible d''analyser CapabilitiesDocument'
+        not_supported_document: 'Le CapabilitiesDocument n''est pas supporté'
+        not_supported_version: 'La version du service WMS n''est pas supportée'
     metadata:
       section:
         common:
           _title: Commun
         useconditions:
-          _title: Conditions d'utilisation
+          _title: 'Conditions d''utilisation'
         contact:
           _title: Contact
         items:
@@ -107,7 +109,7 @@ mb:
           dimensions: Dimensions
     dimhandler:
       class:
-        title: Prise en charge des dimensions
-        description: DimensionsHandler groupe and fait appel aux instances supportant les dimensions
+        title: 'Prise en charge des dimensions'
+        description: 'DimensionsHandler groupe and fait appel aux instances supportant les dimensions'
     dimensionsets:
-      no_dimension: Aucune dimension
+      no_dimension: 'Aucune dimension'

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.it.yaml
@@ -46,9 +46,11 @@ mb:
             exceptionformat: 'Formato di eccezione'
             infoformat: 'Formato della richiesta GetFeatureInfo'
             format: 'Formato della richiesta GetMap'
-            dimensions: 'Dimensioni'
+            dimensions: Dimensioni
             vendorspecifics: 'Parametri specifici del produttore'
-            layers: 'Layers'
+            layers: Layers
+            refresh_interval: 'Intervallo di aggiornamento [s]'
+            refresh_interval_help: 'Se impostato e diverso da 0, il servizio verrà aggiornato automaticamente all''intervallo specificato (in secondi).'
           vendorspecific:
             label: 'specifiche per il produttore'
         preview:

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.nl.yaml
@@ -4,7 +4,7 @@ mb:
       dialog:
         label:
           example: Voorbeeld
-          wmsurl: Service URL
+          wmsurl: 'Service URL'
           wmsuser: Gebruiker
           wmspass: Wachtwoord
       error:
@@ -15,10 +15,10 @@ mb:
             formats: Formaten
         view:
           label:
-            onlineresource: Online Resource
-            exceptionformats: Exceptie Formaten
+            onlineresource: 'Online Resource'
+            exceptionformats: 'Exceptie Formaten'
             fees: Fees
-            accessconstraints: Toegangs beperkingen
+            accessconstraints: 'Toegangs beperkingen'
           message:
             cautionscalehint: 'Pas op: Schaal berekeningen zijn onderworpen aan gelimiteerde Schaal-Hint resolutie in WMS 1.1.1!'
         instance:
@@ -27,24 +27,26 @@ mb:
             cancel: Annuleren
           label:
             transparency: Doorzichtigheid
-            tiled: Getegeld (Tiled)
+            tiled: 'Getegeld (Tiled)'
             title: Titel
-            minsc: Minimale schaal
-            maxsc: Maximale schaal
+            minsc: 'Minimale schaal'
+            maxsc: 'Maximale schaal'
             active: actief
             select: selecteer
             info: info
-            toggle: wissel (toggle)
+            toggle: 'wissel (toggle)'
             reorder: herorder
-            allow: sta toe
+            allow: 'sta toe'
             'on': aan
-            buffer: BBOX factor
-            ratio: Tile buffer
+            buffer: 'BBOX factor'
+            ratio: 'Tile buffer'
+            refresh_interval: 'Update-interval [s]'
+            refresh_interval_help: 'Indien ingesteld en niet 0, wordt de dienst automatisch bijgewerkt met het opgegeven interval (in seconden).'
           vendorspecific:
             label: Leverancier-specifiek
         preview:
           title:
-            servicerepository: Service Repository
+            servicerepository: 'Service Repository'
           label:
             load: Laad
         layer:
@@ -62,34 +64,34 @@ mb:
             boundingbox: BoundingBox
             srs: SRS
             styles: Stijlen
-            legendurl: Legenda URL
+            legendurl: 'Legenda URL'
             scale: Schaal
             min: Min
             max: Max
-            scalehint: Schaal hint
+            scalehint: 'Schaal hint'
             attribution: Attribution
-            onlineresource: Online bron
-            logourl: Logo URL
+            onlineresource: 'Online bron'
+            logourl: 'Logo URL'
             identifier: Identifier
             authority: Autoriteit
             url: URL
             value: Waarde
-            metadataurl: Metadata URL
+            metadataurl: 'Metadata URL'
             dimension: Dimensie
             extent: Extent
-            dataurl: Data URL
-            featurelisturl: Kenmerklijst URL
+            dataurl: 'Data URL'
+            featurelisturl: 'Kenmerklijst URL'
       class:
-        title: WMS lader
-        description: Laad een WMS via de getCapabilities-Request
+        title: 'WMS lader'
+        description: 'Laad een WMS via de getCapabilities-Request'
       admin:
         label:
-          splitlayers: Splits lagen
+          splitlayers: 'Splits lagen'
     repository:
       parser:
-        couldnotparse: Kon Capabilities Document niet parsen
-        not_supported_document: Niet-ondersteund Capabilities Document
-        not_supported_version: De WMS version wordt niet ondersteund
+        couldnotparse: 'Kon Capabilities Document niet parsen'
+        not_supported_document: 'Niet-ondersteund Capabilities Document'
+        not_supported_version: 'De WMS version wordt niet ondersteund'
     metadata:
       section:
         common:
@@ -107,7 +109,7 @@ mb:
           dimensions: Dimensies
     dimhandler:
       class:
-        title: Dimensie afhandelaar
-        description: Dimensie afhandelaar groepen en roept dimensie ondersteund op kaart aan
+        title: 'Dimensie afhandelaar'
+        description: 'Dimensie afhandelaar groepen en roept dimensie ondersteund op kaart aan'
     dimensionsets:
-      no_dimension: geen dimensie
+      no_dimension: 'geen dimensie'

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.pt.yaml
@@ -27,7 +27,7 @@ mb:
             cancel: Cancelar
           label:
             transparency: Transparência
-            tiled: 'Tiled'
+            tiled: Tiled
             title: Título
             minsc: 'Escala mínima'
             maxsc: 'Escala máxima'
@@ -41,14 +41,16 @@ mb:
             ratio: 'Fator BBox'
             buffer: 'Tile buffer'
             layerorder: 'Ordenamento da layer'
-            layerorder.standard: 'Padrão'
-            layerorder.reverse: 'QGIS'
+            layerorder.standard: Padrão
+            layerorder.reverse: QGIS
             exceptionformat: 'Formato para erros'
             infoformat: 'Formato da requisição GetFeatureInfo'
             format: 'Formato da requisição GetMap'
-            dimensions: 'Dimensões'
+            dimensions: Dimensões
             vendorspecifics: 'Parâmetros de pedidos vendor'
-            layers: 'Layers'
+            layers: Layers
+            refresh_interval: 'Intervalo de atualização [s]'
+            refresh_interval_help: 'Se definido e diferente de 0, o serviço será atualizado automaticamente no intervalo especificado (em segundos).'
           vendorspecific:
             label: 'Pedidos vendor'
         preview:
@@ -102,7 +104,7 @@ mb:
     metadata:
       section:
         common:
-          title: Informações gerais
+          title: 'Informações gerais'
         contact:
           title: Contato
         items:
@@ -118,16 +120,16 @@ mb:
           dimensions: Dimensão
     dimhandler:
       class:
-        title: Manipulador de Dimensões
-        description: O Manipulador de Dimensões agrupa e chama as instâncias suportadas por dimensões no mapa
+        title: 'Manipulador de Dimensões'
+        description: 'O Manipulador de Dimensões agrupa e chama as instâncias suportadas por dimensões no mapa'
     dimensionsets:
       no_dimension: 'Não existe nenhuma dimensão'
   core:
     dimensionset:
       admin:
-        title: 'Título'
-        group: 'Grupo'
-        extent: 'Extensão'
+        title: Título
+        group: Grupo
+        extent: Extensão
     dimensionshandler:
       admin:
         tooltip: 'Dica de Ferramenta'
@@ -137,18 +139,18 @@ mb:
         defaultformat: 'Formato Padrão'
         defaultinfoformat: 'Formato de Informação Padrão'
       onlineresource:
-        format: 'Formato'
-        href: 'Href'
+        format: Formato
+        href: Href
       legendurltype:
-        width: 'Largura'
-        height: 'Altura'
+        width: Largura
+        height: Altura
         onlineresource: 'Fonte Online'
       vendorspecifictype:
-        hidden: 'Oculto'
+        hidden: Oculto
         setdefaults: 'Definir padrões'
     vendorspecifictype:
       admin:
         vstype: 'Tipo de Parâmetro'
-        name: 'Nome'
+        name: Nome
         default: 'Valor Padrão'
-        hidden: 'Oculto'
+        hidden: Oculto

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.ru.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.ru.yaml
@@ -16,7 +16,7 @@ mb:
         view:
           label:
             onlineresource: 'Интернет ресурс'
-            exceptionformats: 'Форматы-исключения'
+            exceptionformats: Форматы-исключения
             fees: Сборы
             accessconstraints: 'Ограничения доступа'
           message:
@@ -46,11 +46,13 @@ mb:
             exceptionformat: 'Формат ошибки'
             infoformat: 'Формат запроса GetFeatureInfo'
             format: 'Формат запроса GetMap'
-            dimensions: 'Измерение'
+            dimensions: Измерение
             vendorspecifics: 'Пользовательские параметры'
-            layers: 'Слои'
+            layers: Слои
+            refresh_interval: 'Интервал обновления [с]'
+            refresh_interval_help: 'Если установлено и не равно 0, сервис будет автоматически обновляться с указанным интервалом (в секундах).'
           vendorspecific:
-            label: 'Vendor-определенный'
+            label: Vendor-определенный
           message:
             cautionscalehint: 'Внимание: расчеты Scale подлежат ограниченное разрешение шкалы в WMS 1.1.1!'
         preview:
@@ -107,17 +109,17 @@ mb:
           title: 'Общая информация'
           _title: общий
         contact:
-          title: 'Контакт'
+          title: Контакт
           _title: контакт
         items:
-          title: 'Слой'
+          title: Слой
           name: Имя
           _title: Слой
         useconditions:
           title: 'Условия использования'
           _title: 'условия использования'
       popup:
-        title: 'Метаданные'
+        title: Метаданные
     repo:
       instance:
         label:
@@ -131,9 +133,9 @@ mb:
   core:
     dimensionset:
       admin:
-        title: 'Заголовок'
-        group: 'Группа'
-        extent: 'Размер'
+        title: Заголовок
+        group: Группа
+        extent: Размер
     dimensionshandler:
       admin:
         tooltip: 'Всплывающая подсказка'
@@ -143,18 +145,18 @@ mb:
         defaultformat: 'Фотмат по умолчанию'
         defaultinfoformat: 'Информационный фотмат по умолчанию'
       onlineresource:
-        format: 'Фотмат'
-        href: 'href'
+        format: Фотмат
+        href: href
       legendurltype:
-        width: 'Ширина'
-        height: 'Высота'
-        onlineresource: 'Online-ресурс'
+        width: Ширина
+        height: Высота
+        onlineresource: Online-ресурс
       vendorspecifictype:
-        hidden: 'Cкрыть'
+        hidden: Cкрыть
         setdefaults: 'Установить по умолчанию'
     vendorspecifictype:
       admin:
         vstype: 'Тип параметра'
-        name: 'Имя'
+        name: Имя
         default: 'Значение по умолчанию'
-        hidden: 'Cкрыть'
+        hidden: Cкрыть

--- a/src/Mapbender/WmsBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/WmsBundle/Resources/translations/messages.uk.yaml
@@ -4,7 +4,7 @@ mb:
       dialog:
         label:
           example: Приклад
-          wmsurl: Сервіс URL
+          wmsurl: 'Сервіс URL'
           wmsuser: Користувач
           wmspass: Пароль
       error:
@@ -15,10 +15,10 @@ mb:
             formats: Формат
         view:
           label:
-            onlineresource: Інтернет ресурс
-            exceptionformats: Формат Виключення
+            onlineresource: 'Інтернет ресурс'
+            exceptionformats: 'Формат Виключення'
             fees: Збори
-            accessconstraints: Обмеження доступу
+            accessconstraints: 'Обмеження доступу'
           message:
             cautionscalehint: 'Увага: розрахунки Scale підлягають обмеженій роздільній здатності шкали в WMS 1.1.1!'
         instance:
@@ -35,83 +35,85 @@ mb:
             select: Обрати
             info: Інформація
             toggle: Перемикач
-            reorder: Зміна порядку
+            reorder: 'Зміна порядку'
             allow: Дозволити
             'on': Включити
-            ratio: BBOX фактор
+            ratio: 'BBOX фактор'
             buffer: Буфер
-            layerorder: Порядок шарів
+            layerorder: 'Порядок шарів'
             layerorder.standard: Стандартний
             layerorder.reverse: QGIS
+            refresh_interval: 'Інтервал оновлення [с]'
+            refresh_interval_help: 'Якщо встановлено і не дорівнює 0, служба буде автоматично оновлюватися з заданим інтервалом (у секундах).'
           vendorspecific:
-            label: певний Vendor
+            label: 'певний Vendor'
         preview:
           title:
-            servicerepository: Обслуговування репозиторію
+            servicerepository: 'Обслуговування репозиторію'
           label:
             load: Завантажити
         layer:
           label:
-            name: Ім'я
+            name: 'Ім''я'
             title: Назва
             abstract: Абстрактний
             queryable: Queryable
             cascaded: Каскадна
             opaque: Непрозорий
-            nosubset: Немає підгрупи
-            fixedwidth: Фіксована ширина
-            fixedheight: Фіксована висота
+            nosubset: 'Немає підгрупи'
+            fixedwidth: 'Фіксована ширина'
+            fixedheight: 'Фіксована висота'
             latlonbounds: LatLonBounds
             boundingbox: BoundingBox
             srs: SRS
             styles: Стилі
-            legendurl: Легенда URL
+            legendurl: 'Легенда URL'
             scale: Шкала
             min: Мінімальний
             max: Максимальний
-            scalehint: Примітка масштабу
+            scalehint: 'Примітка масштабу'
             attribution: Атрибуція
-            onlineresource: Інтернет ресурсів
-            logourl: Лого URL
+            onlineresource: 'Інтернет ресурсів'
+            logourl: 'Лого URL'
             identifier: Ідентифікатор
             authority: Повноваження
             url: URL
             value: Значення
-            metadataurl: Метадані URL
+            metadataurl: 'Метадані URL'
             dimension: Вимір
             extent: Екстент
-            dataurl: Data URL
-            featurelisturl: Featurelist URL
+            dataurl: 'Data URL'
+            featurelisturl: 'Featurelist URL'
       class:
-        title: WMS loader
-        description: Завантажує WMS через GetCapabilities-Request
+        title: 'WMS loader'
+        description: 'Завантажує WMS через GetCapabilities-Request'
       admin:
         label:
-          autoopen: Автоматично відкритий
-          splitlayers: Розділення шарів
+          autoopen: 'Автоматично відкритий'
+          splitlayers: 'Розділення шарів'
     repository:
       parser:
-        couldnotparse: Не вдалось проаналізувати CapabilitiesDocument
-        not_supported_document: Не підтримується CapabilitiesDocument
-        not_supported_version: Версія WMS не підтримується
+        couldnotparse: 'Не вдалось проаналізувати CapabilitiesDocument'
+        not_supported_document: 'Не підтримується CapabilitiesDocument'
+        not_supported_version: 'Версія WMS не підтримується'
     metadata:
       section:
         common:
           _title: загальний
         useconditions:
-          _title: умови використання
+          _title: 'умови використання'
         contact:
           _title: контакт
         items:
           _title: Шар
-          name: Ім'я
+          name: 'Ім''я'
     repo:
       instance:
         label:
           dimensions: Розмірність
     dimensionsets:
-      no_dimension: немає розмірності
+      no_dimension: 'немає розмірності'
     dimhandler:
       class:
-        title: Розміри провідника
-        description: DimensionsHandler групує та викликає на карті екземпляри, що підтримуються розмірністю
+        title: 'Розміри провідника'
+        description: 'DimensionsHandler групує та викликає на карті екземпляри, що підтримуються розмірністю'

--- a/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/Repository/instance.html.twig
@@ -9,6 +9,17 @@
   <script type="text/javascript" src="{{ asset('bundles/mapbenderwms/mapbender.wms.dimension.js') }}"></script>
   {{parent()}}
   <script type="text/javascript" src="{{ asset('bundles/mapbenderwms/backend/instance-dimension.js') }}"></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
+            [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl, {
+                html: true,
+                placement: 'left',
+                trigger: 'hover click'
+            }));
+        });
+    </script>
 {% endblock %}
 
 {% block form_main1 %}
@@ -52,6 +63,7 @@
   {% if form.layerOrder is defined %}
     {{ form_row(form.layerOrder) }}
   {% endif %}
+  {{ form_row(form.refreshInterval) }}
   </div>
 {% endblock form_main2 %}
 


### PR DESCRIPTION
Adds an option to refresh a WMS services automatically after a set number of seconds. Can be used e.g. for WMS services that visualise sensor data.

Configuration in backend: Enter a non-zero value in the new backend field:

<img width="600" height="184" alt="grafik" src="https://github.com/user-attachments/assets/a945e1ca-df00-48d1-b61f-03228f2d493c" />

Configuration in YAML: use the property `refreshInterval` in the source configuration. 