### PR TITLE
[Design] Layertree, internal ticket 10672

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.element.layertree.tree.js
@@ -87,9 +87,6 @@
             this.element.on('click', '.-fn-toggle-selected:not(.disabled)', this._toggleSelected.bind(this));
             this.element.on('click', '.layer-title:not(.disabled)', this._toggleSelectedLayer.bind(this));
             this.element.on('click', '.layer-menu-btn', this._toggleMenu.bind(this));
-            this.element.on('click', '.layer-menu .exit-button', function () {
-                $(this).closest('.layer-menu').remove();
-            });
             this.element.on('click', '.layer-remove-btn', function () {
                 var $node = $(this).closest('li.leave');
                 var layer = $node.data('layer');
@@ -388,8 +385,8 @@
         _updateFolderState: function ($node) {
             const active = $node.hasClass('showLeaves');
             $node.children('.leaveContainer').children('.-fn-toggle-children').children('i')
-                .toggleClass('fa-folder-open', active)
-                .toggleClass('fa-folder', !active)
+                .toggleClass('fa-caret-down', active)
+                .toggleClass('fa-caret-right', !active)
             ;
         },
         _toggleSelectedLayer: function (e) {
@@ -545,7 +542,10 @@
                 $menu.remove();
                 return;
             }
-            $layerNode.find('.leaveContainer:first', $layerNode).after($menu);
+            
+            // Insert the menu directly after the leaveContainer, but before any nested ul.layers
+            const $leaveContainer = $layerNode.find('.leaveContainer:first');
+            $leaveContainer.after($menu);
 
             $menu.find('[data-menu-action]').each((index, el) => {
                 const $actionElement = $(el);
@@ -584,6 +584,7 @@
 
             const $wrapper = $opacityControl.find('.layer-opacity-bar');
             const $handle = $opacityControl.find('.layer-opacity-handle');
+            const $valueDisplay = $opacityControl.find('.layer-opacity-value');
             const dragDealer = new Dragdealer($wrapper[0], {
                 x: source.options.opacity,
                 horizontal: true,
@@ -595,6 +596,7 @@
                     var opacity = Math.max(0.0, Math.min(1.0, x));
                     var percentage = Math.round(opacity * 100);
                     $handle.text(percentage);
+                    $valueDisplay.text(percentage);
                     this.model.setSourceOpacity(source, opacity);
                 }
             });
@@ -620,6 +622,7 @@
                     const opacity = Math.max(0.0, Math.min(1.0, newX));
                     const percentage = Math.round(opacity * 100);
                     $handle.text(percentage);
+                    $valueDisplay.text(percentage);
                     this.model.setSourceOpacity(source, opacity);
                 }
             });
@@ -649,16 +652,30 @@
             var $target = $(e.target);
             var $layerNode = $target.closest('li.leave');
             if (!$('>.layer-menu', $layerNode).length) {
+                // Close all other menus first
                 $('.layer-menu', this.element).remove();
+                // Reset all menu button icons back to bars
+                $('.layer-menu-btn i', this.element).removeClass('fa-xmark').addClass('fa-bars');
+                
                 this._initMenu($layerNode);
 
                 const $menu = $layerNode.find('>.layer-menu');
+                
+                // Change only this specific menu button icon to X
+                const $menuBtn = $layerNode.find('>.leaveContainer .layer-menu-btn i');
+                $menuBtn.removeClass('fa-bars').addClass('fa-xmark');
 
                 $menu.find('.exit-button:visible, .layer-opacity-handle:visible, .clickable:visible').attr('tabindex', '0');
                 const $firstFocusable = $menu.find('[tabindex="0"]').first();
                 if ($firstFocusable.length) {
                     $firstFocusable.focus();
                 }
+            } else {
+                // Menu is already open, close it
+                $('>.layer-menu', $layerNode).remove();
+                // Reset only this menu button icon back to bars
+                const $menuBtn = $layerNode.find('>.leaveContainer .layer-menu-btn i');
+                $menuBtn.removeClass('fa-xmark').addClass('fa-bars');
             }
 
             return false;
@@ -782,10 +799,7 @@
                         destroyOnClose: true,
                         width: !useModal && 850 || '100%',
                         height: !useModal && 600 || null,
-                        buttons: [{
-                            label: Mapbender.trans('mb.actions.close'),
-                            cssClass: 'btn btn-sm btn-light popupClose critical'
-                        }]
+                        buttons: []
                     });
                     metadataPopup.$element.find('button').focus();
                     if (initTabContainer) {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/layertree.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/layertree.scss
@@ -17,6 +17,8 @@ $textColor: $darkFontColor !default;
   }
   .leaveContainer {
     display: flex;
+    margin-bottom: 5px;
+    gap: 4px;
   }
   .layer-title {
     flex: 1 1 auto;
@@ -51,9 +53,6 @@ $textColor: $darkFontColor !default;
   .error-icon-wrapper, .leave.state-error .layer-title {
     color: $errorColor;
   }
-  .layer-menu-btn, .error-icon-wrapper, .loading-icon-wrapper {
-    margin-left: 4px;
-  }
 
   .disabled-placeholder {
     pointer-events: none;
@@ -68,46 +67,84 @@ $textColor: $darkFontColor !default;
 
 $layer-slider-bar-height: 5px;
 .layer-menu {
-  color: #222;
-  position: absolute;
-  right: 0;
-  top: 1.5em;
+  color: var(--primary);
+  position: static;
   background-color: white;
   padding: $space / 4;
-
-  z-index: 45;
-  // NEED constant width, otherwise the DragDealer will get confused when resizing Popup
-  width: auto;
-  min-width: 140px;
-  border: solid 1px $panelBorderColor;
   border-radius: $radius;
-  // arrow icon
-  &:before {
-    content: '';
-    display: block;
-    width: 0;
-    height: 0;
-    border-bottom: 5px solid $panelBorderColor;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    position: absolute;
-    right: 0;
-    top: -5px;
-  }
-  &:after {
-    display: none;
-  }
+  margin-top: 2px;
+
+  // Align left edge of slider-bar with left edge of checkbox
+  // Only account for folder icon + spacing to reach checkbox position
+  margin-left: calc(1em + 4px); // folder icon + spacing = checkbox left edge
+
   .layer-slider-bar {
-    font-size: 85%;
-    background: rgba($textColor, 0.4);
-    border-color: transparent;
-    .layer-slider-handle {
-      // enforce minimum width so opacity handle (with text) doesn't
-      // look weird vs dimensions handle (no text)
-      min-width: 2.5em;
-    }
+  font-size: 85%;
+  flex: 1;
+  background: var(--primary) !important;
+  border-color: var(--primary) !important;
+  height: 4px;
+ }
+
+  .layer-opacity-title {
+    color: $textColor;
+    font-size: 0.8rem;
+  }
+
+  .layer-opacity-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .layer-opacity-value {
+    color: $textColor;
+    font-size: 0.9rem;
+    font-family: inherit;
+    min-width: 35px;
+    text-align: left;
+    position: relative;
+    top: -5px;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 1px;
+    width: 35px;
+  }
+
+  .layer-slider-handle {
+    background-color: var(--primary);
+    border-color: var(--primary);
+    border-radius: 50% !important; // circle
+    width: 14px !important;
+    height: 14px !important;
+    min-width: 14px !important;
+    text-indent: -9999px; // hide text
+    top: -1px;
   }
 }
 .layer-dimension-textfield {
     max-width: 120px;
+}
+
+.layer-menu-btn {
+  color: #626161;
+}
+
+.-fn-toggle-selected {
+  color: var(--primary);
+  font-size: 1.4em;
+  display: flex;
+  align-items: center;
+
+  i {
+    font-size: inherit;
+    line-height: 1;
+  }
+}
+
+.-fn-toggle-info {
+  color: var(--primary);
+}
+
+.layer-styles .input-group-text, .form-select{
+  font-size: 0.75rem;
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/template/fullscreen.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/template/fullscreen.scss
@@ -128,7 +128,7 @@ body {
 }
 
 .sidePane {
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .autocompleteWrapper {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -275,7 +275,32 @@ ul.toolBar, .toolBar > ul {
       line-height: inherit;
     }
   }
+  .popupHead{
+    border-bottom: none;
+  }
+  .tabContainerAlt{
 
+    > .tabs {
+      border: transparent;
+      border-bottom: 2px solid #d6d3d3;
+      margin-bottom: 0px;
+      padding-bottom: 0px;
+    }
+    .tab {
+      border: transparent;
+    }
+    .tab.active {
+      border-bottom: 3px solid;
+      border-bottom-color: var(--primary);
+      background-color: transparent;
+      margin-bottom: 0px;
+    }
+  }
+
+  .container {
+    margin-top: 2em;
+  }
+  
   table {
     margin-bottom: 1em;
     tbody th:first-child {

--- a/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/layertree.html.twig
@@ -7,10 +7,10 @@
       <li class="-fn-theme-template themeContainer hidden">
         <div class="leaveContainer">
           <span class="-fn-toggle-children clickable" title="{{ 'mb.core.layertree.tooltip.sublayers_openclose'|trans }}" tabindex="0">
-              <i class="fas fa-folder fa-fw"></i>
+              <i class="fa-solid fa-fw"></i>
           </span>
           <span class="-fn-toggle-selected clickable" title="{{ 'mb.core.layertree.label.sourcevisibility_onoff' | trans }}" tabindex="0">
-                <i class="far fa-square fa-fw"></i>
+                <i class="fa-solid fa-square fa-fw"></i>
           </span>
           <span class="layer-title clickable" tabindex="-1"></span>
         </div>
@@ -19,10 +19,10 @@
       <li class="-fn-template hidden leave showLeaves">
         <div class="leaveContainer">
           <span class="-fn-toggle-children clickable" data-test="mb-lt-layer-folder-icon" title="{{ 'mb.core.layertree.tooltip.sublayers_openclose'|trans }}" tabindex="0">
-            <i class="fas fa-folder fa-fw"></i>
+            <i class="fa-solid  fa-fw"></i>
           </span>
           <span class="clickable -fn-toggle-selected" data-test="mb-lt-layer-visibility" title="{{ 'mb.core.layertree.label.visibility_onoff' | trans }}" tabindex="0">
-              <i class="far fa-square fa-fw"></i>
+              <i class="fa-solid fa-square fa-fw"></i>
           </span>
           <span class="clickable -fn-toggle-info" title="{{ 'mb.core.layertree.label.featureinfo_onoff' | trans  }}" tabindex="0">
             <i class="fas fa-info fa-fw"></i>
@@ -32,20 +32,19 @@
           <span class="loading-icon-wrapper"><i class="fas fa-spinner fa-spin layertree-spinner"></i></span>
           {% if configuration.menu is defined and configuration.menu %}
             {% block layertree_menu %}
-              <span class="layer-menu-btn" tabindex="0"><i class="fas fa-bars"></i></span>
+              <span class="layer-menu-btn" tabindex="0"><i class="fa-solid fa-sliders"></i></span>
               <div class="layer-menu hidden">
-                {% block layertree_menu_close %}
-                  <div class="text-end">
-                    <span class="exit-button" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}"><i class="fa fas fa-xmark"></i></span>
-                  </div>
-                {% endblock %}
                 {% block layertree_menu_opacity %}
                 {% if 'opacity' in configuration.menu %}
                     <div class="layer-control-opacity focus-highlight" data-menu-action="opacity">
-                      <div class="layer-opacity-bar layer-slider-bar" title="{{ "mb.core.layertree.label.opacity"|trans }}">
-                          <div class="layer-opacity-handle layer-slider-handle">100</div>
+                      <div class="layer-opacity-title">{{ "mb.core.layertree.label.opacity"|trans }}</div>
+                      <div class="layer-opacity-container">
+                          <div class="layer-opacity-bar layer-slider-bar" title="{{ "mb.core.layertree.label.opacity"|trans }}">
+                              <div class="layer-opacity-handle layer-slider-handle">100</div>
+                          </div>
+                          <div class="layer-opacity-value">100</div>
                       </div>
-                </div>
+                    </div>
                 {% endif %}
                 {% endblock %}
                 {% block layertree_menu_dimension %}
@@ -84,7 +83,7 @@
                   {% endblock %}
                   {% block layertree_menu_layerremove %}
                   {% if 'layerremove' in configuration.menu %}
-                  <span data-menu-action="layerremove" class="layer-remove-btn fa fas fa-circle-xmark hover-highlight-effect clickable" tabindex="0" title="{{ 'mb.core.layertree.tooltip.removelayer'|trans }}"></span>
+                  <span data-menu-action="layerremove" class="layer-remove-btn far fa-trash-alt hover-highlight-effect clickable" tabindex="0" title="{{ 'mb.core.layertree.tooltip.removelayer'|trans }}" style="color: red;"></span>
                   {% endif %}
                   {% endblock %}
                   {% block layertree_menu_custom_textend %}

--- a/src/Mapbender/WmsBundle/Resources/views/frontend/instance.html.twig
+++ b/src/Mapbender/WmsBundle/Resources/views/frontend/instance.html.twig
@@ -1,29 +1,23 @@
-    <div class="accordionContainer">
-        <div id="accordion-general" class="accordion active">{{ 'mb.wms.metadata.section.common.title' | trans }}</div>
-        <div id="container-general" class="container-accordion active">
-            <div class="accordion-cell">
-                {%- include '@MapbenderWms/Repository/source/view-metadata.html.twig' with {'show_constraints': false} -%}
-            </div>
+    <div class="tabContainerAlt">
+        <ul class="tabs">
+            <li id="tab-general" class="tab active">{{ 'mb.wms.metadata.section.common.title' | trans }}</li>
+            <li id="tab-usage" class="tab">{{ 'mb.wms.metadata.section.useconditions.title' | trans }}</li>
+            <li id="tab-contact" class="tab">{{ 'mb.wms.metadata.section.contact.title' | trans }}</li>
+            <li id="tab-layers" class="tab">{{ 'mb.wms.metadata.section.items.title' | trans }}</li>
+        </ul>
+        <div id="container-general" class="container active">
+            {%- include '@MapbenderWms/Repository/source/view-metadata.html.twig' with {'show_constraints': false} -%}
         </div>
-        <div id="accordion-usage" class="accordion">{{ 'mb.wms.metadata.section.useconditions.title' | trans }}</div>
-        <div id="container-usage" class="container-accordion">
-            <div class="accordion-cell">
-                <table class="table table-borderless table-condensed">
-                    <tr><th>{{ "mb.wms.wmsloader.repo.view.label.fees" | trans }}:</th><td>{{ source.fees }}</td></tr>
-                    <tr><th>{{ "mb.wms.wmsloader.repo.view.label.accessconstraints" | trans }}:</th><td>{{ source.accessConstraints }}</td></tr>
-                </table>
-            </div>
+        <div id="container-usage" class="container">
+            <table class="table table-borderless table-condensed">
+                <tr><th>{{ "mb.wms.wmsloader.repo.view.label.fees" | trans }}:</th><td>{{ source.fees }}</td></tr>
+                <tr><th>{{ "mb.wms.wmsloader.repo.view.label.accessconstraints" | trans }}:</th><td>{{ source.accessConstraints }}</td></tr>
+            </table>
         </div>
-        <div id="accordion-contact" class="accordion">{{ 'mb.wms.metadata.section.contact.title' | trans }}</div>
-        <div id="container-contact" class="container-accordion">
-            <div class="accordion-cell">
-                {%- include '@MapbenderManager/Repository/source/view-contact.html.twig' with {'contact' : source.contact} -%}
-            </div>
+        <div id="container-contact" class="container">
+            {%- include '@MapbenderManager/Repository/source/view-contact.html.twig' with {'contact' : source.contact} -%}
         </div>
-        <div id="accordion-layers" class="accordion">{{ 'mb.wms.metadata.section.items.title' | trans }}</div>
-        <div id="container-layers" class="container-accordion">
-            <div class="accordion-cell">
-                {%- include '@MapbenderWms/frontend/instancelayer.html.twig' with {layer: startLayerInstance, itemLevel: 1} -%}
-            </div>
+        <div id="container-layers" class="container">
+            {%- include '@MapbenderWms/frontend/instancelayer.html.twig' with {layer: startLayerInstance, itemLevel: 1} -%}
         </div>
     </div>


### PR DESCRIPTION
Implemented:

- Layertree redesign:
  Checkboxes and other icons in font-awesome style
  Font size reduced
  Spacing between individual lines and between icons and layer names adjusted
  new menu-icon
  menu is shown under its layer (popup removed)
- Opacity:
  Opacity slider left-aligned with the checkbox above it
  Slider color adjusted
  Handler is now round, opacity is no longer displayed on the handler, but to the right of it
  Title above the slider
- Metadata dialog:
  No more accordion, now tabs
  Solid gray line below the tabs
  Active tab is highlighted in blue
  “Close” button removed.
  Dotted lines above and below “Metadata” removed.


<img width="288" height="372" alt="Bildschirmfoto vom 2025-08-28 09-28-38" src="https://github.com/user-attachments/assets/67f2a9a6-a633-490d-a973-03dbbc95f3a1" />

<img width="929" height="646" alt="Bildschirmfoto vom 2025-08-28 09-39-09" src="https://github.com/user-attachments/assets/9a2b88c7-f90f-4631-a199-d873f158cf97" />
