### PR TITLE
[Design] sketches (sidepane), internal ticket 10677

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next feature release
 * [Design] Redesign Layertree ([#PR1766](https://github.com/mapbender/mapbender/pull/1766))
 * [Design] Redesign Simple Search ([#PR1767](https://github.com/mapbender/mapbender/pull/1767)) 
+* [Design] Redesign Sketch element ([#PR1768](https://github.com/mapbender/mapbender/pull/1768))
 
 ## v4.2.1
 Bugfixes:

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.js
@@ -521,6 +521,13 @@
                 $popover.remove();
                 self._endEdit();
             });
+            $popover.on('keydown', 'span[role="button"]', function(e) {
+                if (e.key === 'Enter') {
+                    $popover.remove();
+                    self._endEdit();
+                    e.preventDefault();
+                }
+            });
         },
         _closePopovers: function() {
             $('table .popover', this.element).each(function() {

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -1,5 +1,5 @@
 .mb-element-sketch {
-  .stop-sketching {
+  .-fn-tool-off:not(:disabled) .stop-sketching {
     color: red;
   }
   .geometry-table {
@@ -69,11 +69,6 @@
     --bs-btn-active-color: #6c757d;
     --bs-btn-active-bg: #e6e6e6;
     --bs-btn-active-border-color: #ccc;
-  }
-  .popover-body {
-    .popupClose {
-      margin-top: -0.75rem !important;
-    }
   }
 }
 .popup.sketch-dialog {

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -1,4 +1,7 @@
 .mb-element-sketch {
+  .stop-sketching {
+    color: red;
+  }
   .geometry-table {
     .geometry-actions {
       text-align:right;
@@ -15,7 +18,7 @@
       right: -1em;
       top: 25px;
       .popover-arrow {
-        transform: translate(250px, -7px);
+        transform: translate(150px, -7px);
       }
       .popover-arrow::before {
         top: 0;
@@ -70,9 +73,6 @@
   .popover-body {
     .popupClose {
       margin-top: -0.75rem !important;
-    }
-    .mr {
-      margin-right: -10rem;
     }
   }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/element/sketch.scss
@@ -9,7 +9,7 @@
     .popover {
       position: absolute;
       font-size: inherit;
-      min-width: 20em;
+      min-width: 15em;
       display: initial;
       left: initial;
       right: -1em;
@@ -66,6 +66,14 @@
     --bs-btn-active-color: #6c757d;
     --bs-btn-active-bg: #e6e6e6;
     --bs-btn-active-border-color: #ccc;
+  }
+  .popover-body {
+    .popupClose {
+      margin-top: -0.75rem !important;
+    }
+    .mr {
+      margin-right: -10rem;
+    }
   }
 }
 .popup.sketch-dialog {

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.de.yaml
@@ -557,7 +557,7 @@ mb:
         circle: Kreis
       inputs:
         label: Beschriftung
-        radius: Radius
+        radius: Radius (m)
       geometry:
         action:
           remove: 'Entfernen der Geometrie'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.en.yaml
@@ -557,7 +557,7 @@ mb:
         circle: Circle
       inputs:
         label: Label
-        radius: Radius
+        radius: Radius (m)
       geometry:
         action:
           remove: 'Remove geometry'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.es.yaml
@@ -552,7 +552,7 @@ mb:
         circle: Círculo
       inputs:
         label: Etiqueta
-        radius: Radio
+        radius: Radio (m)
       geometry:
         action:
           remove: 'Eliminar la geometría'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.fr.yaml
@@ -325,6 +325,9 @@ mb:
         polygon: Polygone
         rectangle: Rectangle
         circle: Cercle
+      inputs:
+        label: Inscription
+        radius: Rayon (m)
       geometry:
         action:
           remove: Supprimer la géométrie

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.it.yaml
@@ -552,7 +552,7 @@ mb:
         circle: Cerchio
       inputs:
         label: Label
-        radius: Raggio
+        radius: Raggio (m)
       geometry:
         action:
           remove: 'Rimuovi la geometria'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.nl.yaml
@@ -318,6 +318,9 @@ mb:
         polygon: Polygoon
         rectangle: Rechthoek
         circle: Cirkel
+      inputs:
+        label: Belettering
+        radius: Radius (m)
       geometry:
         action:
           remove: 'Verwijder geometrie'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.pt.yaml
@@ -552,7 +552,7 @@ mb:
         circle: Círculo
       inputs:
         label: Rótulo
-        radius: Raio
+        radius: Raio (m)
       geometry:
         action:
           remove: 'Remover geometria'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.ru.yaml
@@ -546,7 +546,7 @@ mb:
         circle: Круг
       inputs:
         label: 'Надпись'
-        radius: 'Радиус'
+        radius: 'Радиус (м)'
       geometry:
         action:
           remove: 'Удалить геометрию'

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.tr.yaml
@@ -316,6 +316,9 @@ mb:
         polygon: Çokgen
         rectangle: Dikdörtgen
         circle: Çember
+      inputs:
+        label: Etiketleme
+        radius: Yarıçap (m)
       geometry:
         action:
           remove: Geometriyi kaldır

--- a/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/messages.uk.yaml
@@ -397,7 +397,7 @@ mb:
         circle: Коло
       inputs:
         label: Мітка
-        radius: Радіус
+        radius: Радіус (м)
       geometry:
         action:
           remove: Видалити геометрію

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -17,7 +17,7 @@
         {% endif %}
         </div>
         <button type="button" disabled="disabled" title="{{ "mb.core.sketch.geometry.action.stop_drawing"|trans }}" class="btn btn-outline-secondary -fn-tool-off">
-            <i class="fas fa-stop"></i>
+            <i class="fa-solid fa-xmark stop-sketching"></i>
         </button>
     </div>
     <div class="mb-3 -js-pallette-container{{- not allow_custom_color and colors | length <= 1 ? ' hidden' : '' -}}">
@@ -41,15 +41,6 @@
             <label for="label-text" class="form-label">{{ "mb.core.sketch.inputs.label"|trans}}</label>
             <input name="label-text" type="text" class="form-control" disabled="disabled" placeholder="{{ 'mb.core.viewManager.enter_title' | trans }}...">
         </div>
-        {%- if dialogMode -%}
-        <div class="col-5 col-xs-5">
-            <label for="label-text" class="form-label">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
-            <div class="input-group">
-                <input name="radius" type="text" class="form-control" disabled="disabled">
-                <span class="input-group-text"></span>
-            </div>
-        </div>
-        {%- endif -%}
     </div>
     <table class="table table-striped geometry-table">
         <tr class="geometry-item hidden" data-id="">
@@ -58,7 +49,7 @@
             </td>
             <td class="geometry-name"></td>
             <td class="geometry-actions compact text-nowrap">
-                <i class="geometry-zoom fa fas fa-magnifying-glass-plus clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.zoom" | trans }}" tabindex="0"></i>
+                <i class="geometry-zoom fa fas fa-search clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.zoom" | trans }}" tabindex="0"></i>
                 <span class="static-popover-wrap -js-edit-content-anchor">
                     <i class="geometry-edit fa fas fa-pencil-alt fa-pencil clickable hover-highlight-effect" title="{{"mb.core.sketch.geometry.action.edit" | trans }}" tabindex="0"></i>
                 </span>
@@ -69,17 +60,17 @@
     <div class="hidden -js-edit-content">
         <div class="popover-body">
             <div class="mb-1">
-                <span class="popupClose right" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}">
+                <span role="button" class="popupClose hover-highlight-effect right" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}" tabindex="0">
                     <i class="fa fas fa-xmark -fn-close"></i>
                 </span>
             </div>
-            <div class="mb-3 mr">
-                <label for="label-text" class="col-form-label col-5 col-xs-5">{{- 'mb.core.sketch.inputs.label' | trans -}}</label>
-                <div class="col-7 col-xs-7"><input type="text" name="label-text" class="form-control"></div>
+            <div class="mb-3">
+                <label for="label-text" class="col-form-label col-xs-5">{{- 'mb.core.sketch.inputs.label' | trans -}}</label>
+                <input type="text" name="label-text" class="form-control">
             </div>
-            <div class="mb-3 mr" data-toolnames="circle">
-                <label for="radius" class="col-form-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
-                <div class="col-7 col-xs-7"><input type="text" name="radius" class="form-control"></div>
+            <div class="mb-3" data-toolnames="circle">
+                <label for="radius" class="col-form-label col-xs-4">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
+                <input type="text" name="radius" class="form-control">
             </div>
         </div>
     </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -46,7 +46,7 @@
             <label for="label-text" class="form-label">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
             <div class="input-group">
                 <input name="radius" type="text" class="form-control" disabled="disabled">
-                <span class="input-group-text">m</span>
+                <span class="input-group-text"></span>
             </div>
         </div>
         {%- endif -%}
@@ -68,21 +68,18 @@
     </table>
     <div class="hidden -js-edit-content">
         <div class="popover-body">
-            <div class="row mb-3">
+            <div class="mb-1">
+                <span class="popupClose right" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}">
+                    <i class="fa fas fa-xmark -fn-close"></i>
+                </span>
+            </div>
+            <div class="mb-3 mr">
                 <label for="label-text" class="col-form-label col-5 col-xs-5">{{- 'mb.core.sketch.inputs.label' | trans -}}</label>
                 <div class="col-7 col-xs-7"><input type="text" name="label-text" class="form-control"></div>
             </div>
-            <div class="row mb-3" data-toolnames="circle">
+            <div class="mb-3 mr" data-toolnames="circle">
                 <label for="radius" class="col-form-label col-4 col-xs-4">{{- 'mb.core.sketch.inputs.radius' | trans -}}</label>
-                <div class="col-8 col-xs-8">
-                    <div class="input-group">
-                        <input type="text" name="radius" class="form-control">
-                        <span class="input-group-text">m</span>
-                    </div>
-                </div>
-            </div>
-            <div class="text-nowrap text-end">
-                <button type="button" class="btn btn-sm btn-light -fn-close">{{ 'mb.actions.close' | trans }}</button>
+                <div class="col-7 col-xs-7"><input type="text" name="radius" class="form-control"></div>
             </div>
         </div>
     </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -58,9 +58,9 @@
         </tr>
     </table>
     <div class="hidden -js-edit-content">
-        <div class="popover-body">
+        <div class="popover-body pt-1">
             <div class="mb-1">
-                <span role="button" class="popupClose hover-highlight-effect right" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}" tabindex="0">
+                <span role="button" class="hover-highlight-effect right" title="{{ 'mb.core.layertree.tooltip.menu.close'|trans }}" tabindex="0">
                     <i class="fa fas fa-xmark -fn-close"></i>
                 </span>
             </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/sketch.html.twig
@@ -37,7 +37,7 @@
     </div>
 
     <div class="row mb-3">
-        <div class="px-3 {{- dialogMode ? ' col-7 col-xs-7' : ' col-12 col-xs-12' -}}">
+        <div class="px-3">
             <label for="label-text" class="form-label">{{ "mb.core.sketch.inputs.label"|trans}}</label>
             <input name="label-text" type="text" class="form-control" disabled="disabled" placeholder="{{ 'mb.core.viewManager.enter_title' | trans }}...">
         </div>


### PR DESCRIPTION
- in pop-up: Close button has been removed and replaced with an “x” in the top right corner
- in the “Radius” field, the “m” has been removed (replaced with Radius (m))
- text fields are flush
- the label for a single-line field is now above the input field, not to the left of it

<img width="286" height="454" alt="Bildschirmfoto vom 2025-09-01 09-20-58" src="https://github.com/user-attachments/assets/ec729202-db42-4b6d-bf94-1b17207f0674" />
