### PR TITLE
[WMS] Fix layer order in frontend was wrong after updating instance layer properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## next bugfix release
 * [WMSLoader] Fix default info format and overwritten info format via attributes was ignored ([#PR1769](https://github.com/mapbender/mapbender/pull/1769))
 * [FeatureInfo] Fix iframe did not use full height ([#PR1770](https://github.com/mapbender/mapbender/pull/1770))
-* [WMS] Fix layer order in frontend was wrong after updating instance layer properties ([#PR1772](https://github.com/mapbender/mapbender/pull/1772))
+* [WMS] Fix layer order in frontend was wrong after updating instance layer properties ([#PR1773](https://github.com/mapbender/mapbender/pull/1773))
 * Fix wms:reload and wms:add commands were broken after update ([#PR1771](https://github.com/mapbender/mapbender/pull/1771))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next bugfix release
 * [WMSLoader] Fix default info format and overwritten info format via attributes was ignored ([#PR1769](https://github.com/mapbender/mapbender/pull/1769))
 * [FeatureInfo] Fix iframe did not use full height ([#PR1770](https://github.com/mapbender/mapbender/pull/1770))
+* [WMS] Fix layer order in frontend was wrong after updating instance layer properties ([#PR1772](https://github.com/mapbender/mapbender/pull/1772))
 * Fix wms:reload and wms:add commands were broken after update ([#PR1771](https://github.com/mapbender/mapbender/pull/1771))
 
 

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -555,6 +555,7 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
             ->leftJoin(WmsLayerSource::class, 'ls', 'WITH', 'l.sourceItem = ls.id')
             ->where('l.sourceInstance IN (:instances)')
             ->setParameter('instances', $sourceInstances)
+            ->orderBy('l.priority')
             ->getQuery()
             ->getResult(AbstractQuery::HYDRATE_ARRAY)
         ;


### PR DESCRIPTION
Regression introduced by #1744 

fixes #1772 