### PR TITLE
[SearchRouter] Simplify code for easier overriding of functionality

### DIFF
--- a/src/Mapbender/CoreBundle/Element/SearchRouter.php
+++ b/src/Mapbender/CoreBundle/Element/SearchRouter.php
@@ -172,7 +172,7 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
         $categoryId = $actionParts[0];
         $action = $actionParts[1];
 
-        if ('csrf' === $action) {
+        if ($action === 'csrf') {
             $generatedToken = $this->csrfTokenManager->getToken(SearchRouterFormType::class);
             return new Response($generatedToken->getValue());
         }
@@ -187,16 +187,15 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
         $engine = $this->container->get($engineClassName);
         $data = json_decode($request->getContent(), true);
 
-        if (in_array($action, ['autocomplete', 'search'])) {
-            $token = isset($data['properties']['_token']) ? new CsrfToken(SearchRouterFormType::class, $data['properties']['_token']) : null;
-            $isValid = $token !== null && $this->csrfTokenManager->isTokenValid($token);
+        // Validate CSRF Token
+        $token = isset($data['properties']['_token']) ? new CsrfToken(SearchRouterFormType::class, $data['properties']['_token']) : null;
+        $isValid = $token !== null && $this->csrfTokenManager->isTokenValid($token);
 
-            if (!$isValid) {
-                return new Response('Invalid CSRF token.', Response::HTTP_BAD_REQUEST);
-            }
+        if (!$isValid) {
+            return new Response('Invalid CSRF token.', Response::HTTP_BAD_REQUEST);
         }
 
-        if ('autocomplete' === $action) {
+        if ($action === 'autocomplete') {
             $results = $engine->autocomplete(
                 $categoryConf,
                 $data['key'],
@@ -205,18 +204,20 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
                 $data['srs'],
                 $data['extent']
             );
+            $results = $this->postProcessAutocomplete($results, $categoryConf, $data);
             return new JsonResponse(array_replace($data, array(
                 'results' => $results,
             )));
         }
 
-        if ('search' === $action) {
+        if ($action === 'search') {
             $form = $this->getForm($categoryConf, $categoryId);
             $form->submit($data['properties']);
             $query = array(
                 'form' => $form->getData(),
             );
             $features = $engine->search($categoryConf, $query, $data['srs'], $data['extent']);
+            $features = $this->postProcessFeatures($features, $categoryConf, $data);
             return new JsonResponse(array(
                 'type' => 'FeatureCollection',
                 'features' => $features,
@@ -296,5 +297,23 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
         }
         $config['routes'] = \array_values($config['routes']);
         return $config;
+    }
+
+    /**
+     * Override this method if you want to modify the features returned by the search engine before displaying,
+     * e.g. sort them or perform a string replace on the results
+     */
+    private function postProcessFeatures($features, array $categoryConf, array $data): array
+    {
+        return $features;
+    }
+
+    /**
+     * Override this method if you want to modify the features returned by the search engine before displaying,
+     * e.g. sort them or perform a string replace on the results
+     */
+    private function postProcessAutocomplete($results, array $categoryConf, array $data): array
+    {
+        return $results;
     }
 }


### PR DESCRIPTION
Extract code from overly long functions into smaller chunks to simplify future updates in client projects, where only small parts of functionality are overridden, but the whole function contents must be copied because there's no good encapsulation.