### PR TITLE
Check access rights in instance tunnel controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## next feature release
 Security:
-* Allow custom permissions for source instances ([#PR1812](https://github.com/mapbender/mapbender/pull/1812))
+* Allow custom permissions for source instances ([#PR1812](https://github.com/mapbender/mapbender/pull/1812), [#PR1825](https://github.com/mapbender/mapbender/pull/1825))
 
 Features:
 * [Design] Comprehensive frontend redesign, including several optimisations mobile screens (Layertree: [#PR1766](https://github.com/mapbender/mapbender/pull/1766), [#PR1774](https://github.com/mapbender/mapbender/pull/1774); Simple Search: [#PR1767](https://github.com/mapbender/mapbender/pull/1767); Sketch: [#PR1768](https://github.com/mapbender/mapbender/pull/1768); Data Upload: [#PR1775](https://github.com/mapbender/mapbender/pull/1775); Popup and mobile optimisations: [#PR1782](https://github.com/mapbender/mapbender/pull/1782))

--- a/src/Mapbender/CoreBundle/Controller/InstanceTunnelController.php
+++ b/src/Mapbender/CoreBundle/Controller/InstanceTunnelController.php
@@ -5,12 +5,11 @@ namespace Mapbender\CoreBundle\Controller;
 
 
 use Doctrine\ORM\EntityManagerInterface;
-use FOM\UserBundle\Security\Permission\ResourceDomainApplication;
+use FOM\UserBundle\Security\Permission\ResourceDomainSourceInstance;
 use Mapbender\CoreBundle\Component\Application\ApplicationResolver;
 use Mapbender\CoreBundle\Component\Source\Tunnel\Endpoint;
 use Mapbender\CoreBundle\Component\Source\Tunnel\InstanceTunnelService;
 use Mapbender\CoreBundle\Entity\Application;
-use Mapbender\CoreBundle\Entity\SourceInstance;
 use Mapbender\CoreBundle\Utils\RequestUtil;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -78,10 +77,11 @@ class InstanceTunnelController extends AbstractController
 
     protected function getGrantedTunnelEndpoint(Application $application, string|int $instanceId): Endpoint
     {
-        $instance = $application->getSourceInstanceById($instanceId);
-        if (!$instance) {
+        $assignment = $application->getSourceInstanceAssignmentById($instanceId);
+        if (!$assignment) {
             throw new NotFoundHttpException("No such instance");
         }
-        return $this->tunnelService->makeEndpoint($application, $instance);
+        $this->denyAccessUnlessGranted(ResourceDomainSourceInstance::ACTION_VIEW, $assignment);
+        return $this->tunnelService->makeEndpoint($application, $assignment->getInstance());
     }
 }


### PR DESCRIPTION
Follow-up-PR to #1812: Instead of just not displaying the shared instance when it's secured, also check the access rights in
 /application/{slug}/instance/{instanceId}/tunnel route