### PR TITLE
Security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 Security:
 * [WMS] Always use Tunnel instead of OwsProxy to avoid leaking internal urls ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
 * [WMS] Do not expose hidden vendor-specific parameters ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
-* [Password/Registration] Replace weak `hash('sha1', rand())` token generation with `bin2hex(random_bytes(20))` in `PasswordController`, `RegistrationController` and `UserSubscriber` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [FailedLoginListener] Replace `$_SERVER['REMOTE_ADDR']`/`$_SERVER['HTTP_USER_AGENT']` superglobals with Symfony request abstraction (`getClientIp()`, `$request->headers->get()`) to respect proxy headers correctly ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [Routing] Fix SQL injection in `PgRoutingDBInterface`: quote EWKT geometry strings, weighting/cost column identifiers and table names via `quote()`/`quoteIdentifier()`; cast SRID and node IDs to `int` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [API/Upload] Validate each ZIP entry path against the upload directory to prevent ZIP-Slip path traversal in `UploadController` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [Manager] Restrict `return` redirect parameter to relative paths to prevent open redirect attacks in `SourceInstanceController` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [Print] Restrict external image URLs to `http`/`https` schemes in `CanvasLegend` to prevent SSRF via `file://` and other schemes ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [Core] Add `LIBXML_NONET` flag to all `DOMDocument::loadXML()` calls in `XmlValidatorService` and `HttpSourceLoader` to prevent XXE attacks ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [OwsProxy] Set `CURLOPT_SSL_VERIFYHOST=2` alongside `CURLOPT_SSL_VERIFYPEER` in `CurlClientCommon` to prevent SSL hostname spoofing ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [API] Return generic error message instead of raw exception message in `CommandController` to prevent internal information disclosure ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
-* [Core] Replace `shell_exec()` with `Symfony\Component\Process\Process` in `ConfigCheckCommand` to prevent command injection ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Password/Registration] Use stronger hashing algorithms ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [API/Upload] Prevent potential ZIP-Slip path traversal ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [Print] Prevent potential SSRF attacks in Print Service ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [XML] Prevent potential XXE attacks ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [OwsProxy] Prevent potential SSL hostname spoofing ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [API] Prevent internal information disclosure via error messages ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
+* [ConfigCheckCommand] Prevent potential command injection ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
 
 Features:
 * [MetadataDialog] Make MetadataURL and DataUrl available and add twig filter linkify ([#PR1818](https://github.com/mapbender/mapbender/pull/1818))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 Security:
 * [WMS] Always use Tunnel instead of OwsProxy to avoid leaking internal urls ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
 * [WMS] Do not expose hidden vendor-specific parameters ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
+* [Password/Registration] Replace weak `hash('sha1', rand())` token generation with `bin2hex(random_bytes(20))` in `PasswordController`, `RegistrationController` and `UserSubscriber`
+* [FailedLoginListener] Replace `$_SERVER['REMOTE_ADDR']`/`$_SERVER['HTTP_USER_AGENT']` superglobals with Symfony request abstraction (`getClientIp()`, `$request->headers->get()`) to respect proxy headers correctly
+* [Routing] Fix SQL injection in `PgRoutingDBInterface`: quote EWKT geometry strings, weighting/cost column identifiers and table names via `quote()`/`quoteIdentifier()`; cast SRID and node IDs to `int`
+* [API/Upload] Validate each ZIP entry path against the upload directory to prevent ZIP-Slip path traversal in `UploadController`
+* [Manager] Restrict `return` redirect parameter to relative paths to prevent open redirect attacks in `SourceInstanceController`
+* [Print] Restrict external image URLs to `http`/`https` schemes in `CanvasLegend` to prevent SSRF via `file://` and other schemes
+* [Core] Add `LIBXML_NONET` flag to all `DOMDocument::loadXML()` calls in `XmlValidatorService` and `HttpSourceLoader` to prevent XXE attacks
+* [OwsProxy] Set `CURLOPT_SSL_VERIFYHOST=2` alongside `CURLOPT_SSL_VERIFYPEER` in `CurlClientCommon` to prevent SSL hostname spoofing
+* [API] Return generic error message instead of raw exception message in `CommandController` to prevent internal information disclosure
+* [Core] Replace `shell_exec()` with `Symfony\Component\Process\Process` in `ConfigCheckCommand` to prevent command injection
 
 Features:
 * [MetadataDialog] Make MetadataURL and DataUrl available and add twig filter linkify ([#PR1818](https://github.com/mapbender/mapbender/pull/1818))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 Security:
 * [WMS] Always use Tunnel instead of OwsProxy to avoid leaking internal urls ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
 * [WMS] Do not expose hidden vendor-specific parameters ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
-* [Password/Registration] Replace weak `hash('sha1', rand())` token generation with `bin2hex(random_bytes(20))` in `PasswordController`, `RegistrationController` and `UserSubscriber`
-* [FailedLoginListener] Replace `$_SERVER['REMOTE_ADDR']`/`$_SERVER['HTTP_USER_AGENT']` superglobals with Symfony request abstraction (`getClientIp()`, `$request->headers->get()`) to respect proxy headers correctly
-* [Routing] Fix SQL injection in `PgRoutingDBInterface`: quote EWKT geometry strings, weighting/cost column identifiers and table names via `quote()`/`quoteIdentifier()`; cast SRID and node IDs to `int`
-* [API/Upload] Validate each ZIP entry path against the upload directory to prevent ZIP-Slip path traversal in `UploadController`
-* [Manager] Restrict `return` redirect parameter to relative paths to prevent open redirect attacks in `SourceInstanceController`
-* [Print] Restrict external image URLs to `http`/`https` schemes in `CanvasLegend` to prevent SSRF via `file://` and other schemes
-* [Core] Add `LIBXML_NONET` flag to all `DOMDocument::loadXML()` calls in `XmlValidatorService` and `HttpSourceLoader` to prevent XXE attacks
-* [OwsProxy] Set `CURLOPT_SSL_VERIFYHOST=2` alongside `CURLOPT_SSL_VERIFYPEER` in `CurlClientCommon` to prevent SSL hostname spoofing
-* [API] Return generic error message instead of raw exception message in `CommandController` to prevent internal information disclosure
-* [Core] Replace `shell_exec()` with `Symfony\Component\Process\Process` in `ConfigCheckCommand` to prevent command injection
+* [Password/Registration] Replace weak `hash('sha1', rand())` token generation with `bin2hex(random_bytes(20))` in `PasswordController`, `RegistrationController` and `UserSubscriber` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [FailedLoginListener] Replace `$_SERVER['REMOTE_ADDR']`/`$_SERVER['HTTP_USER_AGENT']` superglobals with Symfony request abstraction (`getClientIp()`, `$request->headers->get()`) to respect proxy headers correctly ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Routing] Fix SQL injection in `PgRoutingDBInterface`: quote EWKT geometry strings, weighting/cost column identifiers and table names via `quote()`/`quoteIdentifier()`; cast SRID and node IDs to `int` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [API/Upload] Validate each ZIP entry path against the upload directory to prevent ZIP-Slip path traversal in `UploadController` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Manager] Restrict `return` redirect parameter to relative paths to prevent open redirect attacks in `SourceInstanceController` ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Print] Restrict external image URLs to `http`/`https` schemes in `CanvasLegend` to prevent SSRF via `file://` and other schemes ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Core] Add `LIBXML_NONET` flag to all `DOMDocument::loadXML()` calls in `XmlValidatorService` and `HttpSourceLoader` to prevent XXE attacks ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [OwsProxy] Set `CURLOPT_SSL_VERIFYHOST=2` alongside `CURLOPT_SSL_VERIFYPEER` in `CurlClientCommon` to prevent SSL hostname spoofing ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [API] Return generic error message instead of raw exception message in `CommandController` to prevent internal information disclosure ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
+* [Core] Replace `shell_exec()` with `Symfony\Component\Process\Process` in `ConfigCheckCommand` to prevent command injection ([#PR1830](https://github.com/mapbender/mapbender/pull/1830))
 
 Features:
 * [MetadataDialog] Make MetadataURL and DataUrl available and add twig filter linkify ([#PR1818](https://github.com/mapbender/mapbender/pull/1818))

--- a/src/FOM/UserBundle/Controller/PasswordController.php
+++ b/src/FOM/UserBundle/Controller/PasswordController.php
@@ -2,6 +2,7 @@
 namespace FOM\UserBundle\Controller;
 
 use FOM\UserBundle\Entity\User;
+use FOM\UserBundle\Security\TokenGenerator;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
@@ -201,8 +202,7 @@ class PasswordController extends AbstractEmailProcessController
      */
     protected function setResetToken($user)
     {
-        // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
-        $user->setResetToken(bin2hex(random_bytes(20)));
+        $user->setResetToken(TokenGenerator::generateSecureToken());
         $user->setResetTime(new \DateTime());
     }
 

--- a/src/FOM/UserBundle/Controller/PasswordController.php
+++ b/src/FOM/UserBundle/Controller/PasswordController.php
@@ -201,7 +201,8 @@ class PasswordController extends AbstractEmailProcessController
      */
     protected function setResetToken($user)
     {
-        $user->setResetToken(hash("sha1", rand()));
+        // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
+        $user->setResetToken(bin2hex(random_bytes(20)));
         $user->setResetTime(new \DateTime());
     }
 

--- a/src/FOM/UserBundle/Controller/RegistrationController.php
+++ b/src/FOM/UserBundle/Controller/RegistrationController.php
@@ -5,6 +5,7 @@ namespace FOM\UserBundle\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use FOM\UserBundle\Component\UserHelperService;
 use FOM\UserBundle\Entity\Group;
+use FOM\UserBundle\Security\TokenGenerator;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -66,8 +67,7 @@ class RegistrationController extends AbstractEmailProcessController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
-            $user->setRegistrationToken(bin2hex(random_bytes(20)));
+            $user->setRegistrationToken(TokenGenerator::generateSecureToken());
             $user->setRegistrationTime(new \DateTime());
 
             $groupRepository = $this->getEntityManager()->getRepository(Group::class);
@@ -148,8 +148,7 @@ class RegistrationController extends AbstractEmailProcessController
             ));
         }
 
-        // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
-        $user->setRegistrationToken(bin2hex(random_bytes(20)));
+        $user->setRegistrationToken(TokenGenerator::generateSecureToken());
         $user->setRegistrationTime(new \DateTime());
 
         $this->sendRegistrationMail($user);

--- a/src/FOM/UserBundle/Controller/RegistrationController.php
+++ b/src/FOM/UserBundle/Controller/RegistrationController.php
@@ -66,7 +66,8 @@ class RegistrationController extends AbstractEmailProcessController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $user->setRegistrationToken(hash("sha1",rand()));
+            // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
+            $user->setRegistrationToken(bin2hex(random_bytes(20)));
             $user->setRegistrationTime(new \DateTime());
 
             $groupRepository = $this->getEntityManager()->getRepository(Group::class);
@@ -147,7 +148,8 @@ class RegistrationController extends AbstractEmailProcessController
             ));
         }
 
-        $user->setRegistrationToken(hash("sha1",rand()));
+        // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
+        $user->setRegistrationToken(bin2hex(random_bytes(20)));
         $user->setRegistrationTime(new \DateTime());
 
         $this->sendRegistrationMail($user);

--- a/src/FOM/UserBundle/EventListener/FailedLoginListener.php
+++ b/src/FOM/UserBundle/EventListener/FailedLoginListener.php
@@ -37,7 +37,9 @@ class FailedLoginListener implements EventSubscriberInterface
         if (!$passport) return;
 
         $userName = $passport->getUser()?->getUserIdentifier();
-        $ipAddress = $_SERVER["REMOTE_ADDR"];
+        $request = $event->getRequest();
+        // Security: use Symfony request abstraction instead of $_SERVER superglobal to respect X-Forwarded-For and proxy settings
+        $ipAddress = $request->getClientIp() ?? '';
         $repository = $em->getRepository(UserLogEntry::class);
         $userInfo = [
             'userName' => $userName,
@@ -48,7 +50,7 @@ class FailedLoginListener implements EventSubscriberInterface
         // Log failed login attempt
         $entry = new UserLogEntry(array_merge($userInfo, [
             'context' => [
-                'userAgent' => $_SERVER["HTTP_USER_AGENT"],
+                'userAgent' => $request->headers->get('User-Agent', ''),
             ],
         ]));
         $em->persist($entry);

--- a/src/FOM/UserBundle/Form/EventListener/UserSubscriber.php
+++ b/src/FOM/UserBundle/Form/EventListener/UserSubscriber.php
@@ -56,7 +56,8 @@ class UserSubscriber implements EventSubscriberInterface
             if ($activated) {
                 $user->setRegistrationToken(null);
             } elseif (!$user->getRegistrationToken()) {
-                $user->setRegistrationToken(hash("sha1",rand()));
+                // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
+                $user->setRegistrationToken(bin2hex(random_bytes(20)));
             }
         }
     }

--- a/src/FOM/UserBundle/Form/EventListener/UserSubscriber.php
+++ b/src/FOM/UserBundle/Form/EventListener/UserSubscriber.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvents;
 use FOM\UserBundle\Entity\User;
+use FOM\UserBundle\Security\TokenGenerator;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -56,8 +57,7 @@ class UserSubscriber implements EventSubscriberInterface
             if ($activated) {
                 $user->setRegistrationToken(null);
             } elseif (!$user->getRegistrationToken()) {
-                // Security: use cryptographically secure random token instead of weak hash(sha1,rand())
-                $user->setRegistrationToken(bin2hex(random_bytes(20)));
+                $user->setRegistrationToken(TokenGenerator::generateSecureToken());
             }
         }
     }

--- a/src/FOM/UserBundle/Security/TokenGenerator.php
+++ b/src/FOM/UserBundle/Security/TokenGenerator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FOM\UserBundle\Security;
+
+class TokenGenerator
+{
+    public static function generateSecureToken(): string
+    {
+        return bin2hex(random_bytes(20));
+    }
+}

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -465,9 +465,10 @@ class CommandController extends AbstractController
                 );
             }
         } catch (\Exception $e) {
+            // Security: return generic message to avoid leaking internal exception details to the client
             return new JsonResponse([
                 'success' => false,
-                'error' => $e->getMessage(),
+                'error' => 'Internal server error',
             ], 500);
         }
     }

--- a/src/Mapbender/ApiBundle/Controller/CommandController.php
+++ b/src/Mapbender/ApiBundle/Controller/CommandController.php
@@ -7,6 +7,7 @@ use FOM\UserBundle\Security\Permission\ResourceDomainInstallation;
 use Mapbender\CoreBundle\Component\Application\ApplicationResolver;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -18,8 +19,10 @@ use OpenApi\Attributes as OA;
 
 class CommandController extends AbstractController
 {
-    public function __construct(protected ApplicationResolver $applicationResolver)
-    {
+    public function __construct(
+        protected ApplicationResolver $applicationResolver,
+        #[Autowire('%kernel.debug%')] private bool $debug = false,
+    ) {
     }
 
     #[Route('/api/wms/show', name: 'api_wms_show', methods: ['GET'])]
@@ -465,10 +468,9 @@ class CommandController extends AbstractController
                 );
             }
         } catch (\Exception $e) {
-            // Security: return generic message to avoid leaking internal exception details to the client
             return new JsonResponse([
                 'success' => false,
-                'error' => 'Internal server error',
+                'error' => $this->debug ? $e->getMessage() : 'Internal server error',
             ], 500);
         }
     }

--- a/src/Mapbender/ApiBundle/Controller/UploadController.php
+++ b/src/Mapbender/ApiBundle/Controller/UploadController.php
@@ -123,6 +123,21 @@ class UploadController extends AbstractController
         // Extract the ZIP file
         $zip = new \ZipArchive();
         if ($zip->open($zipFilePath) === true) {
+            $realUploadDir = realpath($this->uploadDir);
+            // Security: validate each ZIP entry path to prevent ZIP-Slip path traversal attacks
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entryName = $zip->getNameIndex($i);
+                $targetPath = realpath(dirname($realUploadDir . DIRECTORY_SEPARATOR . $entryName))
+                    ?: $realUploadDir;
+                if (!str_starts_with($targetPath, $realUploadDir)) {
+                    $zip->close();
+                    unlink($zipFilePath);
+                    return new JsonResponse([
+                        'success' => false,
+                        'error' => 'ZIP contains invalid path: ' . $entryName,
+                    ], JsonResponse::HTTP_BAD_REQUEST);
+                }
+            }
             $zip->extractTo($this->uploadDir);
             $zip->close();
 

--- a/src/Mapbender/CoreBundle/Command/ConfigCheckCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ConfigCheckCommand.php
@@ -189,12 +189,16 @@ class ConfigCheckCommand extends Command
     {
         $output->title('Check FastCGI');
         if ($this->isLinux()) {
-            // Security: use Symfony Process with argument array instead of shell_exec() to prevent command injection
             $process = new Process(['a2query', '-m']);
             $process->run();
             $outputCmd = $process->isSuccessful() ? $process->getOutput() : null;
-            if ($outputCmd !== null && str_contains($outputCmd, 'fcgi')) {
-                $output->writeln($outputCmd);
+            if ($outputCmd !== null) {
+                $fcgiLines = array_filter(explode("\n", $outputCmd), fn($line) => str_contains($line, 'fcgi'));
+                if (!empty($fcgiLines)) {
+                    $output->writeln(implode("\n", $fcgiLines));
+                } else {
+                    $output->writeln('FastCGI not Found');
+                }
             } else {
                 $output->writeln('FastCGI not Found');
             }
@@ -209,7 +213,6 @@ class ConfigCheckCommand extends Command
     {
         $output->title('Check Apache mod_rewrite');
         if ($this->isLinux()) {
-            // Security: use Symfony Process with argument array instead of shell_exec() to prevent command injection
             $process = new Process(['a2query', '-m', 'rewrite']);
             $process->run();
             $outputCmd = $process->isSuccessful() ? $process->getOutput() : null;

--- a/src/Mapbender/CoreBundle/Command/ConfigCheckCommand.php
+++ b/src/Mapbender/CoreBundle/Command/ConfigCheckCommand.php
@@ -45,6 +45,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
 
 class ConfigCheckCommand extends Command
 {
@@ -188,8 +189,11 @@ class ConfigCheckCommand extends Command
     {
         $output->title('Check FastCGI');
         if ($this->isLinux()) {
-            $outputCmd = shell_exec('a2query -m| grep fcgi');
-            if (isset($outputCmd)) {
+            // Security: use Symfony Process with argument array instead of shell_exec() to prevent command injection
+            $process = new Process(['a2query', '-m']);
+            $process->run();
+            $outputCmd = $process->isSuccessful() ? $process->getOutput() : null;
+            if ($outputCmd !== null && str_contains($outputCmd, 'fcgi')) {
                 $output->writeln($outputCmd);
             } else {
                 $output->writeln('FastCGI not Found');
@@ -205,8 +209,11 @@ class ConfigCheckCommand extends Command
     {
         $output->title('Check Apache mod_rewrite');
         if ($this->isLinux()) {
-            $outputCmd = shell_exec('a2query -m rewrite');
-            if (isset($outputCmd)) {
+            // Security: use Symfony Process with argument array instead of shell_exec() to prevent command injection
+            $process = new Process(['a2query', '-m', 'rewrite']);
+            $process->run();
+            $outputCmd = $process->isSuccessful() ? $process->getOutput() : null;
+            if ($outputCmd !== null) {
                 $output->writeln($outputCmd);
             } else {
                 $output->writeln('mod_rewrite not Found');

--- a/src/Mapbender/CoreBundle/Component/Source/HttpSourceLoader.php
+++ b/src/Mapbender/CoreBundle/Component/Source/HttpSourceLoader.php
@@ -141,7 +141,8 @@ abstract class HttpSourceLoader extends SourceLoader
     {
         $doc = new \DOMDocument();
         try {
-            $xmlSuccess = $doc->loadXML($content);
+            // Security: LIBXML_NONET disables network access during XML parsing to prevent XXE attacks
+            $xmlSuccess = $doc->loadXML($content, LIBXML_NONET);
         } catch (\ErrorException $e) {
             $message = \preg_replace('#^.*?::loadXml\(\):\s+#i', '', $e->getMessage());
             throw new MalformedXmlException($content, $message, $e->getCode(), $e);

--- a/src/Mapbender/CoreBundle/Component/XmlValidatorService.php
+++ b/src/Mapbender/CoreBundle/Component/XmlValidatorService.php
@@ -36,7 +36,8 @@ class XmlValidatorService
     public function validateXmlString($xml, $staticSchemaPath = null)
     {
         $doc = new \DOMDocument();
-        $doc->loadXML($xml);
+        // Security: LIBXML_NONET disables network access during XML parsing to prevent XXE attacks
+        $doc->loadXML($xml, LIBXML_NONET);
         $this->validateDocument($doc, $staticSchemaPath);
     }
 

--- a/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
+++ b/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
@@ -139,7 +139,8 @@ class SourceInstanceController extends ApplicationControllerBase
                 $this->addFlash('success', $this->trans->trans('mb.layerset.remove.success'));
             }
 
-            if ($returnUrl = $request->query->get('return')) {
+            // Security: restrict redirect to relative paths only to prevent open redirect attacks
+            if (($returnUrl = $request->query->get('return')) && str_starts_with($returnUrl, '/') && !str_starts_with($returnUrl, '//')) {
                 return $this->redirect($returnUrl);
             } else {
                 return $this->redirectToRoute('mapbender_manager_repository_index', array(

--- a/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
+++ b/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
@@ -139,14 +139,9 @@ class SourceInstanceController extends ApplicationControllerBase
                 $this->addFlash('success', $this->trans->trans('mb.layerset.remove.success'));
             }
 
-            // Security: restrict redirect to relative paths only to prevent open redirect attacks
-            if (($returnUrl = $request->query->get('return')) && str_starts_with($returnUrl, '/') && !str_starts_with($returnUrl, '//')) {
-                return $this->redirect($returnUrl);
-            } else {
-                return $this->redirectToRoute('mapbender_manager_repository_index', array(
-                    '_fragment' => 'tabSharedInstances',
-                ));
-            }
+            return $this->redirectToRoute('mapbender_manager_repository_index', array(
+                '_fragment' => 'tabSharedInstances',
+            ));
         } else {
             $viewData = $this->getApplicationRelationViewData($instance) + array(
                     'form' => $dummyForm->createView(),

--- a/src/Mapbender/PrintBundle/Component/CanvasLegend.php
+++ b/src/Mapbender/PrintBundle/Component/CanvasLegend.php
@@ -181,7 +181,13 @@ class CanvasLegend
     private function drawExternalImage(array $style)
     {
         if (!isset($this->imageCache[$style['image']])) {
-            $this->imageCache[$style['image']] = @file_get_contents($style['image']);
+            $url = $style['image'];
+            // Security: restrict to http/https schemes to prevent SSRF via file://, ftp://, etc.
+            $scheme = parse_url($url, PHP_URL_SCHEME);
+            if ($scheme && !in_array($scheme, ['http', 'https'], true)) {
+                return;
+            }
+            $this->imageCache[$url] = @file_get_contents($url);
         }
         $externalImage = @imagecreatefromstring($this->imageCache[$style['image']]);
         if (!$externalImage) {

--- a/src/Mapbender/RoutingBundle/Component/RoutingDriver/PgRoutingDBInterface.php
+++ b/src/Mapbender/RoutingBundle/Component/RoutingDriver/PgRoutingDBInterface.php
@@ -82,7 +82,9 @@ class PgRoutingDBInterface {
                       AND i.indrelid = a.attrelid
                       AND a.attnum = i.indkey[i.indkey_subscript]
                 WHERE
-                  a.attrelid = '$tableName'::regclass
+                  a.attrelid = " .
+                    // Security: quote table name to prevent SQL injection via regclass cast
+                    $db->quote($tableName) . "::regclass
                 ORDER BY
                   i.indkey_subscript";
 
@@ -162,9 +164,11 @@ class PgRoutingDBInterface {
         $tempTableNodes = $db->quoteIdentifier($this->temptablenodes);
         $tempTableRouting = $db->quoteIdentifier($this->temptableerouting);
 
-        $routingSrid = $this->getSrid($this->routingTable,false);
+        // Security: cast SRID to int and quote EWKT/column name to prevent SQL injection
+        $routingSrid = (int) $this->getSrid($this->routingTable,false);
 
-        $geom_string = "ST_PointFromText('" . $ewkt . "', 4326)";
+        $geom_string = "ST_PointFromText(" . $db->quote($ewkt) . ", 4326)";
+        $quotedWeightingColumn = $db->quoteIdentifier($weightingColumn);
 
         $queryUpdateRoutingTable =
             "WITH pid AS (SELECT max(id) AS new_pid FROM $tempTableNodes),
@@ -189,7 +193,7 @@ class PgRoutingDBInterface {
                 geom_update AS (SELECT ST_Transform(ST_Multi(ST_MakeLine(
                     (SELECT the_geom FROM $tempTableNodes WHERE id = (SELECT source FROM source_update)),
                     (SELECT the_geom FROM $tempTableNodes WHERE id = (SELECT target FROM target_update)))), $routingSrid) as update_geom_value),
-                insert_query AS (INSERT INTO $tempTableRouting (gid, geom, $weightingColumn, source, target) VALUES
+                insert_query AS (INSERT INTO $tempTableRouting (gid, geom, $quotedWeightingColumn, source, target) VALUES
                     ((SELECT new_pid FROM pid),
                     (SELECT geom_value from geom_query),
                     (SELECT ST_Length(geom_value) FROM geom_query),
@@ -199,7 +203,7 @@ class PgRoutingDBInterface {
                     source = (SELECT source FROM source_update),
                     target = (SELECT target FROM target_update),
                     geom = (SELECT update_geom_value FROM geom_update),
-                    $weightingColumn = (SELECT ST_Length(update_geom_value) FROM geom_update)
+                    $quotedWeightingColumn = (SELECT ST_Length(update_geom_value) FROM geom_update)
                     WHERE gid = (SELECT gid FROM point_data) RETURNING *)
                 SELECT * FROM pid";
 
@@ -213,9 +217,10 @@ class PgRoutingDBInterface {
         $tempTableNodes = $db->quoteIdentifier($this->temptablenodes);
         $tempTableRouting = $db->quoteIdentifier($this->temptableerouting);
 
-        $routingSrid = $this->getSrid($this->routingTable,false);
+        // Security: cast SRID to int and quote EWKT to prevent SQL injection
+        $routingSrid = (int) $this->getSrid($this->routingTable,false);
 
-        $geom_string = "ST_PointFromText('" . $ewkt . "', 4326)";
+        $geom_string = "ST_PointFromText(" . $db->quote($ewkt) . ", 4326)";
 
         // inserts poi as new node into vertices table
         $queryUpdateNodeTable =
@@ -256,9 +261,12 @@ class PgRoutingDBInterface {
         $routingTableGeomField = $db->quoteIdentifier($this->getGeomField($this->temptableerouting));
         $idKey = $db->quoteIdentifier("gid");
 
-        $routingSrid = $this->getSrid($this->routingTable,false);
+        // Security: cast SRID to int, quote cost column identifier, and cast all node IDs to int to prevent SQL injection
+        $routingSrid = (int) $this->getSrid($this->routingTable,false);
+        $quotedRouteCostRow = $db->quoteIdentifier($routeCostRow);
 
         /* convert array to String-Array */
+        $nodeIdList = array_map('intval', $nodeIdList);
         $nodeIdListString = implode(",", $nodeIdList);
 
         $query = "
@@ -278,7 +286,7 @@ class PgRoutingDBInterface {
 					route.edge as edge
                 FROM
                     pgr_dijkstraVia (
-                        'SELECT $idKey AS id, $this->street_name, source, target, $routeCostRow AS cost FROM $this->temptableerouting',
+                        'SELECT $idKey AS id, $this->street_name, source, target, $quotedRouteCostRow AS cost FROM $this->temptableerouting',
                         ARRAY[$nodeIdListString],
                         $directedGraph,
                         $hasReverseCost
@@ -337,7 +345,9 @@ class PgRoutingDBInterface {
     public function getResultGeom(array $geom)
     {
         $db = $this->connection;
-        $wktGeomString = "'".implode("','", array_filter($geom, function($g) { return !!$g; }))."'";
+        $filteredGeom = array_filter($geom, function($g) { return !!$g; });
+        // Security: quote each WKT geometry string individually to prevent SQL injection
+        $wktGeomString = implode(",", array_map([$db, 'quote'], $filteredGeom));
         // get Multiline as GeoJSON
         $query = "SELECT ST_AsGeoJSON(ST_Union( ARRAY[$wktGeomString])) As geom";
         return $db->executeQuery($query)->fetchOne();
@@ -354,7 +364,7 @@ class PgRoutingDBInterface {
     {
         $db = $this->connection;
 
-        $routingSrid = $this->getSrid($this->routingTable,false);
+        $routingSrid = (int) $this->getSrid($this->routingTable,false);
 
         $query = "
               SELECT ST_X(ST_Transform(the_geom,$routingSrid)) as x, ST_Y(ST_Transform(the_geom,$routingSrid)) as y

--- a/src/OwsProxy3/CoreBundle/Component/CurlClientCommon.php
+++ b/src/OwsProxy3/CoreBundle/Component/CurlClientCommon.php
@@ -32,6 +32,9 @@ class CurlClientCommon extends BaseClient
         }
         if (isset($config['checkssl'])) {
             $options[CURLOPT_SSL_VERIFYPEER] = !!$config['checkssl'];
+            // Security: also enforce hostname verification (VERIFYHOST=2) when SSL checking is enabled;
+            // previously only VERIFYPEER was set, leaving hostname spoofing possible
+            $options[CURLOPT_SSL_VERIFYHOST] = $config['checkssl'] ? 2 : 0;
         }
         if (isset($config['host']) && (empty($config['noproxy']) || !in_array($hostName, $config['noproxy']))) {
             $proxyOptions = array(


### PR DESCRIPTION
This PR fixes multiple vulnerabilities reported by a security scan, addressing issues such as weak token generation, SQL injection, XXE, SSRF, open redirects, path traversal, command injection, and information disclosure across various components.

replaces PR #1830 which was based on the develop branch


* [Password/Registration] Replace weak `hash('sha1', rand())` token generation with `bin2hex(random_bytes(20))` in `PasswordController`, `RegistrationController` and `UserSubscriber` 
* [FailedLoginListener] Replace `$_SERVER['REMOTE_ADDR']`/`$_SERVER['HTTP_USER_AGENT']` superglobals with Symfony request abstraction (`getClientIp()`, `$request->headers->get()`) to respect proxy headers correctly 
* [Routing] Fix SQL injection in `PgRoutingDBInterface`: quote EWKT geometry strings, weighting/cost column identifiers and table names via `quote()`/`quoteIdentifier()`; cast SRID and node IDs to `int` 
* [API/Upload] Validate each ZIP entry path against the upload directory to prevent ZIP-Slip path traversal in `UploadController` 
* [Manager] Restrict `return` redirect parameter to relative paths to prevent open redirect attacks in `SourceInstanceController` 
* [Print] Restrict external image URLs to `http`/`https` schemes in `CanvasLegend` to prevent SSRF via `file://` and other schemes 
* [Core] Add `LIBXML_NONET` flag to all `DOMDocument::loadXML()` calls in `XmlValidatorService` and `HttpSourceLoader` to prevent XXE attacks 
* [OwsProxy] Set `CURLOPT_SSL_VERIFYHOST=2` alongside `CURLOPT_SSL_VERIFYPEER` in `CurlClientCommon` to prevent SSL hostname spoofing 
* [API] Return generic error message instead of raw exception message in `CommandController` to prevent internal information disclosure 
* [Core] Replace `shell_exec()` with `Symfony\Component\Process\Process` in `ConfigCheckCommand` to prevent command injection 
