### PR TITLE
Add new parameter mapbender.search.default_regex for default search validation regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Security:
 * [WMS] Always use Tunnel instead of OwsProxy to avoid leaking internal urls ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
 * [WMS] Do not expose hidden vendor-specific parameters ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))
+* [Search] Add validation for input fields, new parameter `mapbender.search.default_regex` ([#PR1824](https://github.com/mapbender/mapbender/pull/1824), [#PR1834](https://github.com/mapbender/mapbender/pull/1834))
 * [Password/Registration] Use stronger hashing algorithms ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
 * [API/Upload] Prevent potential ZIP-Slip path traversal ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))
 * [Print] Prevent potential SSRF attacks in Print Service ([#PR1833](https://github.com/mapbender/mapbender/pull/1833))

--- a/src/Mapbender/CoreBundle/Element/SearchRouter.php
+++ b/src/Mapbender/CoreBundle/Element/SearchRouter.php
@@ -36,7 +36,9 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
                                 protected CsrfTokenManagerInterface $csrfTokenManager,
                                 protected ContainerInterface        $container,
                                 protected ?LoggerInterface          $logger = null,
-                                protected TranslatorInterface       $translator,)
+                                protected TranslatorInterface       $translator,
+                                protected string                    $defaultPattern,
+    )
     {
     }
 
@@ -100,7 +102,6 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
                 ),
                 "styleMap" => $this->getDefaultStyleMapOptions(),
             ),
-            "pattern" => "^[\p{L}0-9_\-\s]*$",
         );
     }
 
@@ -239,10 +240,8 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
 
     protected function validateInputData($inputData, $categoryConf)
     {
-        $config = $this->getDefaultRouteConfiguration();
-        $pattern = $config['pattern'];
         foreach ($categoryConf['form'] as $key => $formField) {
-            $pattern = $formField['pattern'] ?? $pattern;
+            $pattern = $formField['pattern'] ?? $this->defaultPattern;
             if (!preg_match('/' . $pattern . '/u', $inputData[$key])) {
                 $message = $this->translator->trans('mb.core.searchrouter.invalid_input_data');
                 throw new BadRequestHttpException($message);

--- a/src/Mapbender/CoreBundle/Element/SearchRouter.php
+++ b/src/Mapbender/CoreBundle/Element/SearchRouter.php
@@ -35,7 +35,7 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
                                 protected FormFactoryInterface      $formFactory,
                                 protected CsrfTokenManagerInterface $csrfTokenManager,
                                 protected ContainerInterface        $container,
-                                protected ?LoggerInterface          $logger = null,
+                                protected ?LoggerInterface          $logger,
                                 protected TranslatorInterface       $translator,
                                 protected string                    $defaultPattern,
     )
@@ -242,7 +242,13 @@ class SearchRouter extends AbstractElementService implements ConfigMigrationInte
     {
         foreach ($categoryConf['form'] as $key => $formField) {
             $pattern = $formField['pattern'] ?? $this->defaultPattern;
-            if (!preg_match('/' . $pattern . '/u', $inputData[$key])) {
+            // Escape the chosen delimiter in the pattern to avoid breaking the regex.
+            $escapedPattern = str_replace('#', '\#', $pattern);
+            $regex = '#' . $escapedPattern . '#u';
+            // Suppress potential warnings from invalid regexes and handle errors explicitly.
+            $result = @preg_match($regex, $inputData[$key]);
+            if ($result !== 1) {
+                // Either no match (0) or regex error (false): treat as invalid input.
                 $message = $this->translator->trans('mb.core.searchrouter.invalid_input_data');
                 throw new BadRequestHttpException($message);
             }

--- a/src/Mapbender/CoreBundle/Resources/config/elements.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/elements.xml
@@ -64,7 +64,7 @@
             <argument type="service" id="form.factory" />
             <argument type="service" id="security.csrf.token_manager" />
             <argument type="service" id="service_container" />
-            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="logger" />
             <argument type="service" id="translator" />
             <argument>%mapbender.search.default_regex%</argument>
         </service>

--- a/src/Mapbender/CoreBundle/Resources/config/elements.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/elements.xml
@@ -66,6 +66,7 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="translator" />
+            <argument>%mapbender.search.default_regex%</argument>
         </service>
         <service id="mapbender.element.SimpleSearch" class="Mapbender\CoreBundle\Element\SimpleSearch">
             <tag name="mapbender.element" />

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
@@ -30,5 +30,8 @@ parameters:
     mapbender.icons.disable_default_fa: false
     mapbender.icons.custom: ~
 
+    # default regex for validating search router input fields
+    mapbender.search.default_regex: '.*'
+
     mapbender.show_proxied_service_urls: false
 


### PR DESCRIPTION
Follow-up to #1824: The default regex is now configurable using the new parameter `mapbender.search.default_regex` which default to `.*`, allowing all characters (as it was before). This default may be adjusted for the next major release, you can already use it to restrict inputs though. Also, the `pattern` parameter can be used per input field to override this value.