### PR TITLE
Fix layer sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Bugfixes:
 * When duplicating applications, element permissions were not duplicated ([#PR1816](https://github.com/mapbender/mapbender/pull/1816))
 * [Layertree] Improve performance of layertree-actions in layertrees with many WMS
 * Support adding the same shared instance more than once in an application ([#PR1821](https://github.com/mapbender/mapbender/pull/1821))
+* Fix broken layer sorting after WMS or new view was loaded ([#PR1837](https://github.com/mapbender/mapbender/pull/1837))
 
 Other:
 * [ViewManager] Load Views on demand with Ajax

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -455,6 +455,9 @@
             wmsloaderSources.forEach(source => {
                 this.mbMap.getModel().addSourceFromConfig(source);
             });
+            if (wmsloaderSources.length > 0) {
+                layertreeElement.data('mapbenderMbLayertree')._sortableInitialized = false;
+            }
             this.mbMap.getModel().applyViewParams(settings.viewParams);
             this.mbMap.element.trigger('mbsourcesrefreshed', {
                 mbMap: this.mbMap,

--- a/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
+++ b/src/Mapbender/CoreBundle/Resources/public/element/mbViewManager.js
@@ -449,6 +449,7 @@
             this.mbMap.getModel().initializeSourceLayers(sources);
 
             if (layertreeElement.length > 0) {
+                layertreeElement.data('mapbenderMbLayertree')._sortableInitialized = false;
                 layertreeElement.data('mapbenderMbLayertree')._createTree();
             }
             wmsloaderSources.forEach(source => {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.geosource.js
@@ -139,7 +139,8 @@ Mapbender.Geo.SourceHandler = {
             }
             if (layerObj.parent) {
                 var parentId = layerObj.parent.options.id;
-                if (parentId && parentIdOrder.indexOf(parentId) === -1) {
+                var hasChildren = layerObj.children;
+                if (parentId && !hasChildren && parentIdOrder.indexOf(parentId) === -1) {
                     parentIdOrder.push(parentId);
                 }
             }

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.element.wmsloader.js
@@ -218,6 +218,7 @@
                 }
                 source = source || this.mbMap.model.addSourceFromConfig(sourceDef);
             }
+            $('.mb-element-layertree').data('mapbenderMbLayertree')._sortableInitialized = false;
             return source || null;
         },
         /**


### PR DESCRIPTION
- Fixes broken layer sorting after WMS (via WMS-Loader) or new view (via ViewManager) was loaded.
- See internal issue #11121
- Issue was caused by changes in [PR #1820](https://github.com/mapbender/mapbender/pull/1820)
- In this case, the solution of resetting `_sortableInitialized` back to `false` is fine. After all, it’s only called once. Previously, it was unnecessarily called 6–7 times or more.