### PR TITLE
ApplicationSwitcher add option to add a description

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
+++ b/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
@@ -100,6 +100,7 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
             try {
                 $application = $this->applicationResolver->getApplicationEntity($slug);
                 $appConfig['title'] = (!empty($appConfig['title'])) ? $appConfig['title'] : $application->getTitle();
+                $appConfig['description'] = (!empty($appConfig['description'])) ? $appConfig['description'] : $application->getDescription();
                 if (empty($appConfig['url'])) {
                     $appConfig['url'] = $this->router->generate('mapbender_core_application_application', ['slug' => $slug]);
                 }
@@ -129,6 +130,7 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
             foreach ($conf['applications'] as $slug) {
                 $appConfig[$slug] = [
                     'title' => null,
+                    'description' => null,
                     'url' => null,
                     'imgUrl' => null,
                     'group' => null,

--- a/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
@@ -3,7 +3,7 @@
         <select class="hiddenDropdown -fn-application-selector">
             {% for apps in config.applications %}
                 {% for slug, app in apps %}
-                    <option value="{{ slug }}" data-app-url="{{ app.url }}">
+                    <option value="{{ slug }}" data-app-url="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
                         {{ app.title }}
                     </option>
                 {% endfor %}
@@ -21,7 +21,7 @@
         <ul class="list">
             {% for slug, app in apps %}
                 <li class="list-item">
-                    <a href="{{ app.url }}">
+                    <a href="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
                         <div class="list-content">
                             {% if app.imgUrl is defined and app.imgUrl != false %}
                             <img src="{{ app.imgUrl }}" alt="{{ app.title }}">


### PR DESCRIPTION
- added the option to define a description in the configuration for each application
- the description will be shown as tooltip when the application switcher is used in the sidepane (the description is not shown in the selectvbox)

This is the result

<img width="856" height="553" alt="applicationswitcher_screenshot" src="https://github.com/user-attachments/assets/90209ed7-0a9c-484b-ba1b-16dac051bd22" />

You can try this configuration

```
mapbender_user:
  title: null
  description: 'Beschreibung daflsj j dljf ljdlfj ljf laj dflkj'
  url: null
  imgUrl: null
  group: null
mapbender_user_basic:
  title: null
  description: 'Dies ist eine sehr schöne besondere Anwendung. Ein Klick lohnt sich. Sie werden es nicht bereuen. Nur zu. Klick klick :)'
  url: null
  imgUrl: null
  group: null
mapbender_user_db:
  title: DemoDevelop
  description: null
  url: null
  imgUrl: null
  group: DEVELOP
Workshop_Demo:
  title: Workshop_Demo
  description: null
  url: null
  imgUrl: null
  group: DEVELOP
mapbender_user_no_description:
  title: mapbender_user_no_description
  description: null
  url: null
  imgUrl: null
  group: DEVELOP
external_osm:
  title: 'OSM with lon & lat'
  url: 'https://www.openstreetmap.org/?#map=19/%lon%/%lat%'
  imgUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/b0/Openstreetmap_logo.svg'
  group: External
external_osm_mit_desc:
  title: 'OSM with lon & lat'
  url: 'https://www.openstreetmap.org/?#map=19/%lon%/%lat%'
  imgUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/b0/Openstreetmap_logo.svg'
  description: null
  group: External
```

