### PR TITLE
Make sandbox iframe attribute in the feature info dialog configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next bugfix release
+* Fix activating visible layers by name ([#PR1839](https://github.com/mapbender/mapbender/pull/1839))
+* [FeatureInfo] Make sandbox iframe attribute in the feature info dialog configurable using `mapbender.featureinfo.iframe_sandbox_params`  ([#PR1844](https://github.com/mapbender/mapbender/pull/1844))
+
 ## v4.2.5
 Security:
 * [WMS] Always use Tunnel instead of OwsProxy to avoid leaking internal urls ([#PR1817](https://github.com/mapbender/mapbender/pull/1817))

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
@@ -35,5 +35,6 @@ parameters:
 
     mapbender.show_proxied_service_urls: false
 
+    # sandbox iframe attribute in the feature info dialog, see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox for options
     mapbender.featureinfo.iframe_sandbox_params: 'allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads'
 

--- a/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
+++ b/src/Mapbender/CoreBundle/Resources/config/mapbender.yaml
@@ -35,3 +35,5 @@ parameters:
 
     mapbender.show_proxied_service_urls: false
 
+    mapbender.featureinfo.iframe_sandbox_params: 'allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads'
+

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/GetFeatureInfoSource.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/GetFeatureInfoSource.js
@@ -101,7 +101,8 @@
         }
         _formatFeatureInfoResponse(data, mimetype, options) {
             if (mimetype.toLowerCase() === 'text/html') {
-                const $iframe = $('<iframe sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads" class="iframe--responsive">');
+                const sandboxParams = this.options.iframeSandboxParams || 'allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads';
+                const $iframe = $('<iframe sandbox="'+ sandboxParams + '" class="iframe--responsive">');
                 $iframe.attr("srcdoc", [options.injectionScript, data].join(''));
                 return $iframe.get();
             } else {

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -37,6 +37,9 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
         protected string                 $fiIframeSandboxParams,
     )
     {
+        if (!preg_match('/^[a-zA-Z- ]+$/', $this->fiIframeSandboxParams)) {
+            throw new \InvalidArgumentException("mapbender.featureinfo.iframe_sandbox_params contains invalid characters");
+        }
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -33,7 +33,9 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
         protected UrlProcessor           $urlProcessor,
         protected TokenStorageInterface  $tokenStorage,
         protected EntityManagerInterface $em,
-        protected ?string                $defaultLayerOrder)
+        protected ?string                $defaultLayerOrder,
+        protected string                 $fiIframeSandboxParams,
+    )
     {
     }
 
@@ -103,6 +105,7 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
             'ratio' => $ratio,
             'refreshInterval' => $sourceInstance->getRefreshInterval(),
             'layerOrder' => $sourceInstance->getLayerOrder(),
+            'iframeSandboxParams' => $this->fiIframeSandboxParams,
         );
     }
 

--- a/src/Mapbender/WmsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmsBundle/Resources/config/services.xml
@@ -38,6 +38,7 @@
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument>%wms.default_layer_order%</argument>
+            <argument>%mapbender.featureinfo.iframe_sandbox_params%</argument>
         </service>
         <service id="mapbender.source.wms.instance_factory" class="%mapbender.source.wms.instance_factory.class%">
             <argument type="service" id="doctrine.orm.default_entity_manager" />

--- a/src/Mapbender/WmtsBundle/Component/Presenter/ConfigGeneratorCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/Presenter/ConfigGeneratorCommon.php
@@ -18,6 +18,7 @@ abstract class ConfigGeneratorCommon extends SourceInstanceConfigGenerator
 {
     public function __construct(
         protected UrlProcessor $urlProcessor,
+        protected string $fiIframeSandboxParams,
     )
     {
     }
@@ -47,6 +48,7 @@ abstract class ConfigGeneratorCommon extends SourceInstanceConfigGenerator
         return array(
             "proxy" => $sourceInstance->getProxy(),
             "opacity" => $sourceInstance->getOpacity() / 100,
+            "iframeSandboxParams" => $this->fiIframeSandboxParams,
         );
     }
 

--- a/src/Mapbender/WmtsBundle/Component/Presenter/ConfigGeneratorCommon.php
+++ b/src/Mapbender/WmtsBundle/Component/Presenter/ConfigGeneratorCommon.php
@@ -21,6 +21,9 @@ abstract class ConfigGeneratorCommon extends SourceInstanceConfigGenerator
         protected string $fiIframeSandboxParams,
     )
     {
+        if (!preg_match('/^[a-zA-Z- ]+$/', $this->fiIframeSandboxParams)) {
+            throw new \InvalidArgumentException("mapbender.featureinfo.iframe_sandbox_params contains invalid characters");
+        }
     }
 
     abstract protected function getLayerLegendConfig(SourceInstanceItem $instanceLayer);

--- a/src/Mapbender/WmtsBundle/Resources/config/services.xml
+++ b/src/Mapbender/WmtsBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
 
 		<service id="mapbender.source.wmts.config_generator" class="Mapbender\WmtsBundle\Component\Presenter\ConfigGeneratorWmts">
 			<argument type="service" id="mapbender.source.url_processor.service" />
+            <argument>%mapbender.featureinfo.iframe_sandbox_params%</argument>
 		</service>
 		<service id="mapbender.source.wmts.instance_factory"
 				 class="Mapbender\WmtsBundle\Component\InstanceFactoryWmts"
@@ -49,6 +50,7 @@
 		</service>
 		<service id="mapbender.source.tms.config_generator" class="Mapbender\WmtsBundle\Component\Presenter\ConfigGeneratorTms">
 			<argument type="service" id="mapbender.source.url_processor.service" />
+			<argument>%mapbender.featureinfo.iframe_sandbox_params%</argument>
 		</service>
 		<service id="mapbender.source.tms.instance_factory"
 				 class="Mapbender\WmtsBundle\Component\InstanceFactoryTms"


### PR DESCRIPTION
Using the parameter `mapbender.featureinfo.iframe_sandbox_params`. Default value is `allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads`. For list of options, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox)