### PR TITLE
feat: toolbar button color

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/button.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/button.scss
@@ -4,7 +4,6 @@ $hoverEffects: true !default;
   cursor: pointer;
   .toolBar & {
     border-radius: 2 * $radius;
-    opacity: $toolBarButtonDefaultOpacity;
     @if $hoverEffects {
       &:hover {
         opacity: $toolBarButtonHoverOpacity;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/scalebar.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/scalebar.scss
@@ -24,7 +24,7 @@ $textColor: $darkFontColor !default;
   .mb-element-scaleline {
     text-align: center;
     .scaleBorder {
-      border-color: $toolBarFontColor;
+      border-color: var(--toolbar-text-color);
     }
   }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/zoombar.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/zoombar.scss
@@ -50,7 +50,6 @@
       display: block;
     }
     .zoom-level-gap {
-      opacity: $toolBarButtonDefaultOpacity;
       margin-bottom: -1px;
     }
   }
@@ -60,7 +59,7 @@
       height: 2.5em;
       width: auto;
       g {
-        fill: $toolBarFontColor;
+        fill: var(--toolbar-text-color);
       }
       // we only have one icon :)
     }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_mixins.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_mixins.scss
@@ -45,7 +45,7 @@
   // do not use this; add toolBarColors class to your element, and / or optionally use
   // opacity: $toolBarOpacity
   background-color: $toolBarBackgroundColor;
-  color: $toolBarFontColor;
+  color: var(--toolbar-text-color);
   opacity: $toolBarOpacity;
 }
 @mixin smartphones(){

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -100,7 +100,11 @@ $darkFontColor: #3f3f3f; // Doesn't do anything; (re)define $textColor instead
 $ciColor2: #4899ba; // Doesn't do anything
 
 :root {
+    // Brand Colors
     --primary: #079ee0;
+    --primary-dark: hsl(198, 100%, 39%);
+
+    // Colors
     --checkbox-checked: var(--primary);
     --checkbox-unchecked: #a0a0a0;
     --border-color: #ddd;
@@ -110,6 +114,11 @@ $ciColor2: #4899ba; // Doesn't do anything
     --background-color: #fff;
     --focus-color: var(--primary);
 
+    // Menus
+    --menu-hover-color: rgba(0, 0, 0, 0.05);
+
     // Toolbar
     --toolbar-text-color: var(--text-color);
+    --toolbar-button-active-background-color: var(--primary);
+    --toolbar-button-active-background-hover-color: var(--primary-dark);
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -22,13 +22,11 @@ $errorColor:#aa2323; // red
 $lightFontColor:#fff; // white
 
 // Toolbar colors (frontend)
-$toolBarFontColor: #222;
 $toolBarBackgroundColor: #eee;
 $toolBarOpacity: 0.8;
 $toolBarButtonActiveBackgroundColor: $ciColor;
 
 // Default and hover opacity for Button (and Button-like) Elements in toolbars
-$toolBarButtonDefaultOpacity: 0.7;
 $toolBarButtonHoverOpacity: 1.0;
 $toolBarButtonActiveOpacity: $toolBarButtonHoverOpacity;
 
@@ -106,9 +104,12 @@ $ciColor2: #4899ba; // Doesn't do anything
     --checkbox-checked: var(--primary);
     --checkbox-unchecked: #a0a0a0;
     --border-color: #ddd;
-    --text-color: #222;
+    --text-color: #333;
     --text-color-inactive: #636363;
     --text-color-button-inactive: #747577;
     --background-color: #fff;
     --focus-color: var(--primary);
+
+    // Toolbar
+    --toolbar-text-color: var(--text-color);
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -4,7 +4,7 @@
     --sidepane-inactive-text-color: var(--text-color-inactive);
     --sidepane-button-color: var(--text-color-button-inactive);
     --sidepane-background-color: rgba(255, 255, 255, 0.9);
-    --sidepane-hover-color: rgba(0, 0, 0, 0.05);
+    --sidepane-hover-color: var(--menu-hover-color);
     --sidepane-active-background-color: rgba(0, 0, 0, 0.02);
     --sidepane-collapsed-width: 3rem;
     --sidepane-padding-left: 1rem;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -2,11 +2,11 @@
     --sidepane-border-color: var(--border-color);
     --sidepane-text-color: var(--text-color);
     --sidepane-inactive-text-color: var(--text-color-inactive);
-    --sidepane-button-color: var(--text-color-button-inactive);
+    --sidepane-button-color: var(--text-color);
     --sidepane-background-color: rgba(255, 255, 255, 0.9);
     --sidepane-hover-color: var(--menu-hover-color);
     --sidepane-active-background-color: rgba(0, 0, 0, 0.02);
-    --sidepane-collapsed-width: 3rem;
+    --sidepane-collapsed-width: 3.4rem;
     --sidepane-padding-left: 1rem;
     --sidepane-padding-right: 1rem;
     --sidepane-padding-y: 1rem;
@@ -91,12 +91,6 @@
                 padding-left: 0 !important;
             }
         }
-
-        .mb-icon, .sidePane__toggle {
-            &:hover {
-                color: var(--sidepane-text-color);
-            }
-        }
     }
 
     &__toggle {
@@ -126,7 +120,8 @@
 .sidePane--collapsed__icons {
     display: flex;
     flex-direction: column;
-    gap: 1.2rem;
+    align-content: center;
+    gap: 0.8rem;
 
     &.hidden {
         display: none;
@@ -138,15 +133,21 @@
 
     .active-element-icon {
         color: var(--primary);
-        opacity: 1;
     }
 
     .sidePane--collapsed__element-icon {
-        width: 1.2em;
-        height: 1.2em;
+        width: 1.8em;
+        height: 1.8em;
         font-size: 18px;
-        display: inline-block;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         text-align: center;
+        border-radius: var(--bs-border-radius-sm);
+
+        &:hover {
+            background: var(--menu-hover-color);
+        }
     }
 }
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -40,11 +40,10 @@ $hoverEffects: true !default;
 /* ---------------------------------------------------------- TOOLBAR */
 .toolBarColors, .toolBar {
   background-color: $toolBarBackgroundColor;
-  color: $toolBarFontColor;
+  color: var(--toolbar-text-color);
 }
 
 .toolbar-button-hover-effect {
-  opacity: $toolBarButtonDefaultOpacity;
   @if $hoverEffects {
     &:hover {
       opacity: $toolBarButtonHoverOpacity;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -156,8 +156,8 @@ ul.toolBar, .toolBar > ul {
       }
     }
     .toolBarItem {
-      margin: 0.25em;
-      padding: 0.25em;
+      margin: 0.25em 0.5em 0.25em 0.5em;
+      padding: 0.5em;
       display: block;
       .iconBig {
         // emulate ~.fa-fw for neat text alignment

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -2,7 +2,6 @@ $backgroundColor: #fff !default;
 $sidepaneBorderColor: #ccc !default;
 
 $toolBarBackgroundColor: #eee !default;
-$toolBarButtonActiveBackgroundColor: $ciColor !default;
 $toolBarOpacity: 1.0 !default;
 $toolBarBackground: rgba($toolBarBackgroundColor, $toolBarOpacity) !default;
 $toolBarTopBackground: $toolBarBackground !default;
@@ -77,12 +76,20 @@ ul.toolBar, .toolBar > ul {
   vertical-align: middle; // workaround for mismatching effective line heights when mixing .dropdown with better-behaved items
   padding: 5px;
   display: inline-block;
+
+  &.mb-button:hover {
+    background: var(--menu-hover-color);
+  }
 }
 
 .toolBarItemActive {
   // Invert background and foreground
-  background-color: $toolBarButtonActiveBackgroundColor;
+  background-color: var(--toolbar-button-active-background-color);
   color: $toolBarBackgroundColor;
+
+  &.mb-button:hover {
+    background: var(--toolbar-button-active-background-hover-color);
+  }
 }
 
 .toolBarItem + .toolBarItem {


### PR DESCRIPTION
(see internal ticket 11915):
> Farbe der Icons/Texte unterschiedlich in : Sidepane schwarz <-> Werkzeugleiste grau

(English: "Color of icons/texts different in : sidepane black <-> toolbar grey")

## Changes
- The icon and text colors of the toolbar were adjusted to match the ones of the sidepane
- Since the previous hover effects did not work anymore as the icons were already very dark, the hover effects were shifted from the fore- to the background. Now the background is darkened. This also required adjustments to the padding and spacing to make the hovers look good.
- It followed that the spacing of the collapsed toolbar needed adjustment as well
- The icons of the collapsed sidepane were as light as the icons of the toolbar previous to this PR. This was fixed and they were darkened as well, their hover effect was adjusted and their spacing was adapted to make the hover effect look good.
- In the process all SCSS variables that were used were converted into CSS variables

## Changing the toolbar vs. the sidepane
I decided on changing the color of the icons / buttons of the toolbar instead of the ones in the sidepane. The decision was made on the basis of accessibility aspects. The (almost) black icons of the sidepane provide higher contrast against the background making them more legible. Taking into consideration that the toolbar is semi-transparent contrast matters even more. Therefore darkening the toolbar icons was deemed the better decision over lightening the ones of the sidepane.

Looking at how other websites handle this validated the decision. Google Maps for all its flaws offers a very refined UX/UI and uses black text on white background in their top pills:
<img width="1222" height="185" alt="image" src="https://github.com/user-attachments/assets/ea942850-7f4e-4fca-a141-0a257047d4a1" />

## How the UI looks after the PR
<img width="1364" height="823" alt="image" src="https://github.com/user-attachments/assets/1158b735-7c5b-443c-a2e5-3b2f522ef34d" />



