### PR TITLE
[LayerTree] Also show metadata for YAML applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Features:
 * [HTMLElement] Add 'openInline' flag to provide more flexibility in sidebar and content area ([#PR1814](https://github.com/mapbender/mapbender/pull/1814))
 * [MetadataDialog] Make MetadataURL and DataUrl available and add twig filter linkify ([#PR1818](https://github.com/mapbender/mapbender/pull/1818))
 * [SearchRouter] Extend SQLSearchEngine to support multiple search values separated by configurable delimiters ([#PR1836](https://github.com/mapbender/mapbender/pull/1836))
+* [LayerTree] Also show metadata for YAML applications ([#PR1849](https://github.com/mapbender/mapbender/pull/1849))
 
 Bugfixes:
 * When duplicating applications, also duplicate element permissions ([#PR1812](https://github.com/mapbender/mapbender/pull/1812))

--- a/src/Mapbender/CoreBundle/Component/Source/SourceLoader.php
+++ b/src/Mapbender/CoreBundle/Component/Source/SourceLoader.php
@@ -4,6 +4,7 @@
 namespace Mapbender\CoreBundle\Component\Source;
 
 
+use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Source;
 
 /**
@@ -40,5 +41,14 @@ abstract class SourceLoader
     public function getRefreshModel(Source $source): mixed
     {
         return $source;
+    }
+
+    /**
+     * Determines if @see loadSource is called before called reading metadata.
+     * If there is persisted metadata (method returns true), loadSource won't be called
+     */
+    public function hasPersistedMetadata(Application $application, Source $source): bool
+    {
+        return true;
     }
 }

--- a/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
+++ b/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
@@ -52,6 +52,10 @@ class SourceMetaDataController
 
         $source = $instance->getSource();
         $dataSource = $this->typeDirectoryService->getSource($source->getType());
+        $loader = $dataSource->getLoader();
+        if (!$loader->hasPersistedMetadata($application, $source)) {
+            $source = $loader->loadSource($source);
+        }
         $template = $dataSource->getMetadataFrontendTemplate();
         if (!$template) {
             throw new NotFoundHttpException();

--- a/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
+++ b/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
@@ -6,8 +6,14 @@ namespace Mapbender\CoreBundle\Controller;
 
 use FOM\UserBundle\Security\Permission\ResourceDomainApplication;
 use Mapbender\CoreBundle\Component\Application\ApplicationResolver;
+use Mapbender\CoreBundle\Component\Source\DataSource;
 use Mapbender\CoreBundle\Component\Source\TypeDirectoryService;
+use Mapbender\CoreBundle\Entity\Application;
+use Mapbender\CoreBundle\Entity\Source;
+use Mapbender\CoreBundle\Entity\SourceInstanceItem;
+use Mapbender\CoreBundle\Entity\SourceItem;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -34,7 +40,7 @@ class SourceMetaDataController
     }
 
     #[Route(path: '/application/{slug}/metadata/{instanceId}/{layerId}', name: 'mapbender_core_application_metadata', methods: ['GET'])]
-    public function metadataAction(int|string $slug, int|string $instanceId, int|string $layerId): Response
+    public function metadataAction(int|string $slug, int|string $instanceId, int|string $layerId, Request $request): Response
     {
         $application = $this->applicationResolver->getApplicationEntity($slug);
         if (!$this->security->isGranted(ResourceDomainApplication::ACTION_VIEW, $application)) {
@@ -52,10 +58,7 @@ class SourceMetaDataController
 
         $source = $instance->getSource();
         $dataSource = $this->typeDirectoryService->getSource($source->getType());
-        $loader = $dataSource->getLoader();
-        if (!$loader->hasPersistedMetadata($application, $source)) {
-            $source = $loader->loadSource($source);
-        }
+        $source = $this->resolveSource($application, $source, $request, $dataSource, $startLayerInstance);
         $template = $dataSource->getMetadataFrontendTemplate();
         if (!$template) {
             throw new NotFoundHttpException();
@@ -67,5 +70,50 @@ class SourceMetaDataController
             'secureUrls' => !$this->showProxiedServiceUrls && $dataSource->areServiceUrlsInternal($instance)
         ));
         return new Response($content);
+    }
+
+    public function resolveSource(Application $application, Source $source, Request $request, DataSource $dataSource, SourceInstanceItem $startLayerInstance): Source
+    {
+        $loader = $dataSource->getLoader();
+        // metadata persisted, no need to load it from server
+        if ($loader->hasPersistedMetadata($application, $source)) {
+            return $source;
+        }
+
+        $source = $loader->loadSource($source);
+        $layerName = $request->get('layerName');
+
+        $this->resolveLayerRecursive($source, $layerName, $startLayerInstance);
+        return $source;
+    }
+
+    /**
+     * replace minimal source items (read from yaml) by metadata-enriched source items (loaded from server). Matching by name.
+     */
+    protected function resolveLayerRecursive(Source $source, ?string $layerName, SourceInstanceItem $layerInstance): void
+    {
+        if (!$layerName) {
+            if (method_exists($source, 'getRootLayer')) {
+                // keep (potentially overridden) title from yaml
+                $layerInstance->setTitle($layerInstance->getSourceItem()->getTitle());
+                $layerInstance->setSourceItem($source->getRootLayer());
+            }
+        } else foreach ($source->getLayers() as $layer) {
+            /** @var SourceItem $layer */
+            if (method_exists($layer, 'getName') && $layer->getName() === $layerName) {
+                $layerInstance->setTitle($layerInstance->getSourceItem()->getTitle());
+                $layerInstance->setSourceItem($layer);
+            }
+        }
+
+        if (method_exists($layerInstance, 'getSublayer')) {
+
+            foreach ($layerInstance->getSublayer() as $sublayer) {
+                /** @var $sublayer SourceInstanceItem */
+                $sourceItem = $sublayer->getSourceItem();
+                $name = method_exists($sourceItem, 'getName') ? $sourceItem->getName() : $sourceItem->getId();
+                $this->resolveLayerRecursive($source, $name, $sublayer);
+            }
+        }
     }
 }

--- a/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
+++ b/src/Mapbender/CoreBundle/Controller/SourceMetaDataController.php
@@ -4,10 +4,10 @@
 namespace Mapbender\CoreBundle\Controller;
 
 
-use Doctrine\Common\Collections\Criteria;
+use FOM\UserBundle\Security\Permission\ResourceDomainApplication;
+use Mapbender\CoreBundle\Component\Application\ApplicationResolver;
 use Mapbender\CoreBundle\Component\Source\TypeDirectoryService;
-use Mapbender\CoreBundle\Entity\SourceInstance;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -24,22 +24,32 @@ use Twig\Environment;
 class SourceMetaDataController
 {
     public function __construct(
-        protected Environment $templateEngine,
-        protected TypeDirectoryService $typeDirectoryService,
-        protected bool $showProxiedServiceUrls
+        protected Environment                $templateEngine,
+        protected TypeDirectoryService       $typeDirectoryService,
+        protected bool                       $showProxiedServiceUrls,
+        private readonly ApplicationResolver $applicationResolver,
+        private Security                     $security,
     )
     {
     }
 
-    #[Route(path: '/application/metadata/{instance}/{layerId}', name: 'mapbender_core_application_metadata', methods: ['GET'])]
-    public function metadataAction(SourceInstance $instance, int|string $layerId,): Response
+    #[Route(path: '/application/{slug}/metadata/{instanceId}/{layerId}', name: 'mapbender_core_application_metadata', methods: ['GET'])]
+    public function metadataAction(int|string $slug, int|string $instanceId, int|string $layerId): Response
     {
-        $layerCriteria = Criteria::create()
-            ->where(Criteria::expr()->eq('id', $layerId))
-        ;
-        $startLayerInstance = $instance->getLayers()->matching($layerCriteria)->first() ?: null;
-        // NOTE: cannot work for Yaml applications because Yaml-applications don't have source instances in the database
-        // @todo: give Yaml applications a proper object repository and make this work
+        $application = $this->applicationResolver->getApplicationEntity($slug);
+        if (!$this->security->isGranted(ResourceDomainApplication::ACTION_VIEW, $application)) {
+            return new Response(null, Response::HTTP_FORBIDDEN);
+        }
+
+        $instance = $application->getSourceInstanceById($instanceId);
+        if (!$instance) {
+            return new Response('Invalid instance id', Response::HTTP_NOT_FOUND);
+        }
+        $startLayerInstance = $instance->getLayerById($layerId);
+        if (!$startLayerInstance) {
+            return new Response('Invalid instance layer id', Response::HTTP_NOT_FOUND);
+        }
+
         $source = $instance->getSource();
         $dataSource = $this->typeDirectoryService->getSource($source->getType());
         $template = $dataSource->getMetadataFrontendTemplate();

--- a/src/Mapbender/CoreBundle/Entity/SourceInstance.php
+++ b/src/Mapbender/CoreBundle/Entity/SourceInstance.php
@@ -112,7 +112,7 @@ abstract class SourceInstance extends SourceInstanceAssignment implements YamlDe
     /**
      * Sets base source
      *
-     * @param  boolean $baseSource
+     * @param boolean $baseSource
      * @return $this
      */
     public function setBasesource($baseSource)
@@ -174,12 +174,21 @@ abstract class SourceInstance extends SourceInstanceAssignment implements YamlDe
     abstract public function getDisplayTitle(): string;
 
 
-
     /**
      * @return string
      */
     public function __toString()
     {
         return (string)$this->getId();
+    }
+
+    public function getLayerById(int|string $layerId): ?SourceInstanceItem
+    {
+        foreach ($this->getLayers() as $layerInstance) {
+            if ($layerInstance->getId() == $layerId) {
+                return $layerInstance;
+            }
+        }
+        return null;
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/controllers.xml
@@ -106,6 +106,9 @@
             <argument type="service" id="twig" />
             <argument type="service" id="mapbender.source.typedirectory.service" />
             <argument>%mapbender.show_proxied_service_urls%</argument>
+            <argument type="service" id="Mapbender\CoreBundle\Component\Application\ApplicationResolver" />
+            <argument type="service" id="security.helper" />
+
         </service>
         <service id="Mapbender\CoreBundle\Controller\CoordinatesUtilityController"
                  class="Mapbender\CoreBundle\Controller\CoordinatesUtilityController"

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -159,7 +159,7 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
             "maxScale" => $this->getInheritedScale('maxScale', $layer),
             "bbox" => $this->getLayerBboxConfiguration($layer),
             "treeOptions" => $this->getTreeOptionsLayerConfig($layer),
-            "metadataUrl" => $this->getMetadataUrl($instance, $layer),
+            "metadataUrl" => $this->getMetadataUrl($application, $instance, $layer),
             "availableStyles" => $styles,
         );
         $configuration += array_filter(array(
@@ -171,21 +171,18 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
     /**
      * @param WmsInstanceLayerArray $instanceLayer
      */
-    protected function getMetadataUrl(WmsInstance $instance, array $instanceLayer): ?string
+    protected function getMetadataUrl(Application $application, WmsInstance $instance, array $instanceLayer): ?string
     {
         // no metadata for unpersisted instances (WmsLoader)
         if (!$instanceLayer['id']) {
             return null;
         }
-        $layerset = $instance->getLayerset();
-        if ($layerset && $layerset->getApplication() && !$layerset->getApplication()->isDbBased()) {
-            return null;
-        }
         $router = $this->urlProcessor->getRouter();
-        return $router->generate('mapbender_core_application_metadata', array(
-            'instance' => $instance,
+        return $router->generate('mapbender_core_application_metadata', [
+            'slug' => $application->getSlug(),
+            'instanceId' => $instance->getId(),
             'layerId' => $instanceLayer['id'],
-        ));
+        ]);
     }
 
     /**

--- a/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
+++ b/src/Mapbender/WmsBundle/Component/Presenter/WmsSourceInstanceConfigGenerator.php
@@ -182,6 +182,7 @@ class WmsSourceInstanceConfigGenerator extends SourceInstanceConfigGenerator
             'slug' => $application->getSlug(),
             'instanceId' => $instance->getId(),
             'layerId' => $instanceLayer['id'],
+            'layerName' => $instanceLayer['lsName'],
         ]);
     }
 

--- a/src/Mapbender/WmsBundle/Component/Wms/Importer.php
+++ b/src/Mapbender/WmsBundle/Component/Wms/Importer.php
@@ -14,6 +14,7 @@ use Mapbender\CoreBundle\Component\Source\HttpOriginInterface;
 use Mapbender\CoreBundle\Component\Source\HttpSourceLoader;
 use Mapbender\CoreBundle\Component\Source\SourceLoaderSettings;
 use Mapbender\CoreBundle\Component\XmlValidatorService;
+use Mapbender\CoreBundle\Entity\Application;
 use Mapbender\CoreBundle\Entity\Repository\ApplicationRepository;
 use Mapbender\CoreBundle\Entity\Source;
 use Mapbender\CoreBundle\Utils\EntityUtil;
@@ -305,5 +306,10 @@ class Importer extends HttpSourceLoader
             $offset += $this->assignLayerPriorities($child, $value + $offset);
         }
         return $offset;
+    }
+
+    public function hasPersistedMetadata(Application $application, Source $source): bool
+    {
+        return $application->isDbBased();
     }
 }


### PR DESCRIPTION
Until mapbender 4, the metadata dialog in the layer tree menu was only available for database-based applications, not for YAML applications. With this PR, also yaml applications can show the metadata dialog.

see internal ticket 12348