### PR TITLE
[ViewManager] Show date in native format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Features:
 
 Bugfixes:
 * When duplicating applications, also duplicate element permissions ([#PR1812](https://github.com/mapbender/mapbender/pull/1812))
+* [ViewManager] Show date in native format ([#PR1850](https://github.com/mapbender/mapbender/pull/1850))
 
 Other:
 * [Develop] New shared File utility module for geospatial file handling (KML, GeoJSON, GPX, GML) ([#PR1799](https://github.com/mapbender/mapbender/pull/1799)) 

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,9 @@
         "symfony/web-profiler-bundle": "^6.4",
         "symfony/yaml": "^6.4",
 
-        "twig/twig": "^3.6",
+        "twig/twig": "^3.24",
+        "twig/extra-bundle": "^3.24",
+        "twig/intl-extra": "^3.24",
         "doctrine/orm": "^2.15",
         "doctrine/dbal": "^3",
         "doctrine/doctrine-bundle": "^2",

--- a/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
+++ b/src/Mapbender/CoreBundle/Element/ViewManagerHttpHandler.php
@@ -91,7 +91,6 @@ class ViewManagerHttpHandler implements ElementHttpHandlerInterface
         $vars = array(
             'records' => $this->loadListing($element->getApplication(), $config),
             'showDate' => $config['showDate'],
-            'dateFormat' => $this->getDateFormat($request),
             'grants' => $this->getGrantsVariables($config),
             'row_template' => $this->getRowTemplate(),
         );
@@ -173,7 +172,6 @@ class ViewManagerHttpHandler implements ElementHttpHandlerInterface
         $vars = array(
             'record' => $record,
             'showDate' => $config['showDate'],
-            'dateFormat' => $this->getDateFormat($request),
             'grants' => $this->getGrantsVariables($element->getConfiguration()),
         );
         $content = $this->templating->render($this->getRowTemplate(), $vars);
@@ -214,16 +212,6 @@ class ViewManagerHttpHandler implements ElementHttpHandlerInterface
         $record->setLayersetStates(json_decode($allValues['layersetStates'], true) ?? []);
         $record->setSourceStates(json_decode($allValues['sourcesStates'], true) ?? []);
         $record->setMtime(new \DateTime());
-    }
-
-    /**
-     * @param Request $request
-     * @return string
-     */
-    protected function getDateFormat(Request $request)
-    {
-        // @todo: locale-dependent format
-        return 'Y-m-d';
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/view_manager-listing-row.html.twig
@@ -2,14 +2,14 @@
 <tr data-visibility-group="{{ _is_private ? 'private' : 'public' }}"
     data-id="{{ record.id }}"
     data-title="{{ record.title }}"
-    data-mtime="{{ record.mtime | date(dateFormat) }}">
+    data-mtime="{{ record.mtime | format_date }}">
     <td class="-js-forward-to-apply"><i class="recall-marker fa fas fa-fw fa-angle-double-right"></i></td>
     <td class="name-cell -js-forward-to-apply" title="#{{ record.id }}">{{ record.title }}</td>
     <td class="-js-loadingspinner">
         <i class="fas fa-spinner fa-spin opacity-0"></i>
     </td>
     {%- if showDate -%}
-    <td class="text-nowrap">{{ record.mtime | date(dateFormat) }}</td>
+    <td class="text-nowrap">{{ record.mtime | format_date }}</td>
     {%- endif -%}
     <td class="text-nowrap text-end">
         <a href="#" class="-fn-apply hover-highlight-effect" title="{{ 'mb.core.viewManager.apply' | trans }}">


### PR DESCRIPTION
Display's date in native format in ViewManager column.

E.g. British:

<img width="286" height="138" alt="grafik" src="https://github.com/user-attachments/assets/278d432c-5fa1-4036-afb2-b47aab4b1a30" />

German:

<img width="282" height="130" alt="grafik" src="https://github.com/user-attachments/assets/fd3c3659-864b-411d-9db1-b0aa62e148fb" />


:warning: Requires additional composer packages. They will be automatically added after merging and applying composer update, for testing they need to be added manually though:

```bash
bin/composer require twig/intl-extra
bin/composer require twig/extra-bundle
```

see internal ticket 12348