### PR TITLE
Map element validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 * [BatchPrintClient] New batch printing element for creating multiple print frames in a single job ([#PR1799](https://github.com/mapbender/mapbender/pull/1799)) 
 * [ApplicationSwitcher] Enhance application switcher, e.g. to work in popup and allow external applications ([#PR1793](https://github.com/mapbender/mapbender/pull/1793))
 * [Copyright] Add "Don't show again" option ([#PR1800](https://github.com/mapbender/mapbender/pull/1800))
+* [Map] Improve form validation in backend ([#PR1851](https://github.com/mapbender/mapbender/pull/1851))
 * [SearchRouter] Extend SQLSearchEngine with support for dates, numbers and greater/lower than operators ([#PR1796](https://github.com/mapbender/mapbender/pull/1796))
 * [InteractiveHelp] Add new Interactive Help element ([#PR1808](https://github.com/mapbender/mapbender/pull/1808))
 * [HTMLElement] Add 'openInline' flag to provide more flexibility in sidebar and content area ([#PR1814](https://github.com/mapbender/mapbender/pull/1814))

--- a/src/Mapbender/CoreBundle/Element/Map.php
+++ b/src/Mapbender/CoreBundle/Element/Map.php
@@ -10,6 +10,7 @@ use Mapbender\Component\Element\StaticView;
 use Mapbender\CoreBundle\Component\ElementBase\ConfigMigrationInterface;
 use Mapbender\CoreBundle\Component\ElementBase\ValidatableConfigurationInterface;
 use Mapbender\CoreBundle\Component\ElementBase\ValidationFailedException;
+use Mapbender\CoreBundle\Element\Type\MapAdminType;
 use Mapbender\CoreBundle\Entity\Element;
 use Mapbender\CoreBundle\Entity\SRS;
 use Mapbender\ManagerBundle\Component\Mapper;
@@ -149,8 +150,7 @@ class Map extends AbstractElementService
      */
     public function getClientConfiguration(Element $element)
     {
-        // Remove nulls, readd defaults
-        // @todo: prevent saving invalid empty values via form constraints
+        // Remove nulls, readd defaults (only for yaml-based apps, for db-based apps validation is done using form constraints)
         $conf = \array_filter($element->getConfiguration(), function ($v) {
             return $v !== null;
         });
@@ -165,7 +165,7 @@ class Map extends AbstractElementService
      */
     public static function getType()
     {
-        return 'Mapbender\CoreBundle\Element\Type\MapAdminType';
+        return MapAdminType::class;
     }
 
     /**

--- a/src/Mapbender/CoreBundle/Element/Type/LayersetAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/LayersetAdminType.php
@@ -5,6 +5,7 @@ use Mapbender\CoreBundle\Entity\Application;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Count;
 
 class LayersetAdminType extends AbstractType
 {
@@ -32,6 +33,12 @@ class LayersetAdminType extends AbstractType
                 }
                 return $choices;
             },
+            'constraints' => array(
+                new Count(
+                    min: 1,
+                    minMessage: 'mb.core.map.admin.min_one_layerset',
+                ),
+            ),
         ));
     }
 }

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -3,6 +3,7 @@
 namespace Mapbender\CoreBundle\Element\Type;
 
 use Mapbender\CoreBundle\Form\Type\ExtentType;
+use Mapbender\CoreBundle\Validator\Constraints\ValidSrs;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -10,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MapAdminType extends AbstractType implements DataTransformerInterface
@@ -57,6 +59,10 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
             ))
             ->add('srs', TextType::class, array(
                 'label' => 'mb.core.map.admin.srs',
+                'constraints' => [
+                    new NotBlank(),
+                    new ValidSrs(),
+                ],
             ))
             ->add('base_dpi', NumberType::class, $this->createInlineHelpText([
                 'label' => 'mb.manager.admin.map.base_dpi',

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -41,7 +41,7 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
     {
         $builder->addModelTransformer($this);
         $builder
-            ->add('layersets', 'Mapbender\CoreBundle\Element\Type\LayersetAdminType', array(
+            ->add('layersets', LayersetAdminType::class, array(
                 'application' => $options['application'],
                 'required' => true,
                 'label' => 'mb.core.map.admin.layersets',

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -3,6 +3,7 @@
 namespace Mapbender\CoreBundle\Element\Type;
 
 use Mapbender\CoreBundle\Form\Type\ExtentType;
+use Mapbender\CoreBundle\Validator\Constraints\IntegerList;
 use Mapbender\CoreBundle\Validator\Constraints\ValidSrs;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -94,10 +95,17 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
             ->add('scales', TextType::class, array(
                 'label' => 'mb.core.map.admin.scales',
                 'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new IntegerList(),
+                ]
             ))
             ->add('otherSrs', TextType::class, array(
                 'label' => 'mb.core.map.admin.othersrs',
                 'required' => false,
+                'constraints' => [
+                    new ValidSrs(multiple: true),
+                ]
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
+++ b/src/Mapbender/CoreBundle/Element/Type/MapAdminType.php
@@ -7,11 +7,14 @@ use Mapbender\CoreBundle\Validator\Constraints\ValidSrs;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Positive;
+use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MapAdminType extends AbstractType implements DataTransformerInterface
@@ -53,9 +56,13 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
                     'class' => 'input inputWrapper choiceExpandedSortable',
                 ),
             ))
-            ->add('tileSize', NumberType::class, array(
+            ->add('tileSize', IntegerType::class, array(
                 'required' => false,
                 'label' => 'mb.core.map.admin.tilesize',
+                'constraints' => [
+                    new Type("integer"),
+                    new Positive(),
+                ],
             ))
             ->add('srs', TextType::class, array(
                 'label' => 'mb.core.map.admin.srs',
@@ -64,9 +71,13 @@ class MapAdminType extends AbstractType implements DataTransformerInterface
                     new ValidSrs(),
                 ],
             ))
-            ->add('base_dpi', NumberType::class, $this->createInlineHelpText([
+            ->add('base_dpi', IntegerType::class, $this->createInlineHelpText([
                 'label' => 'mb.manager.admin.map.base_dpi',
                 'help' => 'mb.manager.admin.map.base_dpi.help',
+                'constraints' => [
+                    new Type("integer"),
+                    new Positive(),
+                ],
             ], $this->trans))
             ->add('extent_max', ExtentType::class, $this->createInlineHelpText([
                 'label' => 'mb.manager.admin.map.max_extent',

--- a/src/Mapbender/CoreBundle/Form/Type/ExtentType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/ExtentType.php
@@ -3,36 +3,43 @@
 namespace Mapbender\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
 
 class ExtentType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('0', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('0', NumberType::class, array(
                 'label' => 'min x',
-                'attr' => array(
-                    'placeholder' => 'min x',
-                ),
+                'html5' => false,
+                'constraints' => [
+                    new NotBlank(),
+                ]
             ))
-            ->add('1', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('1', NumberType::class, array(
                 'label' => 'min y',
-                'attr' => array(
-                    'placeholder' => 'min y',
-                ),
+                'html5' => false,
+                'constraints' => [
+                    new NotBlank(),
+                ]
             ))
-            ->add('2', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('2', NumberType::class, array(
                 'label' => 'max x',
-                'attr' => array(
-                    'placeholder' => 'max x',
-                ),
+                'html5' => false,
+                'constraints' => [
+                    new NotBlank(),
+                ]
             ))
-            ->add('3', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+            ->add('3', NumberType::class, array(
                 'label' => 'max y',
-                'attr' => array(
-                    'placeholder' => 'max y',
-                ),
+                'html5' => false,
+                'constraints' => [
+                    new NotBlank(),
+                ]
             ))
         ;
     }

--- a/src/Mapbender/CoreBundle/Form/Type/OrderAwareMultipleChoiceType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/OrderAwareMultipleChoiceType.php
@@ -64,14 +64,10 @@ class OrderAwareMultipleChoiceType extends ChoiceType
         $form = $event->getForm();
         $data = $event->getData();
 
-        // Since the type always use mapper an empty array will not be
-        // considered as empty in Form::submit(), we need to evaluate
-        // empty data here so its value is submitted to sub forms
+        // When no choices are submitted, treat as empty array
+        // to allow validation constraints (e.g. Count) to detect empty submissions
         if (null === $data) {
-            $data = $form->getConfig()->getEmptyData();
-            if ($data instanceof \Closure) {
-                $data = $data($form, $form->getData());
-            }
+            $data = array();
         }
 
         // Convert the submitted data to a string, if scalar, before
@@ -102,7 +98,7 @@ class OrderAwareMultipleChoiceType extends ChoiceType
         if (\count($unknownValues) > 0) {
             throw new TransformationFailedException(sprintf('The choices "%s" do not exist in the choice list.', implode('", "', array_keys($unknownValues))));
         }
-        // Reorder checbox-type form children to match submitted data order
+        // Reorder checkbox-type form children to match submitted data order
         // This prevents another re-destruction pass of data order in the default data mapper
         /** @see \Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper */
         foreach ($formChildMap as $checkboxValue => $checkbox) {
@@ -110,8 +106,16 @@ class OrderAwareMultipleChoiceType extends ChoiceType
                 $form->remove($checkbox->getName());
             }
         }
+        // Re-add selected checkboxes first (in submitted order)
         foreach ($reconstructedCheckboxes as $checkbox) {
             $form->add($checkbox);
+        }
+        // Re-add remaining (unselected) checkboxes so the mapper can properly
+        // determine that they are unchecked, instead of falling back to model data
+        foreach ($formChildMap as $checkboxValue => $checkbox) {
+            if ($checkboxValue != '' && !isset($reconstructedData[$checkbox->getName()])) {
+                $form->add($checkbox);
+            }
         }
         $event->setData($reconstructedData);
     }

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -196,6 +196,11 @@
             <tag name="validator.constraint_validator" alias="mapbender.validator.css" />
         </service>
 
+        <service id="mapbender.validator.srs" class="Mapbender\CoreBundle\Validator\Constraints\ValidSrsValidator">
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
+            <tag name="validator.constraint_validator" alias="mapbender.validator.srs" />
+        </service>
+
         <service id="mapbender.source.instancetunnel.service" class="%mapbender.source.instancetunnel.service.class%" lazy="true">
             <argument type="service" id="mapbender.http_transport.service" />
             <argument type="service" id="router" />

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
@@ -6,3 +6,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Bitte fügen Sie mindestens eine Konfiguration hinzu'
 
 mb.core.map.admin.min_one_layerset: 'Bitte wählen Sie mindestens ein Layerset aus.'
+mb.core.map.admin.epsg_invalid_format: "Das Koordinatensystem muss im Format \"EPSG:<Ziffern>\" angegeben werden."
+mb.core.map.admin.epsg_not_found: "Das angegebene Koordinatenreferenzsystem wurde nicht in der Referenztabelle gefunden."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'Das angegebene Query Format enthält keine Platzhalter. Hilfetext beachten!'
   invalid_epsg_code: 'Der eingegebene Text ist kein gültiger EPSG-Code. Geben Sie den Code im Format EPSG:1234 ein'
   no_configuration_added: 'Bitte fügen Sie mindestens eine Konfiguration hinzu'
+
+mb.core.map.admin.min_one_layerset: 'Bitte wählen Sie mindestens ein Layerset aus.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.de.yaml
@@ -8,3 +8,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Bitte wählen Sie mindestens ein Layerset aus.'
 mb.core.map.admin.epsg_invalid_format: "Das Koordinatensystem muss im Format \"EPSG:<Ziffern>\" angegeben werden."
 mb.core.map.admin.epsg_not_found: "Das angegebene Koordinatenreferenzsystem wurde nicht in der Referenztabelle gefunden."
+mb.core.map.admin.invalid_integer: "Es sind nur ganzzahlige Werte erlaubt."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
@@ -6,3 +6,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Please add at least one configuration'
 
 mb.core.map.admin.min_one_layerset: 'Please select at least one layerset.'
+mb.core.map.admin.epsg_invalid_format: "The coordinate system must be in the format \"EPSG:<digits>\"."
+mb.core.map.admin.epsg_not_found: "The given coordinate reference system was not found in the reference table."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'The specified query format does not contain placeholders. Read the help text!'
   invalid_epsg_code: 'The text entered is not a valid EPSG code. Enter the code in the format EPSG:1234'
   no_configuration_added: 'Please add at least one configuration'
+
+mb.core.map.admin.min_one_layerset: 'Please select at least one layerset.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.en.yaml
@@ -8,3 +8,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Please select at least one layerset.'
 mb.core.map.admin.epsg_invalid_format: "The coordinate system must be in the format \"EPSG:<digits>\"."
 mb.core.map.admin.epsg_not_found: "The given coordinate reference system was not found in the reference table."
+mb.core.map.admin.invalid_integer: "Only integer values are allowed."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
@@ -2,3 +2,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'El formato de consulta especificado no contiene marcadores de posición. ¡Lea el texto de ayuda!'
   invalid_epsg_code: 'El texto ingresado no es un código EPSG válido. Ingrese el código en el formato EPSG:1234'
   no_configuration_added: 'Por favor, añade al menos una configuración'
+
+mb.core.map.admin.min_one_layerset: 'Por favor, seleccione al menos un conjunto de capas.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
@@ -6,3 +6,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Por favor, seleccione al menos un conjunto de capas.'
 mb.core.map.admin.epsg_invalid_format: "El sistema de coordenadas debe estar en el formato \"EPSG:<dígitos>\"."
 mb.core.map.admin.epsg_not_found: "El sistema de referencia de coordenadas indicado no se encontró en la tabla de referencia."
+mb.core.map.admin.invalid_integer: "Solo se permiten valores enteros."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.es.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Por favor, añade al menos una configuración'
 
 mb.core.map.admin.min_one_layerset: 'Por favor, seleccione al menos un conjunto de capas.'
+mb.core.map.admin.epsg_invalid_format: "El sistema de coordenadas debe estar en el formato \"EPSG:<dígitos>\"."
+mb.core.map.admin.epsg_not_found: "El sistema de referencia de coordenadas indicado no se encontró en la tabla de referencia."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
@@ -1,3 +1,4 @@
 mb.core.map.admin.min_one_layerset: 'Veuillez sélectionner au moins un ensemble de couches.'
 mb.core.map.admin.epsg_invalid_format: "Le système de coordonnées doit être au format \"EPSG:<chiffres>\"."
 mb.core.map.admin.epsg_not_found: "Le système de référence de coordonnées indiqué n'a pas été trouvé dans la table de référence."
+mb.core.map.admin.invalid_integer: "Seules les valeurs entières sont autorisées."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
@@ -1,0 +1,1 @@
+mb.core.map.admin.min_one_layerset: 'Veuillez sélectionner au moins un ensemble de couches.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.fr.yaml
@@ -1,1 +1,3 @@
 mb.core.map.admin.min_one_layerset: 'Veuillez sélectionner au moins un ensemble de couches.'
+mb.core.map.admin.epsg_invalid_format: "Le système de coordonnées doit être au format \"EPSG:<chiffres>\"."
+mb.core.map.admin.epsg_not_found: "Le système de référence de coordonnées indiqué n'a pas été trouvé dans la table de référence."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
@@ -6,3 +6,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Selezionare almeno un layer set.'
 mb.core.map.admin.epsg_invalid_format: "Il sistema di coordinate deve essere nel formato \"EPSG:<cifre>\"."
 mb.core.map.admin.epsg_not_found: "Il sistema di riferimento delle coordinate indicato non è stato trovato nella tabella di riferimento."
+mb.core.map.admin.invalid_integer: "Sono consentiti solo valori interi."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Si prega di aggiungere almeno una configurazione'
 
 mb.core.map.admin.min_one_layerset: 'Selezionare almeno un layer set.'
+mb.core.map.admin.epsg_invalid_format: "Il sistema di coordinate deve essere nel formato \"EPSG:<cifre>\"."
+mb.core.map.admin.epsg_not_found: "Il sistema di riferimento delle coordinate indicato non è stato trovato nella tabella di riferimento."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.it.yaml
@@ -2,3 +2,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'Il formato di query specificato non contiene segnaposto. Leggere il testo di aiuto!'
   invalid_epsg_code: 'Il testo inserito non è un codice EPSG valido. Inserire il codice nel formato EPSG:1234'
   no_configuration_added: 'Si prega di aggiungere almeno una configurazione'
+
+mb.core.map.admin.min_one_layerset: 'Selezionare almeno un layer set.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
@@ -1,0 +1,2 @@
+mb.core.map.admin.min_one_layerset: 'Selecteer ten minste één lagenset.'
+'Veuillez sélectionner au moins un ensemble de couches.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
@@ -2,3 +2,4 @@ mb.core.map.admin.min_one_layerset: 'Selecteer ten minste één lagenset.'
 'Veuillez sélectionner au moins un ensemble de couches.'
 mb.core.map.admin.epsg_invalid_format: "Het coördinatensysteem moet in het formaat \"EPSG:<cijfers>\" zijn."
 mb.core.map.admin.epsg_not_found: "Het opgegeven coördinatenreferentiesysteem is niet gevonden in de referentietabel."
+mb.core.map.admin.invalid_integer: "Alleen gehele getallen zijn toegestaan."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.nl.yaml
@@ -1,2 +1,4 @@
 mb.core.map.admin.min_one_layerset: 'Selecteer ten minste één lagenset.'
 'Veuillez sélectionner au moins un ensemble de couches.'
+mb.core.map.admin.epsg_invalid_format: "Het coördinatensysteem moet in het formaat \"EPSG:<cijfers>\" zijn."
+mb.core.map.admin.epsg_not_found: "Het opgegeven coördinatenreferentiesysteem is niet gevonden in de referentietabel."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Adicione pelo menos uma configuração'
 
 mb.core.map.admin.min_one_layerset: 'Por favor, selecione pelo menos um layerset.'
+mb.core.map.admin.epsg_invalid_format: "O sistema de coordenadas deve estar no formato \"EPSG:<dígitos>\"."
+mb.core.map.admin.epsg_not_found: "O sistema de referência de coordenadas indicado não foi encontrado na tabela de referência."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
@@ -6,3 +6,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Por favor, selecione pelo menos um layerset.'
 mb.core.map.admin.epsg_invalid_format: "O sistema de coordenadas deve estar no formato \"EPSG:<dígitos>\"."
 mb.core.map.admin.epsg_not_found: "O sistema de referência de coordenadas indicado não foi encontrado na tabela de referência."
+mb.core.map.admin.invalid_integer: "Apenas valores inteiros são permitidos."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.pt.yaml
@@ -2,3 +2,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'O formato de consulta fornecido não contém placeholders. Veja o texto de ajuda!'
   invalid_epsg_code: 'O texto inserido não é um código EPSG válido. Insira o código no formato EPSG:1234'
   no_configuration_added: 'Adicione pelo menos uma configuração'
+
+mb.core.map.admin.min_one_layerset: 'Por favor, selecione pelo menos um layerset.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
@@ -6,3 +6,4 @@ mb.core.simplesearch.errors:
 mb.core.map.admin.min_one_layerset: 'Пожалуйста, выберите хотя бы один набор слоёв.'
 mb.core.map.admin.epsg_invalid_format: "Система координат должна быть в формате \"EPSG:<цифры>\"."
 mb.core.map.admin.epsg_not_found: "Указанная система координат не найдена в справочной таблице."
+mb.core.map.admin.invalid_integer: "Допускаются только целочисленные значения."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
@@ -4,3 +4,5 @@ mb.core.simplesearch.errors:
   no_configuration_added: 'Пожалуйста, добавьте хотя бы одну конфигурацию.'
 
 mb.core.map.admin.min_one_layerset: 'Пожалуйста, выберите хотя бы один набор слоёв.'
+mb.core.map.admin.epsg_invalid_format: "Система координат должна быть в формате \"EPSG:<цифры>\"."
+mb.core.map.admin.epsg_not_found: "Указанная система координат не найдена в справочной таблице."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.ru.yaml
@@ -2,3 +2,5 @@ mb.core.simplesearch.errors:
   invalid_query_format: 'Указанный формат запроса не содержит временного текста. Смотрите примечание!'
   invalid_epsg_code: 'Введенный текст не является действительным EPSG-Кодом. Введите код в формате EPSG:1234.'
   no_configuration_added: 'Пожалуйста, добавьте хотя бы одну конфигурацию.'
+
+mb.core.map.admin.min_one_layerset: 'Пожалуйста, выберите хотя бы один набор слоёв.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
@@ -1,0 +1,1 @@
+mb.core.map.admin.min_one_layerset: 'Lütfen en az bir katman seti seçin.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
@@ -1,3 +1,4 @@
 mb.core.map.admin.min_one_layerset: 'Lütfen en az bir katman seti seçin.'
 mb.core.map.admin.epsg_invalid_format: "Koordinat sistemi \"EPSG:<rakamlar>\" formatında olmalıdır."
 mb.core.map.admin.epsg_not_found: "Belirtilen koordinat referans sistemi referans tablosunda bulunamadı."
+mb.core.map.admin.invalid_integer: "Yalnızca tam sayı değerlere izin verilir."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.tr.yaml
@@ -1,1 +1,3 @@
 mb.core.map.admin.min_one_layerset: 'Lütfen en az bir katman seti seçin.'
+mb.core.map.admin.epsg_invalid_format: "Koordinat sistemi \"EPSG:<rakamlar>\" formatında olmalıdır."
+mb.core.map.admin.epsg_not_found: "Belirtilen koordinat referans sistemi referans tablosunda bulunamadı."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
@@ -2,3 +2,5 @@ html.invalid: 'HTML містить помилку!'
 twig.invalid: 'TWIG містить помилку!'
 
 mb.core.map.admin.min_one_layerset: 'Будь ласка, виберіть принаймні один набір шарів.'
+mb.core.map.admin.epsg_invalid_format: "Система координат повинна бути у форматі \"EPSG:<цифри>\"."
+mb.core.map.admin.epsg_not_found: "Вказану систему координат не знайдено в довідковій таблиці."

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
@@ -1,2 +1,4 @@
 html.invalid: 'HTML містить помилку!'
 twig.invalid: 'TWIG містить помилку!'
+
+mb.core.map.admin.min_one_layerset: 'Будь ласка, виберіть принаймні один набір шарів.'

--- a/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
+++ b/src/Mapbender/CoreBundle/Resources/translations/validators.uk.yaml
@@ -4,3 +4,4 @@ twig.invalid: 'TWIG містить помилку!'
 mb.core.map.admin.min_one_layerset: 'Будь ласка, виберіть принаймні один набір шарів.'
 mb.core.map.admin.epsg_invalid_format: "Система координат повинна бути у форматі \"EPSG:<цифри>\"."
 mb.core.map.admin.epsg_not_found: "Вказану систему координат не знайдено в довідковій таблиці."
+mb.core.map.admin.invalid_integer: "Дозволені лише цілі числа."

--- a/src/Mapbender/CoreBundle/Validator/Constraints/IntegerList.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/IntegerList.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @see IntegerListValidator */
+class IntegerList extends Constraint
+{
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/IntegerListValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/IntegerListValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mapbender\CoreBundle\Entity\SRS;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class IntegerListValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if ($value === null) return;
+        $values = explode(',', $value);
+        foreach($values as $value) {
+            $value = trim($value);
+            if (!intval($value) && $value !== '0') {
+                $this->context->addViolation('mb.core.map.admin.invalid_integer');
+            }
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrs.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrs.php
@@ -7,4 +7,8 @@ use Symfony\Component\Validator\Constraint;
 /** @see ValidSrsValidator */
 class ValidSrs extends Constraint
 {
+    public function __construct(public bool $multiple = false)
+    {
+        parent::__construct(['multiple' => $multiple], null, null);
+    }
 }

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrs.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrs.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @see ValidSrsValidator */
+class ValidSrs extends Constraint
+{
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mapbender\CoreBundle\Validator\Constraints;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mapbender\CoreBundle\Entity\SRS;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class ValidSrsValidator extends ConstraintValidator
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if ($value === null) return;
+        $value = trim($value);
+        if (!preg_match('/^EPSG:\d+$/', $value)) {
+            $this->context->addViolation('mb.core.map.admin.epsg_invalid_format');
+        }
+
+        $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $value));
+        if (!$srs) {
+            $this->context->addViolation('mb.core.map.admin.epsg_not_found');
+        }
+    }
+}

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
@@ -19,6 +19,7 @@ class ValidSrsValidator extends ConstraintValidator
         $value = trim($value);
         if (!preg_match('/^EPSG:\d+$/', $value)) {
             $this->context->addViolation('mb.core.map.admin.epsg_invalid_format');
+            return;
         }
 
         $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $value));

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
@@ -20,12 +20,13 @@ class ValidSrsValidator extends ConstraintValidator
         $values = $constraint->multiple ? explode(',', $value) : [$value];
         foreach($values as $value) {
             $value = trim($value);
-            if (!preg_match('/^EPSG:\d+$/', $value)) {
+            if (!preg_match('/^EPSG:\d+(\|[^,]+)?$/', $value)) {
                 $this->context->addViolation('mb.core.map.admin.epsg_invalid_format');
                 continue;
             }
 
-            $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $value));
+            $srsName = explode('|', $value, 2)[0];
+            $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $srsName));
             if (!$srs) {
                 $this->context->addViolation('mb.core.map.admin.epsg_not_found');
             }

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
@@ -13,7 +13,7 @@ class ValidSrsValidator extends ConstraintValidator
     {
     }
 
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if ($value === null) return;
         $value = trim($value);

--- a/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
+++ b/src/Mapbender/CoreBundle/Validator/Constraints/ValidSrsValidator.php
@@ -16,15 +16,19 @@ class ValidSrsValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint): void
     {
         if ($value === null) return;
-        $value = trim($value);
-        if (!preg_match('/^EPSG:\d+$/', $value)) {
-            $this->context->addViolation('mb.core.map.admin.epsg_invalid_format');
-            return;
-        }
+        /** @var ValidSrs $constraint */
+        $values = $constraint->multiple ? explode(',', $value) : [$value];
+        foreach($values as $value) {
+            $value = trim($value);
+            if (!preg_match('/^EPSG:\d+$/', $value)) {
+                $this->context->addViolation('mb.core.map.admin.epsg_invalid_format');
+                continue;
+            }
 
-        $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $value));
-        if (!$srs) {
-            $this->context->addViolation('mb.core.map.admin.epsg_not_found');
+            $srs = $this->em->getRepository(SRS::class)->findOneBy(array("name" => $value));
+            if (!$srs) {
+                $this->context->addViolation('mb.core.map.admin.epsg_not_found');
+            }
         }
     }
 }


### PR DESCRIPTION
Improves form validation for the map element. When saving the map element, the following is validated now:
- type checks for all number-based fields
- correct formatting for SRS (EPSG:<digits>)
- check that the SRS is defined in the mb_core_srs-Table
- check that at least one layerset is active