### PR TITLE
Fix/ogc api label display and source update

### DIFF
--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
@@ -116,8 +116,12 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
         $index = [];
         foreach ($grouped as $collectionId => $layers) {
             usort($layers, static fn($a, $b) => ($a->getId() ?? \PHP_INT_MAX) <=> ($b->getId() ?? \PHP_INT_MAX));
-            $index[$collectionId] = $layers[0];
+            $kept = $layers[0];
+            $index[$collectionId] = $kept;
             for ($i = 1, $c = count($layers); $i < $c; $i++) {
+                foreach ($layers[$i]->getInstanceLayers() as $instanceLayer) {
+                    $instanceLayer->setSourceItem($kept);
+                }
                 $source->getLayers()->removeElement($layers[$i]);
                 $this->em->remove($layers[$i]);
             }

--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
@@ -66,15 +66,64 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
         $source->setVersion($version);
         $source->setAttribution($json['attribution'] ?? '');
 
-        foreach ($json['collections'] as $collection) {
+        $this->syncLayers($source, $json['collections'] ?? [], $baseUrl);
+    }
+
+    private function syncLayers(OgcApiFeaturesSource $source, array $collections, string $baseUrl): void
+    {
+        $existingByCollectionId = $this->deduplicateAndIndexLayers($source);
+
+        $activeCollectionIds = [];
+        foreach ($collections as $collection) {
+            $collectionId = $collection['id'];
+            $activeCollectionIds[] = $collectionId;
             $bbox = !(empty($collection['extent']['spatial']['bbox'][0])) ? $collection['extent']['spatial']['bbox'][0] : null;
-            $layer = new OgcApiFeaturesLayerSource();
-            $layer->setTitle($collection['title'] ?? '');
-            $layer->setCollectionId($collection['id']);
-            $layer->setBbox($bbox);
-            $layer->setProperties($this->discoverCollectionProperties($baseUrl, $collection['id']));
-            $source->addLayer($layer);
+            $properties = $this->discoverCollectionProperties($baseUrl, $collectionId);
+
+            if (isset($existingByCollectionId[$collectionId])) {
+                $layer = $existingByCollectionId[$collectionId];
+                $layer->setTitle($collection['title'] ?? '');
+                $layer->setBbox($bbox);
+                $layer->setProperties($properties);
+            } else {
+                $layer = new OgcApiFeaturesLayerSource();
+                $layer->setCollectionId($collectionId);
+                $layer->setTitle($collection['title'] ?? '');
+                $layer->setBbox($bbox);
+                $layer->setProperties($properties);
+                $source->addLayer($layer);
+            }
         }
+
+        $activeSet = array_flip($activeCollectionIds);
+        foreach ($source->getLayers()->toArray() as $layer) {
+            /** @var OgcApiFeaturesLayerSource $layer */
+            if (!isset($activeSet[$layer->getCollectionId()])) {
+                $source->getLayers()->removeElement($layer);
+                $this->em->remove($layer);
+            }
+        }
+    }
+
+    private function deduplicateAndIndexLayers(OgcApiFeaturesSource $source): array
+    {
+        $grouped = [];
+        foreach ($source->getLayers()->toArray() as $layer) {
+            /** @var OgcApiFeaturesLayerSource $layer */
+            $grouped[$layer->getCollectionId()][] = $layer;
+        }
+
+        $index = [];
+        foreach ($grouped as $collectionId => $layers) {
+            usort($layers, static fn($a, $b) => ($a->getId() ?? \PHP_INT_MAX) <=> ($b->getId() ?? \PHP_INT_MAX));
+            $index[$collectionId] = $layers[0];
+            for ($i = 1, $c = count($layers); $i < $c; $i++) {
+                $source->getLayers()->removeElement($layers[$i]);
+                $this->em->remove($layers[$i]);
+            }
+        }
+
+        return $index;
     }
 
     private function discoverCollectionProperties(string $baseUrl, string $collectionId): ?array
@@ -140,9 +189,14 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
     {
         /** @var OgcApiFeaturesSource $source */
         $baseUrl = rtrim($source->getJsonUrl(), '/');
+        $processedCollectionIds = [];
         foreach ($source->getLayers() as $layer) {
             /** @var OgcApiFeaturesLayerSource $layer */
             $collectionId = $layer->getCollectionId();
+            if (in_array($collectionId, $processedCollectionIds, true)) {
+                continue;
+            }
+            $processedCollectionIds[] = $collectionId;
             $stylesUrl = $baseUrl . '/collections/' . urlencode($collectionId) . '/styles?f=json';
             try {
                 $response = $this->httpTransport->getUrl($stylesUrl);
@@ -160,10 +214,37 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
                     }
                     $this->fetchAndSaveStyle($source, $collectionId, $styleInfo, $mbsLink);
                 }
-            } catch (\Throwable $e) {
-                // Skip collections where style endpoint is not available
+            } catch (\Throwable) {
                 continue;
             }
+        }
+        $this->removeOrphanStyles($source, $processedCollectionIds);
+    }
+
+    private function removeOrphanStyles(OgcApiFeaturesSource $source, array $activeCollectionIds): void
+    {
+        if ($source->getId() === null) {
+            return;
+        }
+        if (empty($activeCollectionIds)) {
+            $orphans = $this->em->getRepository(Style::class)->findBy([
+                'sourceType' => 'ogc_api',
+                'sourceId' => $source->getId(),
+            ]);
+        } else {
+            $orphans = $this->em->getRepository(Style::class)
+                ->createQueryBuilder('s')
+                ->where('s.sourceType = :type')
+                ->andWhere('s.sourceId = :sourceId')
+                ->andWhere('s.collectionId NOT IN (:collectionIds)')
+                ->setParameter('type', 'ogc_api')
+                ->setParameter('sourceId', $source->getId())
+                ->setParameter('collectionIds', $activeCollectionIds)
+                ->getQuery()
+                ->getResult();
+        }
+        foreach ($orphans as $orphan) {
+            $this->em->remove($orphan);
         }
     }
 
@@ -237,7 +318,6 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
             $remoteStyleName = $styleInfo['title'] ?? $styleInfo['id'] ?? 'style';
             $styleName = $sourceTitle . ' - ' . $layerTitle . ' - ' . $remoteStyleName;
 
-            // Look up existing style for this source + collection + style name to avoid duplicates on reload
             $style = $this->em->getRepository(Style::class)->findOneBy([
                 'sourceType' => 'ogc_api',
                 'sourceId' => $source->getId(),
@@ -256,7 +336,7 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
             $style->setStyle($mbsContent);
 
             $this->em->persist($style);
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             // Skip if style cannot be fetched
         }
     }

--- a/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesLayerSource.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesLayerSource.php
@@ -108,4 +108,9 @@ class OgcApiFeaturesLayerSource extends SourceItem
     {
         return $this->source;
     }
+
+    public function getInstanceLayers(): Collection
+    {
+        return $this->instanceLayers;
+    }
 }

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -103,24 +103,42 @@ class OgcApiSource extends Mapbender.Source {
                 stroke: stroke,
             }),
         };
-        // Add label if defined
-        if (s.label) {
-            const text = new ol.style.Text({
-                text: s.label,
-                font: (s.fontSize || '12') + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
-                fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),
-            });
-            Object.values(styles).forEach(st => st.setText(text));
-        }
-
         styles.MultiPoint = styles.Point;
         styles.MultiLineString = styles.LineString;
         styles.MultiPolygon = styles.Polygon;
         styles.GeometryCollection = styles.Polygon;
 
+        if (!s.label) {
+            return (feature) => styles[feature.getGeometry()?.getType()] || styles.Polygon;
+        }
+
+        const labelTemplate = s.label;
+        const textBaseOptions = {
+            font: (s.fontSize || '12') + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
+            fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),
+        };
+
+        if (!/\$\{[^}]+\}/.test(labelTemplate)) {
+            // Static label — attach once to each base style
+            const text = new ol.style.Text({ ...textBaseOptions, text: labelTemplate });
+            Object.values(styles).forEach(st => st.setText(text));
+            return (feature) => styles[feature.getGeometry()?.getType()] || styles.Polygon;
+        }
+
+        // Dynamic label — resolve ${property} placeholders per feature at render time
         return (feature) => {
-            const geomType = feature.getGeometry()?.getType();
-            return styles[geomType] || styles.Polygon;
+            const base = styles[feature.getGeometry()?.getType()] || styles.Polygon;
+            const props = feature.getProperties();
+            const resolved = labelTemplate.replace(/\$\{([^}]+)\}/g, (_, key) => {
+                const val = props[key];
+                return val != null ? String(val) : '';
+            });
+            return new ol.style.Style({
+                image: base.getImage(),
+                fill: base.getFill(),
+                stroke: base.getStroke(),
+                text: new ol.style.Text({ ...textBaseOptions, text: resolved }),
+            });
         };
     }
 

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -126,19 +126,27 @@ class OgcApiSource extends Mapbender.Source {
         }
 
         // Dynamic label — resolve ${property} placeholders per feature at render time
+        const styleCache = new Map();
         return (feature) => {
-            const base = styles[feature.getGeometry()?.getType()] || styles.Polygon;
+            const geomType = feature.getGeometry()?.getType() || 'Polygon';
+            const base = styles[geomType] || styles.Polygon;
             const props = feature.getProperties();
             const resolved = labelTemplate.replace(/\$\{([^}]+)\}/g, (_, key) => {
                 const val = props[key];
                 return val != null ? String(val) : '';
             });
-            return new ol.style.Style({
-                image: base.getImage(),
-                fill: base.getFill(),
-                stroke: base.getStroke(),
-                text: new ol.style.Text({ ...textBaseOptions, text: resolved }),
-            });
+            const cacheKey = geomType + '\x00' + resolved;
+            let style = styleCache.get(cacheKey);
+            if (!style) {
+                style = new ol.style.Style({
+                    image: base.getImage(),
+                    fill: base.getFill(),
+                    stroke: base.getStroke(),
+                    text: new ol.style.Text({ ...textBaseOptions, text: resolved }),
+                });
+                styleCache.set(cacheKey, style);
+            }
+            return style;
         };
     }
 


### PR DESCRIPTION
- ${property} label templates in simple styles now resolve against feature properties at render time instead of being displayed literally
- Source reload updates existing layer rows in place by collectionId instead of creating new ones
- Deduplicates pre-existing layer rows on reload, keeping the lowest id
- Removes layer rows for collections no longer returned by the API
- Removes Style rows for dropped collections after each reload
- Prevents duplicate Style rows when reloading sources with pre-existing duplicate layer rows