### PR TITLE
Feat/minimap buttons

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbOverview.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbOverview.js
@@ -4,7 +4,7 @@
         constructor(configuration, $element) {
             super(configuration, $element);
 
-            this._updateToggleIcon();
+            this._updateIcon();
             var lsId = this.options.layerset;
             var layerset = Mapbender.layersets.filter(function(x) {
                 return ('' + lsId) === ('' + x.id);
@@ -114,7 +114,7 @@
             var self = this;
             this.$element.toggleClass('closed')
             var newState = !this.$element.hasClass('closed');
-            this._updateToggleIcon();
+            this._updateIcon();
             if (newState) {
                 window.setTimeout(function() {
                     if (!self.overview) {
@@ -129,11 +129,15 @@
             }
         }
 
-        _updateToggleIcon() {
-            var state = !this.$element.hasClass('closed');
-            var $icon = $('.toggleOverview i.fa', this.$element);
-            $icon.toggleClass('fa-plus', !state);
-            $icon.toggleClass('fa-minus', state);
+        _updateIcon() {
+            const isClosed = this.$element.hasClass('closed');
+
+            const $button = $('.toggleOverview', this.$element);
+            $button.toggleClass('closed', isClosed);
+
+            const $icon = $('.fas', $button);
+            $icon.toggleClass('fa-map', isClosed);
+            $icon.toggleClass('fa-chevron-right', !isClosed);
         }
 
         _onMbMapSrsChanged(event, data) {

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbOverview.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbOverview.js
@@ -4,6 +4,11 @@
         constructor(configuration, $element) {
             super(configuration, $element);
 
+            this.$button = this.$element.find('.toggleOverview');
+            this.$toggleIcon = this.$button.find('i');
+            this.isLeftAligned = this.$element.closest('.anchored-element-wrap-lb').length > 0
+                || this.$element.closest('.anchored-element-wrap-lt').length > 0;
+
             this._updateIcon();
             var lsId = this.options.layerset;
             var layerset = Mapbender.layersets.filter(function(x) {
@@ -132,12 +137,10 @@
         _updateIcon() {
             const isClosed = this.$element.hasClass('closed');
 
-            const $button = $('.toggleOverview', this.$element);
-            $button.toggleClass('closed', isClosed);
-
-            const $icon = $('.fas', $button);
-            $icon.toggleClass('fa-map', isClosed);
-            $icon.toggleClass('fa-chevron-right', !isClosed);
+            this.$button.toggleClass('closed', isClosed);
+            this.$toggleIcon.toggleClass('far fa-map', isClosed);
+            const iconClass = this.isLeftAligned ? 'fa-chevron-left' : 'fa-chevron-right';
+            this.$toggleIcon.toggleClass('fas ' + iconClass, !isClosed);
         }
 
         _onMbMapSrsChanged(event, data) {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/basesourceswitcher.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/basesourceswitcher.scss
@@ -65,16 +65,16 @@ $panelBorderColor: #888 !default;
       border-bottom-width: 0;
       &:last-child {
         border-bottom-width: 1px;
-        border-bottom-left-radius: $radius;
-        border-bottom-right-radius: $radius;
+        border-bottom-left-radius: var(--radius-md);
+        border-bottom-right-radius: var(--radius-md);
       }
     }
     .basesourcegroup, > .basesourcesetswitch {
       &:first-child {
-        border-top-left-radius: $radius;
+        border-top-left-radius: var(--radius-md);
       }
       &:last-child{
-        border-top-right-radius: $radius;
+        border-top-right-radius: var(--radius-md);
       }
     }
   }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/button.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/button.scss
@@ -3,7 +3,7 @@ $hoverEffects: true !default;
 .mb-button {
   cursor: pointer;
   .toolBar & {
-    border-radius: 2 * $radius;
+    border-radius: var(--radius-lg);
     @if $hoverEffects {
       &:hover {
         opacity: $toolBarButtonHoverOpacity;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/layertree.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/layertree.scss
@@ -69,7 +69,7 @@ $layer-slider-bar-height: 5px;
 .layer-menu {
   color: var(--primary);
   position: static;
-  border-radius: $radius;
+  border-radius: var(--radius-md);
 
   .text-end {
     font-size: 1.2rem;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/overview.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/overview.scss
@@ -6,8 +6,18 @@ $panelBorderColor: #888 !default;
 
   .toggleOverview {
     position: absolute;
-    padding: 3px;
-    border-radius: 3px;
+    padding: 5px;
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+    width: 33.4px;
+    height: 33.4px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    &.closed {
+      border-radius: var(--radius-md);
+    }
   }
 
   .olMap, .ol-overviewmap-map {
@@ -56,8 +66,8 @@ $panelBorderColor: #888 !default;
     right: -2.25em;
   }
   .anchored-element-wrap-rb & .toggleOverview {
-    bottom: 0;
-    left: -2.25em;
+    bottom: 1px;
+    left: -2.55em;
   }
   .anchored-element-wrap-lb & .toggleOverview {
     bottom: 0;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/overview.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/overview.scss
@@ -1,6 +1,8 @@
 $panelBorderColor: #888 !default;
 
 .mb-element-overview {
+  --size-close-button: 28px;
+
   user-select: none;
   position: relative; // For .toggleOverview absolute
 
@@ -8,15 +10,21 @@ $panelBorderColor: #888 !default;
     position: absolute;
     padding: 5px;
     border-radius: var(--radius-md) 0 0 var(--radius-md);
-    width: 33.4px;
-    height: 33.4px;
+    width: var(--size-close-button);
+    height: var(--size-close-button);
     display: flex;
     flex-direction: row;
     justify-content: center;
     align-items: center;
 
+    .anchored-element-wrap-lt &, .anchored-element-wrap-lb & {
+        border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    }
+
     &.closed {
       border-radius: var(--radius-md);
+      width: 33.4px;
+      height: 33.4px;
     }
   }
 
@@ -59,19 +67,19 @@ $panelBorderColor: #888 !default;
   }
   .anchored-element-wrap-rt  & .toggleOverview {
     top: 0;
-    left: -2.25em;
+    left: calc(-1 * var(--size-close-button));
   }
   .anchored-element-wrap-lt & .toggleOverview {
     top: 0;
-    right: -2.25em;
+    right: calc(-1 * var(--size-close-button));
   }
   .anchored-element-wrap-rb & .toggleOverview {
     bottom: 1px;
-    left: -2.55em;
+    left: calc(-1 * var(--size-close-button));
   }
   .anchored-element-wrap-lb & .toggleOverview {
     bottom: 0;
-    right: -2.25em;
+    right: calc(-1 * var(--size-close-button));
   }
   .anchored-element-wrap-lb &, .anchored-element-wrap-rb & {
     vertical-align: bottom;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/element/zoombar.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/element/zoombar.scss
@@ -32,7 +32,7 @@
   .toolPane{
     display: inline-block; // for automatic width and centering
     padding:5px;
-    border-radius: $radius;
+    border-radius: var(--radius-md);
   }
   .toolPane {
     font-size: 1.6rem;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -11,7 +11,6 @@ $panelBorderColor: #888;
 
 //-----------------------------------------------------------------other
 $space: 20px;
-$radius: 3px;
 $popupModalWidth: 600px;
 $desktopBreakpointWidth: 1200px;
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -121,4 +121,15 @@ $ciColor2: #4899ba; // Doesn't do anything
     --toolbar-text-color: var(--text-color);
     --toolbar-button-active-background-color: var(--primary);
     --toolbar-button-active-background-hover-color: var(--primary-dark);
+
+    // Buttons
+    --button-white-foreground: var(--text-color);
+    --button-white-background: var(--background-color);
+    --button-white-background-hover: #f7f7fa;
+
+    // Radii
+    --radius-sm: 2px;
+    --radius-md: 3px;
+    --radius-lg: 5px;
+    --radius-full: calc(infinity * 1px);
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -130,5 +130,5 @@ $ciColor2: #4899ba; // Doesn't do anything
     --radius-sm: 2px;
     --radius-md: 3px;
     --radius-lg: 5px;
-    --radius-full: calc(infinity * 1px);
+    --radius-circle: calc(infinity * 1px);
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -277,9 +277,12 @@ div.notifyjs-container > div.notifyjs-bootstrap-base > span{
 
 .toggleOverview.collapse-toggle {
   $buttonTextColor: $lightFontColor !default;
-  background: $buttonFirstColor;
-  color: $buttonTextColor;
+  background: var(--button-white-background);
+  color: var(--button-white-foreground);
   cursor: pointer;
+  &:hover {
+    background: var(--button-white-background-hover);
+  }
 }
 
 // Filter Element visibility by "screenType"

--- a/src/Mapbender/CoreBundle/Resources/views/Element/overview.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/overview.html.twig
@@ -1,6 +1,6 @@
     <div class="overviewContainer" style="height: {{ height ~ 'px' }};"></div>
     {%- if show_toggle -%}
     <div class="toggleOverview collapse-toggle">
-        <i class="fas {{ closed ? 'fa-map' : 'fa-chevron-right' }}"></i>
+        <i></i> {# fa-chevron-right, fa-chevron-left or fa-map, set in MbOverview.js::_updateIcon #}
     </div>
     {%- endif -%}

--- a/src/Mapbender/CoreBundle/Resources/views/Element/overview.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/overview.html.twig
@@ -1,4 +1,6 @@
     <div class="overviewContainer" style="height: {{ height ~ 'px' }};"></div>
     {%- if show_toggle -%}
-    <div class="toggleOverview collapse-toggle"><i class="fas {{ closed ? 'fa-plus' : 'fa-minus' }} fa-fw"></i></div>
+    <div class="toggleOverview collapse-toggle">
+        <i class="fas {{ closed ? 'fa-map' : 'fa-chevron-right' }}"></i>
+    </div>
     {%- endif -%}


### PR DESCRIPTION
(see internal ticket 11915):

> Overview - Klötzchen verschönern - aber wie? [...] 

(English: "Prettify Overview - Button - but how? [...]")

## Changes
- The icons functionality to switch between an icon for the closed and open state was fixed (previously it did not change)
- The icon was made white and given more padding to match the scale slider above it on the screen (a hover effect was added to the background)
- The button now attaches to the overview map when open

**Changes not directly addressing the issue**:

- The `$radius`-SCSS variable was replaced by a new `radius-md`-CSS variable. Three additional radius classes were added for ease of use (and necessity for the buttons radii): `radius-sm`, `radius-lg` and `radius-full`.

## Screenshots
<img width="285" height="213" alt="image" src="https://github.com/user-attachments/assets/6516d466-a4cb-45b6-aa49-3a9875710245" />

<img width="278" height="216" alt="image" src="https://github.com/user-attachments/assets/d641cc27-69ca-4368-95a5-5d0ec6379a40" />
