### PR TITLE
Do not show "abort" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## next bugfix release
+* Do not show "abort" error message ([#PR1855](https://github.com/mapbender/mapbender/pull/1855))
 * Fix activating visible layers by name ([#PR1839](https://github.com/mapbender/mapbender/pull/1839))
 * [FeatureInfo] Make sandbox iframe attribute in the feature info dialog configurable using `mapbender.featureinfo.iframe_sandbox_params`  ([#PR1844](https://github.com/mapbender/mapbender/pull/1844))
 

--- a/src/Mapbender/CoreBundle/Resources/public/util.js
+++ b/src/Mapbender/CoreBundle/Resources/public/util.js
@@ -27,6 +27,11 @@ Mapbender.confirm = function (message) {
  * @param {string} [errorMessage] - Optional. Message shown to the user for non 403/404 errors.
  */
 Mapbender.handleAjaxError = function (error, retry, errorMessage) {
+    if (error.status === 0) {
+        // status 0 means the request is aborted which is not an error
+        // (e.g. a autocomplete search is cancelled when the next character is entered)
+        return;
+    }
     if (error.status !== 403 && error.status !== 404) {
         // For non-403 and 404 errors don't offer a reload and retry button, just forward to Mapbender.error
         return Mapbender.error(errorMessage || error.responseText || error.statusText || '');


### PR DESCRIPTION
When e.g. quickly swiping through digitizer lists, the previous requests get cancelled. This should an "abort" error message to the user. However,  aborting the request is not in fact an error but intended behaviour. This PR removes these error displays.