### PR TITLE
Fix GpsPosition: Initialize stack array to fix geolocation error

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbGpsPosition.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbGpsPosition.js
@@ -35,6 +35,9 @@
         }
 
         _setup() {
+            this.stack = [];
+            this.observer = null;
+            this.firstPosition = false;
             this.layer = Mapbender.vectorLayerPool.getElementLayer(this, 0);
             if (this.options.autoStart === true) {
                 this.activate();


### PR DESCRIPTION
Initialize this.stack, this.observer, and this.firstPosition in the _setup() 
method to prevent "Cannot read properties of undefined" errors when 
_handleGeolocationPosition() is called.