### PR TITLE
Fix/poi textarea

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbPoi.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbPoi.js
@@ -50,7 +50,7 @@
                         cssClass: 'btn btn-sm btn-primary',
                         attrDataTest: 'mb-poi-btn-add',
                         callback: () => {
-                            self._sendPoi(this.$element);
+                            self._sendPoi();
                         }
                     }
                 ]
@@ -118,8 +118,8 @@
             this.poiMarkerLayer.show();
         }
 
-        _sendPoi(content) {
-            const label = $('textarea', content).val();
+        _sendPoi() {
+             const label = this.popup.$element.find('textarea').val();
 
             if(!this.poi) {
                 return;

--- a/src/Mapbender/CoreBundle/Resources/views/Element/poi.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/poi.html.twig
@@ -4,9 +4,4 @@
 <div class="output">
     <p>{{ 'mb.core.poi.text.snippet'|trans }}</p>
     <textarea class="form-control"></textarea>
-    <div class="text-nowrap text-end">
-        <button type="button" class="btn btn-sm btn-light popupClose">
-            {{ 'mb.actions.close' | trans }}
-        </button>
-    </div>
 </div>


### PR DESCRIPTION
The _sendPoi() method was reading the textarea value from the original
element container (this.$element) instead of from the active popup
where the user actually enters their input. This caused the method to
always return the initial placeholder text, ignoring any user input.


Also removes the “Close” button from the POI element's popup