### PR TITLE
write OGC API - Features with -

### DIFF
--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -10,7 +10,7 @@ A data source describes the content that is displayed on a map. The core mapbend
 | Tile Map Service (TMS)                           | tms              |
 | Web Map Service Time (WMS-T)                     | wms              |
 | Vector Tiles using the Mapbox Vector Tile format | vector_tiles     |
-| OGC API Features                                 | ocg_api_features |
+| OGC API - Features                               | ocg_api_features |
 
 This tutorial describes how to create a new source that can be configured in the backoffice and displayed in the frontend.
 

--- a/src/Mapbender/CoreBundle/Extension/Twig/SourceTwigExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/Twig/SourceTwigExtension.php
@@ -23,6 +23,7 @@ class SourceTwigExtension extends AbstractExtension
     {
         return [
             new TwigFilter('source_label', [$this, 'getSourceLabel']),
+            new TwigFilter('source_label_long', [$this, 'getSourceLabelLong']),
             new TwigFilter('source_accent_color', [$this, 'getSourceAccentColor']),
         ];
     }
@@ -31,6 +32,12 @@ class SourceTwigExtension extends AbstractExtension
     {
         $source = $this->typeDirectoryService->getSource($type);
         return $source->getLabel(true);
+    }
+
+    function getSourceLabelLong(string $type): ?string
+    {
+        $source = $this->typeDirectoryService->getSource($type);
+        return $source->getLabel(false);
     }
 
     function getSourceAccentColor(string $type): string

--- a/src/Mapbender/ManagerBundle/Resources/views/macros/source.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/macros/source.html.twig
@@ -4,7 +4,7 @@
       <tr>
           <th>{{ 'mb.manager.admin.element.type' | trans }}:</th>
           <td>
-              <span class="badge bg-{{ source.type | source_accent_color }}">{{ source.type | source_label }}{% if source.version is defined and source.version %} {{ source.version }}{% endif %}</span>
+              <span class="badge bg-{{ source.type | source_accent_color }}">{{ source.type | source_label_long }}{% if source.version is defined and source.version %} {{ source.version }}{% endif %}</span>
           </td>
       </tr>
       {% if source.displayUrl %}

--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesLoader.php
@@ -61,7 +61,7 @@ class OgcApiFeaturesLoader extends SourceLoader implements StyleableSourceLoader
 
         $baseUrl = str_replace('/collections', '', $url);
         $source->setJsonUrl($baseUrl);
-        $source->setTitle($json['title'] ?? 'Ogc Api Features Source');
+        $source->setTitle($json['title'] ?? 'OGC API - Features Source');
         $source->setDescription($json['description'] ?? '');
         $source->setVersion($version);
         $source->setAttribution($json['attribution'] ?? '');

--- a/src/Mapbender/OgcApiFeaturesBundle/OgcApiFeaturesDataSource.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/OgcApiFeaturesDataSource.php
@@ -33,7 +33,7 @@ class OgcApiFeaturesDataSource extends DataSource
 
     public function getLabel(bool $compact = false): string
     {
-        return $compact ? 'OGC-Features' : 'OGC API Features';
+        return $compact ? 'OGC-Features' : 'OGC API - Features';
     }
 
     public function getConfigGenerator(): SourceInstanceConfigGenerator

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.de.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: Link zu OGC API Features Service
+      json_url: Link zum OGC API - Features Service
       feature_limit: Max.-Anzahl Features
       layers: Collections
       layer:
@@ -44,7 +44,7 @@ mb:
         property_title: Titel
       tooltip:
         heading: Hover-Tooltip
-        description: "Wählen Sie, welche Eigenschaften beim Überfahren von Features auf der Karte als Tooltip angezeigt werden."
+        description: "Wählen Sie, welche Eigenschaften beim Überfahren von Features auf der Karte als Tooltip angezeigt werden sollen."
         no_properties: "Keine Eigenschaften verfügbar. Versuchen Sie, die Quelle neu zu laden."
     metadata:
       title: Titel

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.en.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL to OGC API Features Service
+      json_url: URL to OGC API - Features Service
       feature_limit: Max-Features
       layers: Collections
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.es.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL del servicio OGC API Features
+      json_url: URL del servicio OGC API - Features
       feature_limit: Número máx. de objetos
       layers: Colecciones
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.fr.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL du service OGC API Features
+      json_url: URL du service OGC API - Features
       feature_limit: Nombre max. d'objets
       layers: Collections
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.it.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL del servizio OGC API Features
+      json_url: URL del servizio OGC API - Features
       feature_limit: Max oggetti
       layers: Collezioni
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.nl.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL naar OGC API Features Service
+      json_url: URL naar OGC API - Features Service
       feature_limit: Max. objecten
       layers: Collecties
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.pl.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.pl.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL usługi OGC API Features
+      json_url: URL usługi OGC API - Features
       feature_limit: Maks. obiektów
       layers: Kolekcje
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.pt.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL do serviço OGC API Features
+      json_url: URL do serviço OGC API - Features
       feature_limit: Número máx. de objetos
       layers: Coleções
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.ru.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.ru.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL сервиса OGC API Features
+      json_url: URL сервиса OGC API - Features
       feature_limit: Макс. объектов
       layers: Коллекции
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.tr.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.tr.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: OGC API Features Servisi URL'si
+      json_url: OGC API - Features Servisi URL'si
       feature_limit: Maks. nesne sayısı
       layers: Koleksiyonlar
       layer:

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.uk.yaml
@@ -1,7 +1,7 @@
 mb:
   ogcapifeatures:
     admin:
-      json_url: URL сервісу OGC API Features
+      json_url: URL сервісу OGC API - Features
       feature_limit: Макс. об'єктів
       layers: Колекції
       layer:


### PR DESCRIPTION
changed in translation files and more

one open issue
- in the list of the services, the long name should be used
- in the list of the instances in the application configuration the compact name should be used