### PR TITLE
Sidebar improvements

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
+++ b/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
@@ -104,11 +104,11 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
                 if (empty($appConfig['url'])) {
                     $appConfig['url'] = $this->router->generate('mapbender_core_application_application', ['slug' => $slug]);
                 }
-                if (empty($appConfig['imgUrl'])) {
-                    $appConfig['imgUrl'] = false;
+                if (empty($appConfig['img_url'])) {
+                    $appConfig['img_url'] = false;
                     $imgPath = '/uploads/' . $slug . '/' . $application->getScreenshot();
                     if (@\is_file($this->rootDir . '/public' . $imgPath)) {
-                        $appConfig['imgUrl'] = $this->router->getContext()->getBaseUrl() . $imgPath;
+                        $appConfig['img_url'] = $this->router->getContext()->getBaseUrl() . $imgPath;
                     }
                 }
                 $preparedAppConfig[$group][$slug] = $appConfig;
@@ -132,7 +132,7 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
                     'title' => null,
                     'description' => null,
                     'url' => null,
-                    'imgUrl' => null,
+                    'img_url' => null,
                     'group' => null,
                 ];
             }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
@@ -119,6 +119,7 @@
     --sidepane-collapsed-width: 3.4rem;
     --sidepane-padding-left: 1rem;
     --sidepane-padding-right: 1rem;
+    --sidepane-closer-security-padding: 40px;
     --sidepane-padding-y: 1rem;
 
     // ---- Inputs ----

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -159,6 +159,31 @@
     }
 }
 
+.list-back-btn {
+    padding: var(--sidepane-padding-y) var(--sidepane-padding-right) var(--sidepane-padding-y) var(--sidepane-padding-left);
+    background: none;
+    border: none;
+    color: var(--sidepane-inactive-text-color);
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    font-size: 14px;
+
+    i {
+        margin-right: 8px;
+    }
+
+    &:hover {
+        color: var(--sidepane-text-color);
+    }
+
+    &:focus {
+        outline-offset: -2px;
+    }
+}
+
 .container-list-group-item {
     position: absolute;
     top: 0;
@@ -178,34 +203,6 @@
         transform: translateX(-100%);
         opacity: 1;
         pointer-events: all;
-    }
-
-    .list-group-item-header {
-
-        .list-back-btn {
-            padding: var(--sidepane-padding-y) var(--sidepane-padding-right) var(--sidepane-padding-y) var(--sidepane-padding-left);
-            background: none;
-            border: none;
-            color: var(--sidepane-inactive-text-color);
-            width: 100%;
-            text-align: left;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            font-size: 14px;
-
-            i {
-                margin-right: 8px;
-            }
-
-            &:hover {
-                color: var(--sidepane-text-color);
-            }
-
-            &:focus {
-                outline-offset: -2px;
-            }
-        }
     }
 
     .list-group-item-cell {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -93,7 +93,7 @@
         font-size: 1rem;
         padding: 0 var(--sidepane-padding-right) 0 var(--sidepane-padding-left);
         margin-bottom: 0.5rem;
-        padding-right: 40px;
+        padding-right: var(--sidepane-closer-security-padding);
     }
 
     .accordion-cell, .list-group-item-content {
@@ -142,9 +142,13 @@
     padding-top: 16px;
     height: 100%;
 
-    > .auto-scroll-v {
-        // Grow "unstyled" sidepane vertically to avoid clipping misc popover markup
+    > .unstyled {
         height: 100%;
+        padding: var(--sidepane-padding-y) var(--sidepane-padding-right) var(--sidepane-padding-y) var(--sidepane-padding-left);
+
+        .mb-element {
+            margin-bottom: 15px;
+        }
     }
 }
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -6,6 +6,7 @@
     height: 100%;
     overflow: visible;
     width: 350px;
+    max-width: 100vw;
     position: absolute;
     z-index: 3;
 
@@ -27,9 +28,10 @@
         border-left: 1px solid var(--sidepane-border-color);
 
         .sidePane--collapsed {
-            left: 0.5rem;
+            right: 0.5rem;
 
             &.closed {
+                right: initial;
                 left: calc(-1 * var(--sidepane-collapsed-width));
             }
         }
@@ -45,6 +47,7 @@
             width: 3px;
             height: 100%;
             cursor: ew-resize;
+            z-index: 10;
         }
 
         &.left::after {
@@ -90,14 +93,7 @@
         font-size: 1rem;
         padding: 0 var(--sidepane-padding-right) 0 var(--sidepane-padding-left);
         margin-bottom: 0.5rem;
-
-        .sidePane.left & {
-            padding-right: 40px;
-        }
-
-        .sidePane.right & {
-            padding-left: 40px;
-        }
+        padding-right: 40px;
     }
 
     .accordion-cell, .list-group-item-content {

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -65,11 +65,15 @@
         font-size: 1.4rem;
         position: absolute;
         top: 0;
-        background: var(--sidepane-background-color);
         z-index: 10;
         color: var(--sidepane-button-color);
 
+        &:hover {
+            background: var(--sidepane-hover-color);
+        }
+
         &.closed {
+            background: var(--sidepane-background-color);
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -157,6 +161,7 @@
     height: 100%;
     transform: translateX(0);
     transition: transform 0.3s ease-in-out;
+    overflow-y: auto;
 
     &.list-shifted {
         transform: translateX(-100%);

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_tabcontainer.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_tabcontainer.scss
@@ -130,7 +130,7 @@ $hoverEffects: true !default;
 
     > .container {
         // Undo Bootstrap margin + padding
-        // @ŧodo: if we want nothing from Bootstrap .container, we should not add Bootstrap .container
+        // @todo: if we want nothing from Bootstrap .container, we should not add Bootstrap .container
         margin: 0;
         padding: 0;
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_tabcontainer.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_tabcontainer.scss
@@ -86,50 +86,62 @@ $hoverEffects: true !default;
   }
 }
 
-.tabContainerAlt{
-  > .tabs {
-    list-style: none;
+.tabContainerAlt {
+    > .tabs {
+        list-style: none;
 
-    // show border only if there's at least one tab
-    &:has(li) {
-      border-bottom: 1px solid #d6d3d3;
-    }
-  }
-  .tab {
-    @extend .buttonCore;
-    display: inline-block;
-    font-size: var(--sidepane-button-font-size);
-    padding: 0.25em 10px;
-    margin: 0 0.25em 0.1em 0;
-    color: var(--sidepane-button-text);
-    background-color: var(--sidepane-button-background);
+        // show border only if there's at least one tab
+        &:has(li) {
+            border-bottom: 1px solid #d6d3d3;
+        }
 
-    &.active{
-      cursor:default;
-      color: var(--sidepane-button-active-text);
-      border-bottom: 3px solid var(--primary);
-      margin-bottom: -2px;
+        .sidePane & {
+            margin-right: var(--sidepane-closer-security-padding);
+        }
     }
 
-    &:focus-visible{
-      outline: 2px solid var(--focus-color);
-      outline-offset: -2px;
+    .tab {
+        @extend .buttonCore;
+        display: inline-block;
+        font-size: var(--sidepane-button-font-size);
+        padding: 0.25em 10px;
+        margin: 0 0.25em 0.1em 0;
+        color: var(--sidepane-button-text);
+        background-color: var(--sidepane-button-background);
+
+        &.active {
+            cursor: default;
+            color: var(--sidepane-button-active-text);
+            border-bottom: 3px solid var(--primary);
+            margin-bottom: -2px;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--focus-color);
+            outline-offset: -2px;
+        }
+
+        @if $hoverEffects {
+            &:hover:not(.active) {
+                background-color: var(--sidepane-button-hover);
+            }
+        }
     }
-    @if $hoverEffects {
-      &:hover:not(.active) {
-        background-color: var(--sidepane-button-hover);
-      }
+
+    > .container {
+        // Undo Bootstrap margin + padding
+        // @ŧodo: if we want nothing from Bootstrap .container, we should not add Bootstrap .container
+        margin: 0;
+        padding: 0;
+
+        .sidePane & {
+            margin: var(--sidepane-padding-y) var(--sidepane-padding-right) var(--sidepane-padding-y) var(--sidepane-padding-left);
+            width: calc(100% - var(--sidepane-padding-left) - var(--sidepane-padding-right));
+        }
     }
-  }
-  .container {
-    // Undo Bootstrap margin + padding
-    // @ŧodo: if we want nothing from Bootstrap .container, we should not add Bootstrap .container
-    margin: 0;
-    padding: 0;
-  }
 }
 
-.tabContainer .container, .tabContainerAlt .container {
+.tabContainer > .container, .tabContainerAlt > .container {
   width: 100%;  // overrule Bootstrap .container (which has varying width depending on screen size)
 }
 

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -91,13 +91,16 @@ $(function () {
     window.addEventListener("resize", constrainSize, false);
 
     $(document).on('pointerdown', '.sidePane.resizable', function (e) {
-        if ((sidePaneLeft && sidePaneWidth() - e.offsetX < BORDER_SIZE) || (!sidePaneLeft && e.offsetX < BORDER_SIZE)) {
+        const paneRect = this.getBoundingClientRect();
+        const offsetX = e.clientX - paneRect.left;
+
+        if ((sidePaneLeft && sidePaneWidth() - offsetX < BORDER_SIZE) || (!sidePaneLeft && offsetX < BORDER_SIZE)) {
             pointerPosition = e.x;
             $("body").addClass("prevent-selection");
             document.addEventListener("pointermove", resize);
         }
 
-        $(document).one('pointercancel pointerup', function (e) {
+        $(document).one('pointercancel pointerup', function () {
             document.removeEventListener("pointermove", resize);
             $("body").removeClass("prevent-selection");
         });

--- a/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
@@ -23,8 +23,8 @@
                 <li class="list-item">
                     <a href="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
                         <div class="list-content">
-                            {% if app.imgUrl is defined and app.imgUrl != false %}
-                            <img src="{{ app.imgUrl }}" alt="{{ app.title }}">
+                            {% if app.img_url is defined and app.img_url != false %}
+                            <img src="{{ app.img_url }}" alt="{{ app.title }}">
                             {% else %}
                                 <img class="bg-light" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABHNCSVQICAgIfAhkiAAA
                                     ACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAABfElEQVR4

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -43,68 +43,60 @@
 
 
     {% elseif region_props.name == 'accordion' %}
-      <div class="accordionContainer list-group">
-          {%- for element_info in _visible -%}
-              {%- set element = element_info.element -%}
-              {% if element.configuration.openInline is defined and element.configuration.openInline == 1 %}
-                  <div class="sidePane__inline-element">
-                      <div>
-                          {{ element_info.content | raw }}
-                      </div>
-                  </div>
-              {% endif %}
-          {%- endfor -%}
-        {%- for element_info in _visible -%}
-          {%- set element = element_info.element -%}
-          {% if element.configuration.openInline is not defined or element.configuration.openInline != 1 %}
-              {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
-              <div id="accordion{{loop.index}}" class="element-title {{ ('accordion' ~ (loop.first ? ' active' : '') ~ ' ' ~ element_visibility_class(element)) | trim }}">
-                  {% if element_icon %}
-                    <span class="element-icon-wrapper">{{element_icon | raw }}</span>
-                  {% endif %}
-                   {{ element.title | trans }}
-              </div>
-              <div id="container{{loop.index}}" class="container-accordion{% if loop.first %} active{% endif %}" tabindex="-1">
-                  <div class="accordion-cell">
-                      {{ element_info.content | raw }}
-                  </div>
-              </div>
-            {% endif %}
-        {%- endfor -%}
-      </div>
+        <div class="accordionContainer list-group">
+            {%- for element_info in _visible -%}
+                {%- set element = element_info.element -%}
+                {% if element.configuration.openInline is defined and element.configuration.openInline == 1 %}
+                    <div class="sidePane__inline-element">
+                        <div>
+                            {{ element_info.content | raw }}
+                        </div>
+                    </div>
+                {% else %}
+                    {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
+                    <div id="accordion{{ loop.index }}" class="element-title {{ ('accordion' ~ (loop.first ? ' active' : '') ~ ' ' ~ element_visibility_class(element)) | trim }}">
+                        {% if element_icon %}
+                            <span class="element-icon-wrapper">{{ element_icon | raw }}</span>
+                        {% endif %}
+                        {{ element.title | trans }}
+                    </div>
+                    <div id="container{{ loop.index }}" class="container-accordion{% if loop.first %} active{% endif %}" tabindex="-1">
+                        <div class="accordion-cell">
+                            {{ element_info.content | raw }}
+                        </div>
+                    </div>
+                {% endif %}
+            {%- endfor -%}
+        </div>
 
 
     {% elseif region_props.name == 'list' %}
         <div class="listContainer">
-              {%- for element_info in _visible -%}
-                    {%- set element = element_info.element -%}
-                    {% if element.configuration.openInline is defined and element.configuration.openInline == 1 %}
-                      <div class="sidePane__inline-element">
-                          <div>
-                              {{ element_info.content | raw }}
-                          </div>
-                      </div>
-                    {% endif %}
-                {%- endfor -%}
-                {%- for element_info in _visible -%}
-                    {%- set element = element_info.element -%}
-                    {% if element.configuration.openInline is not defined or element.configuration.openInline != 1 %}
-                      {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
-                      <div id="list_group_item{{loop.index}}" class="element-title list-group-item {{ element_visibility_class(element) | trim }}">
-                          {% if element_icon %}
-                              <span class="element-icon-wrapper">{{ element_icon | raw }}</span>
-                          {% endif %}
-                          {{ element.title | trans }}
-                      </div>
-                    {% endif %}
-                {%- endfor -%}
+            {%- for element_info in _visible -%}
+                {%- set element = element_info.element -%}
+                {% if element.configuration.openInline is defined and element.configuration.openInline == 1 %}
+                    <div class="sidePane__inline-element">
+                        <div>
+                            {{ element_info.content | raw }}
+                        </div>
+                    </div>
+                {% else %}
+                    {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
+                    <div id="list_group_item{{ loop.index }}" class="element-title list-group-item {{ element_visibility_class(element) | trim }}">
+                        {% if element_icon %}
+                            <span class="element-icon-wrapper">{{ element_icon | raw }}</span>
+                        {% endif %}
+                        {{ element.title | trans }}
+                    </div>
+                {% endif %}
+            {%- endfor -%}
         </div>
         {%- for element_info in _visible -%}
             {%- set element = element_info.element -%}
             {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
             <div id="list_group_item_container{{loop.index}}" class="container-list-group-item">
                 <div class="list-group-item-header">
-                    <button class="list-back-btn{% if 'right' in region_class %}d-flex justify-content-end{% endif %}" type="button">
+                    <button class="list-back-btn" type="button">
                         <i class="fa-solid fa-angle-left iconBig"></i>
                         <span>{{ return_text | trans}}</span>
                     </button>

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -42,6 +42,7 @@
 
     {% elseif region_props.name == 'accordion' %}
         <div class="accordionContainer list-group">
+            {%- set firstAccordion = true -%}
             {%- for element_info in _visible -%}
                 {%- set element = element_info.element -%}
                 {% if element.configuration.openInline is defined and element.configuration.openInline == 1 %}
@@ -51,14 +52,16 @@
                         </div>
                     </div>
                 {% else %}
+                    {%- set isActive = firstAccordion -%}
+                    {%- set firstAccordion = false -%}
                     {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
-                    <div id="accordion{{ loop.index }}" class="element-title {{ ('accordion' ~ (loop.first ? ' active' : '') ~ ' ' ~ element_visibility_class(element)) | trim }}">
+                    <div id="accordion{{ loop.index }}" class="element-title {{ ('accordion' ~ (isActive ? ' active' : '') ~ ' ' ~ element_visibility_class(element)) | trim }}">
                         {% if element_icon %}
                             <span class="element-icon-wrapper">{{ element_icon | raw }}</span>
                         {% endif %}
                         {{ element.title | trans }}
                     </div>
-                    <div id="container{{ loop.index }}" class="container-accordion{% if loop.first %} active{% endif %}" tabindex="-1">
+                    <div id="container{{ loop.index }}" class="container-accordion{% if isActive %} active{% endif %}" tabindex="-1">
                         <div class="accordion-cell">
                             {{ element_info.content | raw }}
                         </div>

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -116,7 +116,7 @@
         {%- endfor -%}
     {%- endif -%}
   {%- else -%}
-        <div class="auto-scroll-v">
+        <div class="auto-scroll-v unstyled">
             {{ region_content(application, region_name) | raw }}
         </div>
   {% endif %}

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -26,9 +26,7 @@
             {%- set element = element_info.element -%}
             {%- set element_icon = find_icon(element, 'js-mb-icon') -%}
             <li id="tab{{loop.index}}" class="{{ ('tab' ~ (loop.first ? ' active' : '') ~ ' ' ~ element_visibility_class(element)) | trim }}">
-              <div class="hidden">
                 {{element_icon | raw }}
-              </div>
               {{ element.title | trans }}
             </li>
           {%- endfor -%}


### PR DESCRIPTION
Fixes the following sidepane-related issues:

- Inline elements (HTML or Simple Search) were always at the top, regardless of their order in the sidepane
-  You could not enlarge the view by dragging with the mouse if an element is expanded in List mode
-  If the sidepane is on the right, the Close button overlapped the other buttons
- Sidepane Mode Button: Show icons as well
- When moving the slider on the WMS, the width of the sidepane increased
- Padding in the Sidepane modes "Buttons" und "unstyled" was missing
- on mobile, sidepane could not be closed when the initial width exceeded the display width

see internal tickets 13378 and 13383
