### PR TITLE
Enhance OgcApiFeaturesInstance creation with ID 

### DIFF
--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
@@ -86,6 +86,7 @@ class OgcApiFeaturesInstanceFactory extends SourceInstanceFactory
     {
         $source = $this->getSourceFromConfig($data, $id);
         $instance = new OgcApiFeaturesInstance();
+        $instance->setId($id);
         $instance->setSource($source);
         $instance->setTitle($data['title'] ?? $source->getTitle());
         $instance->setOpacity($data['opacity'] ?? 100);
@@ -95,8 +96,12 @@ class OgcApiFeaturesInstanceFactory extends SourceInstanceFactory
         $instance->setToggle($data['toggle'] ?? true);
         $instance->setMinScale($data['minScale'] ?? null);
         $instance->setMaxScale($data['maxScale'] ?? null);
-        $instance->setFeatureLimit($data['featureLimit'] ?? null);
-        $featureInfoPropertyMap = json_encode($data['featureInfoPropertyMap']);
+        $instanceFeatureLimit = $data['featureLimit'] ?? null;
+        if ($instanceFeatureLimit !== null) {
+            $instance->setFeatureLimit((int)$instanceFeatureLimit);
+        }
+        $instance->setBasesource(isset($data['isBaseSource']) ? (bool)$data['isBaseSource'] : false);
+        $featureInfoPropertyMap = isset($data['featureInfoPropertyMap']) ? json_encode($data['featureInfoPropertyMap']) : null;
         $instance->setFeatureInfoPropertyMap($featureInfoPropertyMap);
 
         foreach ($data['layers'] as $layer) {
@@ -119,7 +124,10 @@ class OgcApiFeaturesInstanceFactory extends SourceInstanceFactory
             $instanceLayer->setAllowSelected($layer['allowSelected'] ?? true);
             $instanceLayer->setInfo($layer['info'] ?? false);
             $instanceLayer->setAllowInfo($layer['allowInfo'] ?? true);
-            $instanceLayer->setFeatureLimit($data['featureLimit'] ?? null);
+            $layerFeatureLimit = $layer['featureLimit'] ?? $instanceFeatureLimit;
+            if ($layerFeatureLimit !== null) {
+                $instanceLayer->setFeatureLimit((int)$layerFeatureLimit);
+            }
             $instanceLayer->setPriority(null);
             $instance->addLayer($instanceLayer);
         };

--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
@@ -100,7 +100,7 @@ class OgcApiFeaturesInstanceFactory extends SourceInstanceFactory
         if ($instanceFeatureLimit !== null) {
             $instance->setFeatureLimit((int)$instanceFeatureLimit);
         }
-        $instance->setBasesource(isset($data['isBaseSource']) ? (bool)$data['isBaseSource'] : false);
+        $instance->setBasesource($data['basesource'] ?? $data['isBaseSource'] ?? false);
         $featureInfoPropertyMap = isset($data['featureInfoPropertyMap']) ? json_encode($data['featureInfoPropertyMap']) : null;
         $instance->setFeatureInfoPropertyMap($featureInfoPropertyMap);
 


### PR DESCRIPTION
Enables definition of OgcApiFeaturesInstances in yaml based applications

Testing:

place this section under  layersets: main

```
                      liegenschaften_nrw:
                        type: ogc_api_features
                        title: Liegenschaftskataster NRW
                        jsonUrl: https://ogc-api.nrw.de/lika/v1
                        layers:
                            31: { collectionId: flurstueck, title: Flurstück, active: true, minScale: ~, maxScale: ~, selected: true, allowSelected: true, info: true, allowInfo: true, featureLimit: 90 }
                            32: { collectionId: flurstueck_punkt, title: Flurstückspunkt, active: true, minScale: ~, maxScale: ~, selected: true, allowSelected: true, info: true, allowInfo: true, featureLimit: 90 }
                            33: { collectionId: gebaeude_bauwerk, title: 'Gebäude, Bauwerk', active: true, minScale: ~, maxScale: ~, selected: true, allowSelected: true, info: true, allowInfo: true, featureLimit: 90 }
                        visible: false
                        opacity: 100
                        isBaseSource: false
                        selected: false
                        allowSelected: true
                        toggle: false
                        allowToggle: true
                        minScale: ~
                        maxScale: ~
                        featureLimit: 100
                        featureInfoPropertyMap:
                            - { aktualit: 'Aktualität' }
                            - gebnutzbez
```
