### PR TITLE
Fix Layertree: Ignore not allowed layers on shift click

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbLayertree.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbLayertree.js
@@ -490,7 +490,8 @@
         _updateChildrenState($layer, newState) {
             $layer.children('.layers').children('.leave').each((index, child) => {
                 const $child = $(child);
-                const $childToggle = $child.children('.leaveContainer').children('.-fn-toggle-selected');
+                const $childToggle = $child.children('.leaveContainer').children('.-fn-toggle-selected:not(.disabled)');
+                if (!$childToggle.length) return;
                 this.updateIconVisual_($childToggle, newState, null);
                 this.model.controlLayer($child.data('layer'), newState);
             });


### PR DESCRIPTION
If the user is not permitted to deactivate an active layer, this is now taken into account when Shift+clicking on the root layer.

internal ticket: #13381