### PR TITLE
Fix/adjust ogcapi style

### DIFF
--- a/src/Mapbender/ManagerBundle/Controller/StyleController.php
+++ b/src/Mapbender/ManagerBundle/Controller/StyleController.php
@@ -214,6 +214,7 @@ class StyleController extends ApplicationControllerBase
             'fontFamily' => 'Arial, Helvetica, sans-serif',
             'fontSize' => 11,
             'fontWeight' => 'regular',
+            'fontStyle' => 'normal',
             'fontColor' => '#333333',
             'fontOpacity' => 1,
         ];

--- a/src/Mapbender/ManagerBundle/Resources/public/css/style-editor.css
+++ b/src/Mapbender/ManagerBundle/Resources/public/css/style-editor.css
@@ -84,6 +84,13 @@
     margin-bottom: 6px;
 }
 
+/* ── Empty field validation ── */
+input.field-empty,
+input.field-empty:focus {
+    background-color: #fff0f0 !important;
+    border-color: #f5a0a0 !important;
+}
+
 /* ── Layer Accordion ── */
 #layers-editor .layers-header {
     display: flex;

--- a/src/Mapbender/ManagerBundle/Resources/public/css/style-editor.css
+++ b/src/Mapbender/ManagerBundle/Resources/public/css/style-editor.css
@@ -86,7 +86,11 @@
 
 /* ── Empty field validation ── */
 input.field-empty,
-input.field-empty:focus {
+select.field-empty,
+textarea.field-empty,
+input.field-empty:focus,
+select.field-empty:focus,
+textarea.field-empty:focus {
     background-color: #fff0f0 !important;
     border-color: #f5a0a0 !important;
 }

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-layers.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-layers.js
@@ -120,6 +120,9 @@ class StyleEditorLayers {
             $(item).find('.-js-colorpicker').on('changeColor', onLayerChange);
         } catch(e) {}
 
+        // Re-apply after colorpicker init, which may have set inline styles that override the class
+        item.querySelectorAll('[data-layer-prop]').forEach(el => this._markIfEmpty(el));
+
         item.querySelector('.-fn-remove-layer')?.addEventListener('click', () => {
             item.remove();
             this.syncLayersToJson();
@@ -172,6 +175,10 @@ class StyleEditorLayers {
             const vp = input.closest('.row')?.querySelector('.layer-range-preview');
             if (vp) vp.textContent = parseFloat(input.value).toFixed(2);
         });
+
+        this.layerAccordion.querySelectorAll('[data-layer-prop]').forEach(input => {
+            this._markIfEmpty(input);
+        });
     }
 
     // ── Paint control builders (DOM-based, using <template> elements) ──
@@ -188,11 +195,11 @@ class StyleEditorLayers {
             container.appendChild(this._createNumberRow('line-width', Mapbender.trans('mb.manager.admin.style.editor.line_width'), this._scalarVal(paint['line-width'], 2), 0, 50, 0.5));
             container.appendChild(this._createRangeRow('line-opacity', Mapbender.trans('mb.manager.admin.style.editor.line_opacity'), paint['line-opacity'] ?? 1, 0, 1, 'any'));
         } else if (type === 'circle') {
-            container.appendChild(this._createNumberRow('circle-radius', Mapbender.trans('mb.manager.admin.style.editor.circle_radius'), paint['circle-radius'] || 5, 0, 50, 1));
+            container.appendChild(this._createNumberRow('circle-radius', Mapbender.trans('mb.manager.admin.style.editor.circle_radius'), paint['circle-radius'] ?? 5, 0, 50, 1));
             container.appendChild(this._createColorRow('circle-color', Mapbender.trans('mb.manager.admin.style.editor.circle_color'), paint['circle-color'] || '#000000'));
             container.appendChild(this._createRangeRow('circle-opacity', Mapbender.trans('mb.manager.admin.style.editor.circle_opacity'), paint['circle-opacity'] ?? 1, 0, 1, 'any'));
             container.appendChild(this._createColorRow('circle-stroke-color', Mapbender.trans('mb.manager.admin.style.editor.stroke_color'), paint['circle-stroke-color'] || ''));
-            container.appendChild(this._createNumberRow('circle-stroke-width', Mapbender.trans('mb.manager.admin.style.editor.stroke_width'), paint['circle-stroke-width'] || 0, 0, 10, 0.5));
+            container.appendChild(this._createNumberRow('circle-stroke-width', Mapbender.trans('mb.manager.admin.style.editor.stroke_width'), paint['circle-stroke-width'] ?? 0, 0, 10, 0.5));
         } else if (type === 'symbol') {
             container.appendChild(this._createSymbolControls(layout, paint));
             container.appendChild(this._createColorRow('text-color', Mapbender.trans('mb.manager.admin.style.editor.text_color'), paint['text-color'] || '#000000'));
@@ -221,6 +228,16 @@ class StyleEditorLayers {
         }
     }
 
+    _markIfEmpty(input) {
+        if (input.value === '' || input.value === null || input.value === undefined) {
+            input.style.backgroundColor = '#fff0f0';
+            input.style.borderColor = '#f5a0a0';
+        } else {
+            input.style.backgroundColor = '';
+            input.style.borderColor = '';
+        }
+    }
+
     _createColorRow(prop, label, value) {
         const frag = document.getElementById('tpl-color-row').content.cloneNode(true);
         frag.querySelector('label').textContent = label;
@@ -237,6 +254,8 @@ class StyleEditorLayers {
         } else {
             input.value = value;
         }
+        this._markIfEmpty(input);
+        input.addEventListener('input', () => this._markIfEmpty(input));
         return frag;
     }
 
@@ -261,7 +280,16 @@ class StyleEditorLayers {
         input.min = min;
         input.max = max;
         input.step = step;
-        input.value = value;
+        if (typeof value === 'object' && value !== null) {
+            // Complex value – try to evaluate as pure arithmetic, else show empty
+            const resolved = this._evalExpression(value);
+            input.value = resolved !== null ? resolved : '';
+            this._addComplexBadge(frag, value);
+        } else {
+            input.value = value;
+        }
+        this._markIfEmpty(input);
+        input.addEventListener('input', () => this._markIfEmpty(input));
         return frag;
     }
 
@@ -396,6 +424,8 @@ class StyleEditorLayers {
             return val ?? '';
         }
         if (Array.isArray(val)) {
+            const resolved = this._evalExpression(val);
+            if (resolved !== null) return resolved;
             return JSON.stringify(val);
         }
         if (val.stops && val.stops[0]) {
@@ -408,6 +438,27 @@ class StyleEditorLayers {
         if (typeof val === 'number') return val;
         if (typeof val === 'object' && val?.stops) return val.stops[0]?.[1] || fallback;
         return fallback;
+    }
+
+    /**
+     * Evaluate simple arithmetic Mapbox expressions composed of literal numbers.
+     * Returns the numeric result, or null if the expression is not pure arithmetic.
+     */
+    _evalExpression(expr) {
+        if (typeof expr === 'number') return expr;
+        if (!Array.isArray(expr) || expr.length < 2) return null;
+        const op = expr[0];
+        if (!['+', '-', '*', '/', '%'].includes(op)) return null;
+        const operands = expr.slice(1).map(v => this._evalExpression(v));
+        if (operands.some(v => v === null || !isFinite(v))) return null;
+        switch (op) {
+            case '+': return operands.reduce((a, b) => a + b, 0);
+            case '-': return operands.length === 1 ? -operands[0] : operands.reduce((a, b) => a - b);
+            case '*': return operands.reduce((a, b) => a * b, 1);
+            case '/': return operands.length === 2 && operands[1] !== 0 ? operands[0] / operands[1] : null;
+            case '%': return operands.length === 2 && operands[1] !== 0 ? operands[0] % operands[1] : null;
+        }
+        return null;
     }
 
     // ── Rule & filter info ──

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-layers.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-layers.js
@@ -229,13 +229,8 @@ class StyleEditorLayers {
     }
 
     _markIfEmpty(input) {
-        if (input.value === '' || input.value === null || input.value === undefined) {
-            input.style.backgroundColor = '#fff0f0';
-            input.style.borderColor = '#f5a0a0';
-        } else {
-            input.style.backgroundColor = '';
-            input.style.borderColor = '';
-        }
+        const isEmpty = input.value === '';
+        input.classList.toggle('field-empty', isEmpty);
     }
 
     _createColorRow(prop, label, value) {

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
@@ -13,12 +13,21 @@ class StyleEditorPreview {
     }
 
     drawLabel(ctx, s, x, y) {
-        const text = s.label || '';
-        if (!text) return;
+        const label = s.label || '';
+        const text = label;
         const fw = s.fontWeight || 'regular';
-        const prefix = fw === 'bold' ? 'bold ' : (fw === 'italic' ? 'italic ' : '');
-        ctx.font = `${prefix}${parseInt(s.fontSize) || 11}px ${s.fontFamily || 'Arial, Helvetica, sans-serif'}`;
-        ctx.fillStyle = StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1);
+        const fi = s.fontStyle || 'normal';
+        const isItalic = fi === 'italic';
+        const isBold = fw === 'bold';
+        const fontParts = [];
+        if (isItalic) fontParts.push('italic');
+        if (isBold) fontParts.push('bold');
+        fontParts.push(`${parseInt(s.fontSize) || 11}px`);
+        fontParts.push(s.fontFamily || 'Arial, Helvetica, sans-serif');
+        ctx.font = fontParts.join(' ');
+        ctx.fillStyle = label
+            ? StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1)
+            : 'rgba(0,0,0,0.35)';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(text, x, y);

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
@@ -26,7 +26,7 @@ class StyleEditorPreview {
         fontParts.push(s.fontFamily || 'Arial, Helvetica, sans-serif');
         ctx.font = fontParts.join(' ');
         ctx.fillStyle = label
-            ? StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1)
+            ? StyleUtils.hexToRgba(s.fontColor || '#000000', s.fontOpacity)
             : 'rgba(0,0,0,0.35)';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
@@ -35,8 +35,8 @@ class StyleEditorPreview {
 
     drawAll(visualStyle) {
         const s = visualStyle;
-        const fillStyle   = StyleUtils.hexToRgba(s.fillColor || '#3399CC', parseFloat(s.fillOpacity) || 1);
-        const strokeStyle = StyleUtils.hexToRgba(s.strokeColor || '#ffffff', parseFloat(s.strokeOpacity) || 1);
+        const fillStyle   = StyleUtils.hexToRgba(s.fillColor || '#3399CC', s.fillOpacity);
+        const strokeStyle = StyleUtils.hexToRgba(s.strokeColor || '#ffffff', s.strokeOpacity);
         const strokeWidth = parseFloat(s.strokeWidth) || 1;
         const pointRadius = parseFloat(s.pointRadius) || 6;
         const dashes = this.dashMap[s.strokeDashstyle] || [];

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
@@ -15,7 +15,8 @@ class StyleUtils {
         const r = parseInt(hex.substring(0,2), 16);
         const g = parseInt(hex.substring(2,4), 16);
         const b = parseInt(hex.substring(4,6), 16);
-        return `rgba(${r},${g},${b},${parseFloat(opacity) || 1})`;
+        const alpha = parseFloat(opacity);
+        return `rgba(${r},${g},${b},${isNaN(alpha) ? 1 : alpha})`;
     }
 
     static extractMapboxPaint(styleJson, collectionId) {
@@ -61,8 +62,8 @@ class StyleUtils {
         }
         const s = styleJson || {};
         return {
-            fillStyle: StyleUtils.hexToRgba(s.fillColor || '#3399CC', parseFloat(s.fillOpacity) || 1),
-            strokeStyle: StyleUtils.hexToRgba(s.strokeColor || '#ffffff', parseFloat(s.strokeOpacity) || 1),
+            fillStyle: StyleUtils.hexToRgba(s.fillColor || '#3399CC', s.fillOpacity),
+            strokeStyle: StyleUtils.hexToRgba(s.strokeColor || '#ffffff', s.strokeOpacity),
             strokeWidth: parseFloat(s.strokeWidth) || 1,
             pointRadius: parseFloat(s.pointRadius) || 5,
             isMapbox: false

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normal
           weight_bold: Fett
           weight_italic: Kursiv
+          font_style: Stil
+          style_normal: Normal
+          style_italic: Kursiv
           font_color: Schriftfarbe
           font_opacity: Schriftdeckkraft
           preview_legend: Vorschau

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -237,6 +237,9 @@ mb:
           weight_regular: Regular
           weight_bold: Bold
           weight_italic: Italic
+          font_style: Style
+          style_normal: Normal
+          style_italic: Italic
           font_color: Font Color
           font_opacity: Font Opacity
           preview_legend: Preview

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
@@ -233,6 +233,9 @@ mb:
           weight_regular: Normal
           weight_bold: Negrita
           weight_italic: Cursiva
+          font_style: Estilo
+          style_normal: Normal
+          style_italic: Cursiva
           font_color: Color de fuente
           font_opacity: Opacidad de fuente
           preview_legend: Vista previa

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
@@ -182,6 +182,9 @@ mb:
           weight_regular: Normal
           weight_bold: Gras
           weight_italic: Italique
+          font_style: Style
+          style_normal: Normal
+          style_italic: Italique
           font_color: Couleur de police
           font_opacity: Opacité de police
           preview_legend: Aperçu

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normale
           weight_bold: Grassetto
           weight_italic: Corsivo
+          font_style: Stile
+          style_normal: Normale
+          style_italic: Corsivo
           font_color: Colore del carattere
           font_opacity: Opacità del carattere
           preview_legend: Anteprima

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
@@ -182,6 +182,9 @@ mb:
           weight_regular: Normaal
           weight_bold: Vet
           weight_italic: Cursief
+          font_style: Stijl
+          style_normal: Normaal
+          style_italic: Cursief
           font_color: Letterkleur
           font_opacity: Letterdekking
           preview_legend: Voorbeeld

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
@@ -237,6 +237,9 @@ mb:
           weight_regular: Zwykły
           weight_bold: Pogrubiony
           weight_italic: Kursywa
+          font_style: Styl
+          style_normal: Normalny
+          style_italic: Kursywa
           font_color: Kolor czcionki
           font_opacity: Krycie czcionki
           preview_legend: Podgląd

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normal
           weight_bold: Negrito
           weight_italic: Itálico
+          font_style: Estilo
+          style_normal: Normal
+          style_italic: Itálico
           font_color: Cor da fonte
           font_opacity: Opacidade da fonte
           preview_legend: Pré-visualização

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
@@ -232,6 +232,9 @@ mb:
           weight_regular: Обычный
           weight_bold: Полужирный
           weight_italic: Курсив
+          font_style: Стиль
+          style_normal: Обычный
+          style_italic: Курсив
           font_color: Цвет шрифта
           font_opacity: Непрозрачность шрифта
           preview_legend: Предпросмотр

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
@@ -177,6 +177,9 @@ mb:
           weight_regular: Normal
           weight_bold: Kalın
           weight_italic: İtalik
+          font_style: Stil
+          style_normal: Normal
+          style_italic: İtalik
           font_color: Yazı tipi rengi
           font_opacity: Yazı tipi opaklığı
           preview_legend: Önizleme

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
@@ -222,6 +222,9 @@ mb:
           weight_regular: Звичайний
           weight_bold: Напівжирний
           weight_italic: Курсив
+          font_style: Стиль
+          style_normal: Звичайний
+          style_italic: Курсив
           font_color: Колір шрифту
           font_opacity: Непрозорість шрифту
           preview_legend: Попередній перегляд

--- a/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
@@ -155,7 +155,7 @@
                             <input data-prop="label" type="text" class="form-control" value="{{ _visual.label ?? '' }}" placeholder="e.g. ${name}">
                         </div>
                         <div class="row">
-                            <div class="col-sm-6">
+                            <div class="col-sm-4">
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_family' | trans }}</label>
                                     <select data-prop="fontFamily" class="form-select">
@@ -178,7 +178,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="col-sm-3">
+                            <div class="col-sm-2">
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_size' | trans }}</label>
                                     <input data-prop="fontSize" type="number" min="5" max="30" class="form-control" value="{{ _visual.fontSize ?? 11 }}">
@@ -188,9 +188,19 @@
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_weight' | trans }}</label>
                                     <select data-prop="fontWeight" class="form-select">
-                                        <option value="regular"{{ _visual.fontWeight == 'regular' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
-                                        <option value="bold"{{ _visual.fontWeight == 'bold' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_bold' | trans }}</option>
-                                        <option value="italic"{{ _visual.fontWeight == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_italic' | trans }}</option>
+                                        <option value="regular"{{ (_visual.fontWeight ?? 'regular') not in ['bold'] ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
+                                        <option value="bold"{{ (_visual.fontWeight ?? '') == 'bold' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_bold' | trans }}</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-sm-3">
+                                <div class="mb-3">
+                                    <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_style' | trans }}</label>
+                                    {# backward compat: old styles stored italic in fontWeight #}
+                                    {% set _effectiveFontStyle = _visual.fontStyle ?? (_visual.fontWeight == 'italic' ? 'italic' : 'normal') %}
+                                    <select data-prop="fontStyle" class="form-select">
+                                        <option value="normal"{{ _effectiveFontStyle != 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_normal' | trans }}</option>
+                                        <option value="italic"{{ _effectiveFontStyle == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_italic' | trans }}</option>
                                     </select>
                                 </div>
                             </div>

--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesConfigGenerator.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesConfigGenerator.php
@@ -59,6 +59,8 @@ class OgcApiFeaturesConfigGenerator extends SourceInstanceConfigGenerator
             ],
             'featureInfo' => [
                 'propertyMap' => $featureInfoPropertyMapExists ? $featureInfoPropertyMap : null,
+                'template' => $sourceInstance->getFeatureInfoTemplate() ?: null,
+                'mode' => $sourceInstance->getFeatureInfoMode(),
             ],
         ];
         $config['state'] = [
@@ -96,10 +98,16 @@ class OgcApiFeaturesConfigGenerator extends SourceInstanceConfigGenerator
                     $childConfig['options']['availableStyles'] = $availableStyles;
                 }
                 $tooltipMap = $layer->getTooltipPropertyMap();
-                if ($tooltipMap) {
-                    $childConfig['options']['tooltip'] = [
-                        'propertyMap' => $tooltipMap,
-                    ];
+                $tooltipTemplate = $layer->getTooltipTemplate();
+                $tooltipMode = $layer->getTooltipMode();
+                if ($tooltipMap || $tooltipTemplate) {
+                    $childConfig['options']['tooltip'] = ['mode' => $tooltipMode];
+                    if ($tooltipMap) {
+                        $childConfig['options']['tooltip']['propertyMap'] = $tooltipMap;
+                    }
+                    if ($tooltipTemplate) {
+                        $childConfig['options']['tooltip']['template'] = $tooltipTemplate;
+                    }
                 }
                 $propertyTitles = $layer->getSourceItem()->getPropertyTitles();
                 if ($propertyTitles) {

--- a/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesInstance.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesInstance.php
@@ -47,6 +47,13 @@ class OgcApiFeaturesInstance extends SourceInstance
     #[ORM\Column(name: 'feature_info_property_map', type: 'text', nullable: true)]
     protected ?string $featureInfoPropertyMap = "";
 
+    #[ORM\Column(name: 'feature_info_template', type: 'text', nullable: true)]
+    protected ?string $featureInfoTemplate = null;
+
+    /** Persisted mode selection: 'props' or 'template'. Null defaults to 'props'. */
+    #[ORM\Column(name: 'feature_info_mode', type: 'string', length: 16, nullable: true)]
+    protected ?string $featureInfoMode = null;
+
     public function __construct()
     {
         $this->layers = new ArrayCollection();
@@ -190,6 +197,28 @@ class OgcApiFeaturesInstance extends SourceInstance
     public function setFeatureInfoPropertyMap(?string $featureInfoPropertyMap): static
     {
         $this->featureInfoPropertyMap = $featureInfoPropertyMap;
+        return $this;
+    }
+
+    public function getFeatureInfoTemplate(): ?string
+    {
+        return $this->featureInfoTemplate;
+    }
+
+    public function setFeatureInfoTemplate(?string $featureInfoTemplate): static
+    {
+        $this->featureInfoTemplate = $featureInfoTemplate ?: null;
+        return $this;
+    }
+
+    public function getFeatureInfoMode(): string
+    {
+        return $this->featureInfoMode ?? 'props';
+    }
+
+    public function setFeatureInfoMode(?string $featureInfoMode): static
+    {
+        $this->featureInfoMode = ($featureInfoMode === 'template') ? 'template' : null;
         return $this;
     }
 

--- a/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesInstanceLayer.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Entity/OgcApiFeaturesInstanceLayer.php
@@ -57,6 +57,13 @@ class OgcApiFeaturesInstanceLayer extends SourceInstanceItem
     #[ORM\Column(name: 'tooltip_property_map', type: 'json', nullable: true)]
     protected ?array $tooltipPropertyMap = null;
 
+    #[ORM\Column(name: 'tooltip_template', type: 'text', nullable: true)]
+    protected ?string $tooltipTemplate = null;
+
+    /** Persisted mode selection: 'props' or 'template'. Null defaults to 'props'. */
+    #[ORM\Column(name: 'tooltip_mode', type: 'string', length: 16, nullable: true)]
+    protected ?string $tooltipMode = null;
+
     public function setMinScale(?float $value): static
     {
         $this->minScale = ($value === null || $value == INF) ? null : floatval($value);
@@ -202,6 +209,28 @@ class OgcApiFeaturesInstanceLayer extends SourceInstanceItem
     public function setTooltipPropertyMap(?array $tooltipPropertyMap): static
     {
         $this->tooltipPropertyMap = $tooltipPropertyMap;
+        return $this;
+    }
+
+    public function getTooltipTemplate(): ?string
+    {
+        return $this->tooltipTemplate;
+    }
+
+    public function setTooltipTemplate(?string $tooltipTemplate): static
+    {
+        $this->tooltipTemplate = $tooltipTemplate ?: null;
+        return $this;
+    }
+
+    public function getTooltipMode(): string
+    {
+        return $this->tooltipMode ?? 'props';
+    }
+
+    public function setTooltipMode(?string $tooltipMode): static
+    {
+        $this->tooltipMode = ($tooltipMode === 'template') ? 'template' : null;
         return $this;
     }
 }

--- a/src/Mapbender/OgcApiFeaturesBundle/Form/Type/OgcApiFeaturesInstanceLayerType.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Form/Type/OgcApiFeaturesInstanceLayerType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -100,6 +101,18 @@ class OgcApiFeaturesInstanceLayerType extends AbstractType
             ])
             ->add('tooltipPropertyMap', HiddenType::class, [
                 'required' => false,
+            ])
+            ->add('tooltipMode', HiddenType::class, [
+                'required' => false,
+            ])
+            ->add('tooltipTemplate', TextareaType::class, [
+                'required' => false,
+                'label' => false,
+                'attr' => [
+                    'class' => 'form-control form-control-sm tooltip-template-textarea',
+                    'rows' => 6,
+                    'placeholder' => '<b>${name}</b><br>Year: ${year}',
+                ],
             ])
         ;
         $builder->get('tooltipPropertyMap')->addModelTransformer(new JsonArrayTransformer());

--- a/src/Mapbender/OgcApiFeaturesBundle/Form/Type/OgcApiFeaturesInstanceType.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Form/Type/OgcApiFeaturesInstanceType.php
@@ -4,7 +4,9 @@ namespace Mapbender\OgcApiFeaturesBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -67,6 +69,18 @@ class OgcApiFeaturesInstanceType extends AbstractType
                 'help' => 'mb.vectortiles.admin.featureinfo.property_map_help',
                 'json_encode' => true,
             ], $this->translator))
+            ->add('featureInfoTemplate', TextareaType::class, [
+                'required' => false,
+                'label' => 'mb.ogcapifeatures.admin.featureinfo_template.heading',
+                'attr' => [
+                    'class' => 'form-control featureinfo-template-textarea',
+                    'rows' => 6,
+                    'placeholder' => '<b>${name}</b><br>Year: ${year}',
+                ],
+            ])
+            ->add('featureInfoMode', HiddenType::class, [
+                'required' => false,
+            ])
             ->add('layers', CollectionType::class, [
                 'entry_type' => OgcApiFeaturesInstanceLayerType::class,
                 'entry_options' => [

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/edit-instance.css
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/edit-instance.css
@@ -61,10 +61,14 @@
 .dropdownList .choice.filter-kept { font-style: italic; color: #6c757d; }
 
 /* ── Tooltip property checkboxes ── */
-.tooltip-checkbox-list { max-height: 250px; overflow-y: auto; padding: 6px 0; border: 1px solid #dee2e6; border-radius: 4px; padding: 8px; }
-.tooltip-prop-check { margin-bottom: 2px; }
-.tooltip-prop-check .form-check-label { user-select: none; }
+.tooltip-checkbox-list { max-height: 250px; overflow-y: auto; border: 1px solid #dee2e6; border-radius: 4px; padding: 8px; }
+.tooltip-prop-check { display: grid; grid-template-columns: 16px 110px 20px 150px; align-items: center; column-gap: 6px; margin-bottom: 4px; cursor: move; }
+.tooltip-prop-check .form-check-input { grid-column: 1; margin: 0; }
+.tooltip-prop-check .form-check-label { grid-column: 2; user-select: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tooltip-prop-label-toggle { grid-column: 3; text-align: center; font-size: 0.9em; line-height: 1; color: #6c757d; text-decoration: none; }
+.tooltip-prop-label-toggle:hover { color: #0d6efd; }
 .tooltip-prop-check .prop-key { color: #6c757d; font-size: 0.85em; }
+.tooltip-prop-label-input { grid-column: 4; font-size: 0.8em; padding: 1px 5px; border: 1px solid #adb5bd; border-radius: 3px; background: #fff; width: 100%; box-sizing: border-box; }
 
 /* ── Tooltip property drag-and-drop ── */
 .tooltip-prop-check.tooltip-prop-dragging {

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/edit-instance.css
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/edit-instance.css
@@ -65,3 +65,15 @@
 .tooltip-prop-check { margin-bottom: 2px; }
 .tooltip-prop-check .form-check-label { user-select: none; }
 .tooltip-prop-check .prop-key { color: #6c757d; font-size: 0.85em; }
+
+/* ── Tooltip property drag-and-drop ── */
+.tooltip-prop-check.tooltip-prop-dragging {
+    opacity: 0.5;
+    background-color: #f0f0f0;
+}
+
+.tooltip-prop-check.tooltip-prop-drag-over {
+    background-color: #e7f3ff;
+    border-radius: 4px;
+    transition: background-color 0.15s;
+}

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/ogc-api-tooltip.css
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/css/ogc-api-tooltip.css
@@ -2,20 +2,24 @@
     background: rgba(255, 255, 255, 0.95);
     border: 1px solid #ccc;
     border-radius: 6px;
-    padding: 8px 12px;
+    padding: 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     font-size: 13px;
-    line-height: 1.4;
-    max-width: 320px;
-    pointer-events: none;
+    line-height: 1.5;
+    max-width: 500px;
+    width: fit-content;
+    pointer-events: auto;
     z-index: 10000;
-    white-space: nowrap;
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 .ogc-api-tooltip-row {
     display: flex;
     gap: 8px;
-    padding: 2px 0;
+    padding: 4px 0;
     border-bottom: 1px solid #eee;
+    align-items: flex-start;
 }
 .ogc-api-tooltip-row:last-child {
     border-bottom: none;
@@ -24,12 +28,13 @@
     font-weight: 600;
     color: #555;
     flex-shrink: 0;
+    min-width: fit-content;
 }
 .ogc-api-tooltip-key::after {
     content: ':';
 }
 .ogc-api-tooltip-val {
     color: #222;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
+    flex: 1;
 }

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -373,6 +373,15 @@ class OgcApiSource extends Mapbender.Source {
 
     _buildTooltipContent(feature, child) {
         const properties = feature.getProperties();
+        // Use explicit mode field; fall back to 'template' if template is set but mode is missing
+        const mode = child.options.tooltip?.mode
+            || (child.options.tooltip?.template ? 'template' : 'props');
+        if (mode === 'template') {
+            const template = child.options.tooltip?.template;
+            if (template) {
+                return this._renderHtmlTemplate(template, properties);
+            }
+        }
         const propertyMap = this._getChildTooltipMap(child);
         const propertyTitles = child.options.propertyTitles || {};
         const skipKeys = new Set(['geometry', 'layer', 'featureTitle']);
@@ -405,6 +414,20 @@ class OgcApiSource extends Mapbender.Source {
         if (this._tooltipElement) {
             this._tooltipElement.style.display = 'none';
         }
+    }
+
+    /**
+     * Resolves ${propertyName} placeholders in an HTML template string against feature properties.
+     * Returns a <div> wrapping the rendered HTML, or null if the template produces no visible content.
+     */
+    _renderHtmlTemplate(template, properties) {
+        const html = template.replace(/\$\{([^}]+)\}/g, (_, key) => {
+            const val = properties[key];
+            return val != null ? String(val) : '';
+        });
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = html;
+        return wrapper;
     }
 
     _getChildTooltipMap(child) {
@@ -489,6 +512,19 @@ class OgcApiSource extends Mapbender.Source {
             h5.className = 'featureinfo__title mt-3';
             h5.textContent = label;
             geometryDiv.appendChild(h5);
+        }
+        // HTML template mode: use instance-level featureInfoTemplate if defined
+        const featureInfoMode = this.options.featureInfo?.mode
+            || (this.options.featureInfo?.template ? 'template' : 'props');
+        if (featureInfoMode === 'template') {
+            const featureInfoTemplate = this.options.featureInfo?.template;
+            if (featureInfoTemplate) {
+                const rendered = this._renderHtmlTemplate(featureInfoTemplate, properties);
+                if (rendered) {
+                    geometryDiv.appendChild(rendered);
+                }
+                return geometryDiv;
+            }
         }
         const table = document.createElement('table');
         table.className = 'table table-striped table-bordered table-condensed featureinfo__table';

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -39,7 +39,8 @@ class OgcApiSource extends Mapbender.Source {
         const r = parseInt(hex.substring(0,2), 16);
         const g = parseInt(hex.substring(2,4), 16);
         const b = parseInt(hex.substring(4,6), 16);
-        return [r, g, b, parseFloat(opacity) || 1];
+        const alpha = parseFloat(opacity);
+        return [r, g, b, isNaN(alpha) ? 1 : alpha];
     }
 
     _getDashArray(dashStyle) {

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -113,8 +113,10 @@ class OgcApiSource extends Mapbender.Source {
         }
 
         const labelTemplate = s.label;
+        const fontWeight = s.fontWeight === 'bold' ? 'bold' : 'normal';
+        const fontStyle = s.fontStyle === 'italic' ? 'italic' : (s.fontWeight === 'italic' ? 'italic' : 'normal');
         const textBaseOptions = {
-            font: (s.fontSize || '12') + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
+            font: `${fontStyle} ${fontWeight} ${s.fontSize || 12}px ${s.fontFamily || 'Arial, Helvetica, sans-serif'}`,
             fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),
         };
 

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -387,11 +387,15 @@ class OgcApiSource extends Mapbender.Source {
         const skipKeys = new Set(['geometry', 'layer', 'featureTitle']);
         const fragment = document.createDocumentFragment();
         let count = 0;
-        for (const [key, value] of Object.entries(properties)) {
+        // When propertyMap is set, iterate its keys in saved order; otherwise use feature property order
+        const keys = propertyMap
+            ? Object.keys(propertyMap)
+            : Object.keys(properties);
+        for (const key of keys) {
             if (skipKeys.has(key)) continue;
+            const value = properties[key];
             if (value == null || value === '') continue;
             if (typeof value === 'object') continue;
-            if (propertyMap && !propertyMap[key]) continue;
             const row = document.createElement('div');
             row.className = 'ogc-api-tooltip-row';
             const label = document.createElement('span');

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -244,7 +244,9 @@ class OgcApiSource extends Mapbender.Source {
                     // expression evaluator (EvaluationContext.properties()) can read them.
                     // That method accesses feature.properties (GeoJSON convention), not OL's
                     // feature.get(). Without this, ['get', 'prop'] in filters returns undefined.
-                    f.properties = f.getProperties();
+                    const propsCopy = Object.assign({}, f.getProperties());
+                    delete propsCopy.geometry;
+                    f.properties = propsCopy;
                 });
                 source.clear(true);
                 source.addFeatures(parsed);

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -154,32 +154,57 @@ class OgcApiSource extends Mapbender.Source {
     }
 
     _applyMapboxStyle(vectorLayer, mbStyle, collectionId) {
-        // Find the source name that uses our collectionId as source-layer
-        let sourceName = null;
-        for (const layer of (mbStyle.layers || [])) {
-            if (layer['source-layer'] === collectionId && layer.source) {
-                sourceName = layer.source;
-                break;
-            }
-        }
-        // Fallback: use first vector/geojson source
-        if (!sourceName) {
-            for (const [name, src] of Object.entries(mbStyle.sources || {})) {
-                if (src.type === 'vector' || src.type === 'geojson') {
-                    sourceName = name;
-                    break;
-                }
-            }
-        }
-        if (!sourceName) {
+        const resolved = this._resolveMapboxSource(mbStyle, collectionId);
+        if (!resolved) {
             return;
         }
+        if (!this._mapboxSourceLayers) this._mapboxSourceLayers = {};
+        this._mapboxSourceLayers[collectionId] = resolved.effectiveSourceLayer;
         vectorLayer.set('_collectionId', collectionId);
         try {
-            ol.mapboxStyle.stylefunction(vectorLayer, mbStyle, sourceName);
+            ol.mapboxStyle.stylefunction(vectorLayer, mbStyle, resolved.sourceName);
         } catch (e) {
             console.error('[OgcApiStyle] ol.mapboxStyle.stylefunction failed for "' + collectionId + '":', e);
         }
+    }
+
+    /**
+     * Resolves the Mapbox source name and the effective source-layer for a given collectionId.
+     *
+     * The collectionId may differ from the style's source-layer name when the style was built
+     * for an MVT dataset with a different layer name. The stylefunction looks up styles via
+     * l[feature.getProperties()['mvt:layer']], so features must be tagged with the source-layer
+     * name from the style, not the collectionId.
+     *
+     * @returns {{sourceName: string, effectiveSourceLayer: string}|null}
+     */
+    _resolveMapboxSource(mbStyle, collectionId) {
+        // Prefer an exact match: a style layer whose source-layer equals the collectionId
+        for (const layer of (mbStyle.layers || [])) {
+            if (layer['source-layer'] === collectionId && layer.source) {
+                return { sourceName: layer.source, effectiveSourceLayer: collectionId };
+            }
+        }
+        // Fallback: use the first vector/geojson source in the style
+        let sourceName = null;
+        for (const [name, src] of Object.entries(mbStyle.sources || {})) {
+            if (src.type === 'vector' || src.type === 'geojson') {
+                sourceName = name;
+                break;
+            }
+        }
+        if (!sourceName) {
+            return null;
+        }
+        // Find the first source-layer referenced by that source
+        let effectiveSourceLayer = collectionId;
+        for (const layer of (mbStyle.layers || [])) {
+            if (layer.source === sourceName && layer['source-layer']) {
+                effectiveSourceLayer = layer['source-layer'];
+                break;
+            }
+        }
+        return { sourceName, effectiveSourceLayer };
     }
 
     _loadCollection(collectionId, extent, resolution, projection, source) {
@@ -202,6 +227,7 @@ class OgcApiSource extends Mapbender.Source {
             })
             .then((data) => {
                 if (requestId !== this._currentRequestIds[collectionId]) {
+                    console.warn(`Discarding response for collection "${collectionId}" due to newer request`);
                     return;
                 }
                 const parsed = geojsonReader.readFeatures(data, {
@@ -210,9 +236,15 @@ class OgcApiSource extends Mapbender.Source {
                 });
                 // Set 'layer' property for internal use (tooltips, identification)
                 // Set 'mvt:layer' property so ol-mapbox-style's stylefunction can match source-layer
+                const mvtLayer = this._mapboxSourceLayers?.[collectionId] ?? collectionId;
                 parsed.forEach(f => {
                     f.set('layer', collectionId, true);
-                    f.set('mvt:layer', collectionId, true);
+                    f.set('mvt:layer', mvtLayer, true);
+                    // Expose properties on the feature object itself so the ol-mapbox-style
+                    // expression evaluator (EvaluationContext.properties()) can read them.
+                    // That method accesses feature.properties (GeoJSON convention), not OL's
+                    // feature.get(). Without this, ['get', 'prop'] in filters returns undefined.
+                    f.properties = f.getProperties();
                 });
                 source.clear(true);
                 source.addFeatures(parsed);

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.sourcelayer.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.sourcelayer.js
@@ -1,3 +1,6 @@
+/** OGC API Features Part 1 mandates bounding boxes are always in WGS 84 */
+const OGC_API_BBOX_CRS = 'EPSG:4326';
+
 class OgcApiSourceLayer extends Mapbender.SourceLayer {
 
     constructor(definition, source, parent) {
@@ -9,19 +12,18 @@ class OgcApiSourceLayer extends Mapbender.SourceLayer {
     }
 
     getBounds(projCode, inheritFromParent) {
-        // bbox is always in WGS 84
-        const bounds = this.source._bboxArrayToBounds(this.options.bbox, 'EPSG:4326');
-        return Mapbender.mapEngine.transformBounds(bounds, 'EPSG:4326', projCode);
+        const bounds = this.source._bboxArrayToBounds(this.options.bbox, OGC_API_BBOX_CRS);
+        return Mapbender.mapEngine.transformBounds(bounds, OGC_API_BBOX_CRS, projCode);
     }
 
     intersectsExtent(extent, srsName) {
         if (!this.hasBounds()) {
             return true;
         }
-        const extent_ = srsName !== 'EPSG:4326'
-            ? Mapbender.mapEngine.transformBounds(extent, srsName, 'EPSG:4326')
+        const extent_ = srsName !== OGC_API_BBOX_CRS
+            ? Mapbender.mapEngine.transformBounds(extent, srsName, OGC_API_BBOX_CRS)
             : extent;
-        const layerBounds = this.source._bboxArrayToBounds(this.options.bbox, 'EPSG:4326');
+        const layerBounds = this.source._bboxArrayToBounds(this.options.bbox, OGC_API_BBOX_CRS);
         return Mapbender.Util.extentsIntersect(extent_, layerBounds);
     }
 }

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/mode-switcher.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/mode-switcher.js
@@ -1,0 +1,35 @@
+/**
+ * Generic mode-switcher utility (props / template toggle).
+ * Used by per-layer tooltip popovers (StyleInstanceEditor) and
+ * the page-level feature info section.
+ */
+
+function initModeSwitcher(switcher, propsPanel, templatePanel, modeInput, initialMode) {
+    if (!switcher) return;
+    setMode(switcher, propsPanel, templatePanel, modeInput, initialMode);
+    switcher.querySelectorAll('input[type="radio"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            setMode(switcher, propsPanel, templatePanel, modeInput, radio.value);
+        });
+    });
+}
+
+function setMode(switcher, propsPanel, templatePanel, modeInput, mode) {
+    switcher.querySelectorAll('input[type="radio"]').forEach(r => { r.checked = r.value === mode; });
+    if (propsPanel)    propsPanel.style.display    = mode === 'props'    ? '' : 'none';
+    if (templatePanel) templatePanel.style.display = mode === 'template' ? '' : 'none';
+    if (modeInput) modeInput.value = mode === 'template' ? 'template' : '';
+}
+
+// Feature info mode switcher — page-level, independent of the layer table
+$(function() {
+    const modeInput = document.querySelector('input[id$="_featureInfoMode"]');
+    const initialMode = modeInput?.value === 'template' ? 'template' : 'props';
+    initModeSwitcher(
+        document.querySelector('.featureinfo-mode-switcher'),
+        document.querySelector('.featureinfo-props-panel'),
+        document.querySelector('.featureinfo-template-panel'),
+        modeInput,
+        initialMode
+    );
+});

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
@@ -73,7 +73,10 @@ class StyleInstanceEditor {
                 const body = $target.find('.popover-body')[0];
                 if (body) this.updatePreview(body);
                 const row = $trigger.closest('tr')[0];
-                if (body && row) this._initTooltipCheckboxes(body, row);
+                if (body && row) {
+                    this._initTooltipCheckboxes(body, row);
+                    this._initTooltipMode(body, row);
+                }
             }
         });
 
@@ -482,6 +485,13 @@ class StyleInstanceEditor {
         }
 
         this._renderCheckboxes(container, propNames, selected, hiddenInput, propertyTitles);
+
+        // Also build prop tag buttons for the tooltip template panel
+        const templateTagsContainer = popoverBody.querySelector('.template-prop-tags');
+        const templateTextarea = popoverBody.querySelector('.tooltip-template-textarea');
+        if (templateTagsContainer && templateTextarea) {
+            this._buildPropTags(templateTagsContainer, propNames, propertyTitles, templateTextarea);
+        }
     }
 
     _renderCheckboxes(container, propNames, selected, hiddenInput, propertyTitles) {
@@ -534,5 +544,133 @@ class StyleInstanceEditor {
         });
         hiddenInput.value = checked.length > 0 ? JSON.stringify(checked) : '';
     }
+
+    // ── Tooltip Mode Switcher ──
+
+    _initTooltipMode(popoverBody, row) {
+        if (popoverBody.dataset.tooltipModeInit === 'true') return;
+        popoverBody.dataset.tooltipModeInit = 'true';
+
+        const switcher = popoverBody.querySelector('.tooltip-mode-switcher');
+        if (!switcher) return;
+
+        // Read persisted mode from the hidden form field
+        const modeInput = popoverBody.querySelector('input[id$="_tooltipMode"]');
+        const initialMode = (modeInput && modeInput.value === 'template') ? 'template' : 'props';
+        this._setTooltipMode(popoverBody, initialMode);
+
+        // Wire radio buttons
+        switcher.querySelectorAll('input[type="radio"]').forEach(radio => {
+            radio.addEventListener('change', () => {
+                this._setTooltipMode(popoverBody, radio.value);
+            });
+        });
+    }
+
+    _setTooltipMode(popoverBody, mode) {
+        const switcher = popoverBody.querySelector('.tooltip-mode-switcher');
+        if (!switcher) return;
+
+        const propsPanel = popoverBody.querySelector('.tooltip-props-panel');
+        const templatePanel = popoverBody.querySelector('.tooltip-template-panel');
+        const modeInput = popoverBody.querySelector('input[id$="_tooltipMode"]');
+        const radios = switcher.querySelectorAll('input[type="radio"]');
+
+        radios.forEach(r => { r.checked = r.value === mode; });
+        if (propsPanel)    propsPanel.style.display    = mode === 'props'    ? '' : 'none';
+        if (templatePanel) templatePanel.style.display = mode === 'template' ? '' : 'none';
+        // Persist the selection in the hidden form field
+        if (modeInput) modeInput.value = mode === 'template' ? 'template' : '';
+    }
+
+    // ── Property Tag Buttons (for HTML templates) ──
+
+    /**
+     * Builds clickable property tag buttons that insert ${propertyName} into the target textarea.
+     */
+    _buildPropTags(container, propNames, propertyTitles, targetTextarea) {
+        container.innerHTML = '';
+        if (!propNames.length) {
+            const msg = document.createElement('span');
+            msg.className = 'text-muted small';
+            msg.textContent = Mapbender.trans('mb.ogcapifeatures.admin.tooltip.no_properties');
+            container.appendChild(msg);
+            return;
+        }
+        propNames.forEach(prop => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-outline-secondary btn-sm prop-tag-btn';
+            const title = propertyTitles?.[prop];
+            btn.textContent = title ? title + ' (' + prop + ')' : prop;
+            btn.title = '${' + prop + '}';
+            btn.addEventListener('click', () => {
+                this._insertAtCursor(targetTextarea, '${' + prop + '}');
+            });
+            container.appendChild(btn);
+        });
+    }
+
+    _insertAtCursor(textarea, text) {
+        if (!textarea) return;
+        textarea.focus();
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const before = textarea.value.substring(0, start);
+        const after = textarea.value.substring(end);
+        textarea.value = before + text + after;
+        textarea.selectionStart = textarea.selectionEnd = start + text.length;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    // ── Feature Info Template ──
+
+    _initFeatureInfoTemplate(popoverBody, row) {
+        if (popoverBody.dataset.featureInfoTemplateInit === 'true') return;
+        popoverBody.dataset.featureInfoTemplateInit = 'true';
+
+        const tagsContainer = popoverBody.querySelector('.featureinfo-prop-tags');
+        const textarea = popoverBody.querySelector('.featureinfo-template-textarea');
+        if (!tagsContainer || !textarea) return;
+
+        let propNames = [];
+        try { propNames = JSON.parse(row.dataset.properties || '[]'); } catch(e) {}
+        if (!Array.isArray(propNames)) propNames = [];
+
+        let propertyTitles = {};
+        try { propertyTitles = JSON.parse(row.dataset.propertyTitles || '{}'); } catch(e) {}
+
+        this._buildPropTags(tagsContainer, propNames, propertyTitles, textarea);
+    }
 }
-$(function() { new StyleInstanceEditor(); });
+$(function() {
+    new StyleInstanceEditor();
+    _initFeatureInfoModeSwitcher();
+});
+
+function _initFeatureInfoModeSwitcher() {
+    const switcher = document.querySelector('.featureinfo-mode-switcher');
+    if (!switcher) return;
+
+    const propsPanel = document.querySelector('.featureinfo-props-panel');
+    const templatePanel = document.querySelector('.featureinfo-template-panel');
+    const modeInput = document.querySelector('input[id$="_featureInfoMode"]');
+
+    // Determine initial mode: read from persisted hidden field
+    const initialMode = (modeInput && modeInput.value === 'template') ? 'template' : 'props';
+    _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, initialMode);
+
+    switcher.querySelectorAll('input[type="radio"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, radio.value);
+        });
+    });
+}
+
+function _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, mode) {
+    switcher.querySelectorAll('input[type="radio"]').forEach(r => { r.checked = r.value === mode; });
+    if (propsPanel)    propsPanel.style.display    = mode === 'props'    ? '' : 'none';
+    if (templatePanel) templatePanel.style.display = mode === 'template' ? '' : 'none';
+    // Persist the selection in the hidden form field
+    if (modeInput) modeInput.value = mode === 'template' ? 'template' : '';
+}

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
@@ -503,10 +503,19 @@ class StyleInstanceEditor {
             return;
         }
 
-        propNames.forEach(prop => {
+        // Restore saved order: selected props first (in their saved sequence), then remaining
+        const orderedProps = [
+            ...selected.filter(p => propNames.includes(p)),
+            ...propNames.filter(p => !selected.includes(p))
+        ];
+
+        orderedProps.forEach((prop) => {
             const id = 'tooltip_cb_' + Math.random().toString(36).substr(2, 6);
             const wrapper = document.createElement('div');
             wrapper.className = 'form-check tooltip-prop-check';
+            wrapper.draggable = true;
+            wrapper.dataset.prop = prop;
+            wrapper.style.cursor = 'move';
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
@@ -532,6 +541,46 @@ class StyleInstanceEditor {
 
             wrapper.appendChild(cb);
             wrapper.appendChild(label);
+            
+            // Drag event handlers
+            wrapper.addEventListener('dragstart', (e) => {
+                e.dataTransfer.effectAllowed = 'move';
+                wrapper.classList.add('tooltip-prop-dragging');
+            });
+            
+            wrapper.addEventListener('dragend', () => {
+                wrapper.classList.remove('tooltip-prop-dragging');
+                container.querySelectorAll('.tooltip-prop-check').forEach(w => {
+                    w.classList.remove('tooltip-prop-drag-over');
+                });
+                this._syncTooltipHidden(container, hiddenInput);
+            });
+            
+            wrapper.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+                const dragging = container.querySelector('.tooltip-prop-dragging');
+                if (dragging && dragging !== wrapper) {
+                    wrapper.classList.add('tooltip-prop-drag-over');
+                    // Insert before or after depending on cursor position
+                    const rect = wrapper.getBoundingClientRect();
+                    const midY = rect.top + rect.height / 2;
+                    if (e.clientY < midY) {
+                        container.insertBefore(dragging, wrapper);
+                    } else {
+                        container.insertBefore(dragging, wrapper.nextSibling);
+                    }
+                }
+            });
+            
+            wrapper.addEventListener('dragleave', () => {
+                wrapper.classList.remove('tooltip-prop-drag-over');
+            });
+            
+            wrapper.addEventListener('drop', () => {
+                this._syncTooltipHidden(container, hiddenInput);
+            });
+
             container.appendChild(wrapper);
         });
     }
@@ -539,6 +588,7 @@ class StyleInstanceEditor {
     _syncTooltipHidden(container, hiddenInput) {
         if (!hiddenInput) return;
         const checked = [];
+        // Read in DOM order to respect drag-and-drop reordering
         container.querySelectorAll('input[type="checkbox"]:checked').forEach(cb => {
             checked.push(cb.value);
         });

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/js/style-instance-editor.js
@@ -54,13 +54,22 @@ class StyleInstanceEditor {
     // ── Events ──
 
     _bindEvents() {
+        this._bindStyleEvents();
+        this._bindPopoverEvents();
+        this._bindFilterEvents();
+        this._bindSecondaryStyleEvents();
+    }
+
+    _bindStyleEvents() {
         $(document).on('change', 'select[id$="_styleId"]', (e) => {
             const popoverBody = e.target.closest('.popover-body');
             if (popoverBody) this.updatePreview(popoverBody);
             this._updateNativeStyleIndicator(e.target);
             this._updateChangedIndicator(e.target);
         });
+    }
 
+    _bindPopoverEvents() {
         this.$table.on('click', '.-fn-toggle-layer-detail', (e) => {
             const $trigger = $(e.currentTarget);
             const target = $trigger.attr('data-toggle-target');
@@ -100,7 +109,9 @@ class StyleInstanceEditor {
                 this._updateSecondaryCount(secSelect);
             }
         });
+    }
 
+    _bindFilterEvents() {
         this.$table.on('click', '.-fn-apply-style-filter', (e) => {
             e.preventDefault();
             const row = e.currentTarget.closest('.style-filter-row');
@@ -120,8 +131,9 @@ class StyleInstanceEditor {
             this._applyFilters();
             this._updateFilterButtons();
         });
+    }
 
-        // Secondary styles: toggle panel
+    _bindSecondaryStyleEvents() {
         this.$table.on('click', '.-fn-toggle-secondary-styles', (e) => {
             e.preventDefault();
             const section = e.currentTarget.closest('.secondary-styles-section');
@@ -133,7 +145,6 @@ class StyleInstanceEditor {
             arrow.classList.toggle('fa-chevron-up', !visible);
         });
 
-        // Secondary styles: apply filter
         this.$table.on('click', '.-fn-apply-sec-filter', (e) => {
             e.preventDefault();
             const row = e.currentTarget.closest('.secondary-filter-row');
@@ -145,7 +156,6 @@ class StyleInstanceEditor {
             this._applySecFilters();
         });
 
-        // Secondary styles: reset filter
         this.$table.on('click', '.-fn-reset-sec-filter', (e) => {
             e.preventDefault();
             this._secFilterState = { name: '', origin: '', source: this.sourceId };
@@ -153,7 +163,6 @@ class StyleInstanceEditor {
             this._applySecFilters();
         });
 
-        // Secondary styles: update badge on selection change
         this.$table.on('change', '.secondary-style-select', (e) => {
             this._updateSecondaryCount(e.target);
         });
@@ -503,134 +512,180 @@ class StyleInstanceEditor {
             return;
         }
 
-        // Restore saved order: selected props first (in their saved sequence), then remaining
+        const { selectedKeys, savedLabels } = this._parseSelectedEntries(selected);
         const orderedProps = [
-            ...selected.filter(p => propNames.includes(p)),
-            ...propNames.filter(p => !selected.includes(p))
+            ...selectedKeys.filter(p => propNames.includes(p)),
+            ...propNames.filter(p => !selectedKeys.includes(p))
         ];
 
-        orderedProps.forEach((prop) => {
-            const id = 'tooltip_cb_' + Math.random().toString(36).substr(2, 6);
-            const wrapper = document.createElement('div');
-            wrapper.className = 'form-check tooltip-prop-check';
-            wrapper.draggable = true;
-            wrapper.dataset.prop = prop;
-            wrapper.style.cursor = 'move';
+        orderedProps.forEach(prop => {
+            const row = this._buildCheckboxRow(prop, selectedKeys, savedLabels, propertyTitles, container, hiddenInput);
+            container.appendChild(row);
+        });
+    }
 
-            const cb = document.createElement('input');
-            cb.type = 'checkbox';
-            cb.className = 'form-check-input';
-            cb.id = id;
-            cb.value = prop;
-            cb.checked = selected.includes(prop);
-            cb.addEventListener('change', () => this._syncTooltipHidden(container, hiddenInput));
-
-            const label = document.createElement('label');
-            label.className = 'form-check-label small';
-            label.htmlFor = id;
-            const title = propertyTitles?.[prop];
-            if (title) {
-                label.textContent = title + ' ';
-                const keySpan = document.createElement('span');
-                keySpan.className = 'prop-key';
-                keySpan.textContent = '(' + prop + ')';
-                label.appendChild(keySpan);
-            } else {
-                label.textContent = prop;
+    _parseSelectedEntries(selected) {
+        const selectedKeys = selected.map(e => (typeof e === 'string' ? e : Object.keys(e)[0]));
+        const savedLabels = {};
+        selected.forEach(e => {
+            if (typeof e !== 'string') {
+                const [k, v] = Object.entries(e)[0];
+                savedLabels[k] = v;
             }
+        });
+        return { selectedKeys, savedLabels };
+    }
 
-            wrapper.appendChild(cb);
-            wrapper.appendChild(label);
-            
-            // Drag event handlers
-            wrapper.addEventListener('dragstart', (e) => {
-                e.dataTransfer.effectAllowed = 'move';
-                wrapper.classList.add('tooltip-prop-dragging');
-            });
-            
-            wrapper.addEventListener('dragend', () => {
-                wrapper.classList.remove('tooltip-prop-dragging');
-                container.querySelectorAll('.tooltip-prop-check').forEach(w => {
-                    w.classList.remove('tooltip-prop-drag-over');
-                });
+    _buildCheckboxRow(prop, selectedKeys, savedLabels, propertyTitles, container, hiddenInput) {
+        const id = 'tooltip_cb_' + Math.random().toString(36).substr(2, 6);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'tooltip-prop-check';
+        wrapper.draggable = true;
+        wrapper.dataset.prop = prop;
+        wrapper.style.cursor = 'move';
+
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'form-check-input';
+        cb.id = id;
+        cb.value = prop;
+        cb.checked = selectedKeys.includes(prop);
+        cb.addEventListener('change', () => this._syncTooltipHidden(container, hiddenInput));
+
+        const label = document.createElement('label');
+        label.className = 'form-check-label small';
+        label.htmlFor = id;
+        const title = propertyTitles?.[prop];
+        if (title) {
+            label.textContent = title + ' ';
+            const keySpan = document.createElement('span');
+            keySpan.className = 'prop-key';
+            keySpan.textContent = '(' + prop + ')';
+            label.appendChild(keySpan);
+        } else {
+            label.textContent = prop;
+        }
+
+        const { toggleBtn, labelInput } = this._buildLabelToggle(prop, savedLabels, title, container, hiddenInput);
+
+        wrapper.appendChild(cb);
+        wrapper.appendChild(label);
+        wrapper.appendChild(toggleBtn);
+        wrapper.appendChild(labelInput);
+        this._attachDragHandlers(wrapper, container, hiddenInput);
+
+        return wrapper;
+    }
+
+    _buildLabelToggle(prop, savedLabels, title, container, hiddenInput) {
+        const hasLabel = !!savedLabels[prop];
+
+        const toggleBtn = document.createElement('button');
+        toggleBtn.type = 'button';
+        toggleBtn.className = 'tooltip-prop-label-toggle btn btn-link btn-sm p-0 flex-shrink-0';
+        toggleBtn.title = 'Custom label';
+        toggleBtn.textContent = hasLabel ? '×' : '+';
+
+        const labelInput = document.createElement('input');
+        labelInput.type = 'text';
+        labelInput.className = 'tooltip-prop-label-input';
+        labelInput.placeholder = title || prop;
+        labelInput.value = savedLabels[prop] || '';
+        labelInput.style.display = hasLabel ? '' : 'none';
+        labelInput.addEventListener('input', () => this._syncTooltipHidden(container, hiddenInput));
+
+        toggleBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const isOpen = labelInput.style.display !== 'none';
+            if (isOpen) {
+                labelInput.value = '';
+                labelInput.style.display = 'none';
+                toggleBtn.textContent = '+';
                 this._syncTooltipHidden(container, hiddenInput);
+            } else {
+                labelInput.style.display = '';
+                toggleBtn.textContent = '×';
+                labelInput.focus();
+            }
+        });
+
+        return { toggleBtn, labelInput };
+    }
+
+    _attachDragHandlers(wrapper, container, hiddenInput) {
+        wrapper.addEventListener('dragstart', (e) => {
+            e.dataTransfer.effectAllowed = 'move';
+            wrapper.classList.add('tooltip-prop-dragging');
+        });
+
+        wrapper.addEventListener('dragend', () => {
+            wrapper.classList.remove('tooltip-prop-dragging');
+            container.querySelectorAll('.tooltip-prop-check').forEach(w => {
+                w.classList.remove('tooltip-prop-drag-over');
             });
-            
-            wrapper.addEventListener('dragover', (e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                const dragging = container.querySelector('.tooltip-prop-dragging');
-                if (dragging && dragging !== wrapper) {
-                    wrapper.classList.add('tooltip-prop-drag-over');
-                    // Insert before or after depending on cursor position
-                    const rect = wrapper.getBoundingClientRect();
-                    const midY = rect.top + rect.height / 2;
-                    if (e.clientY < midY) {
-                        container.insertBefore(dragging, wrapper);
-                    } else {
-                        container.insertBefore(dragging, wrapper.nextSibling);
-                    }
+            this._syncTooltipHidden(container, hiddenInput);
+        });
+
+        wrapper.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            const dragging = container.querySelector('.tooltip-prop-dragging');
+            if (dragging && dragging !== wrapper) {
+                wrapper.classList.add('tooltip-prop-drag-over');
+                const rect = wrapper.getBoundingClientRect();
+                const midY = rect.top + rect.height / 2;
+                if (e.clientY < midY) {
+                    container.insertBefore(dragging, wrapper);
+                } else {
+                    container.insertBefore(dragging, wrapper.nextSibling);
                 }
-            });
-            
-            wrapper.addEventListener('dragleave', () => {
-                wrapper.classList.remove('tooltip-prop-drag-over');
-            });
-            
-            wrapper.addEventListener('drop', () => {
-                this._syncTooltipHidden(container, hiddenInput);
-            });
+            }
+        });
 
-            container.appendChild(wrapper);
+        wrapper.addEventListener('dragleave', () => {
+            wrapper.classList.remove('tooltip-prop-drag-over');
+        });
+
+        wrapper.addEventListener('drop', () => {
+            this._syncTooltipHidden(container, hiddenInput);
         });
     }
 
     _syncTooltipHidden(container, hiddenInput) {
         if (!hiddenInput) return;
-        const checked = [];
+        const result = [];
         // Read in DOM order to respect drag-and-drop reordering
         container.querySelectorAll('input[type="checkbox"]:checked').forEach(cb => {
-            checked.push(cb.value);
+            const wrapper = cb.closest('.tooltip-prop-check');
+            const labelInput = wrapper?.querySelector('.tooltip-prop-label-input');
+            const customLabel = labelInput?.value.trim();
+            if (customLabel) {
+                result.push({[cb.value]: customLabel});
+            } else {
+                result.push(cb.value);
+            }
         });
-        hiddenInput.value = checked.length > 0 ? JSON.stringify(checked) : '';
+        hiddenInput.value = result.length > 0 ? JSON.stringify(result) : '';
     }
 
-    // ── Tooltip Mode Switcher ──
+    // ── Mode Switchers (tooltip + feature info) ──
 
     _initTooltipMode(popoverBody, row) {
         if (popoverBody.dataset.tooltipModeInit === 'true') return;
         popoverBody.dataset.tooltipModeInit = 'true';
-
-        const switcher = popoverBody.querySelector('.tooltip-mode-switcher');
-        if (!switcher) return;
-
-        // Read persisted mode from the hidden form field
         const modeInput = popoverBody.querySelector('input[id$="_tooltipMode"]');
-        const initialMode = (modeInput && modeInput.value === 'template') ? 'template' : 'props';
-        this._setTooltipMode(popoverBody, initialMode);
-
-        // Wire radio buttons
-        switcher.querySelectorAll('input[type="radio"]').forEach(radio => {
-            radio.addEventListener('change', () => {
-                this._setTooltipMode(popoverBody, radio.value);
-            });
-        });
+        const initialMode = modeInput?.value === 'template' ? 'template' : 'props';
+        this._initModeSwitcher(
+            popoverBody.querySelector('.tooltip-mode-switcher'),
+            popoverBody.querySelector('.tooltip-props-panel'),
+            popoverBody.querySelector('.tooltip-template-panel'),
+            modeInput,
+            initialMode
+        );
     }
 
-    _setTooltipMode(popoverBody, mode) {
-        const switcher = popoverBody.querySelector('.tooltip-mode-switcher');
-        if (!switcher) return;
-
-        const propsPanel = popoverBody.querySelector('.tooltip-props-panel');
-        const templatePanel = popoverBody.querySelector('.tooltip-template-panel');
-        const modeInput = popoverBody.querySelector('input[id$="_tooltipMode"]');
-        const radios = switcher.querySelectorAll('input[type="radio"]');
-
-        radios.forEach(r => { r.checked = r.value === mode; });
-        if (propsPanel)    propsPanel.style.display    = mode === 'props'    ? '' : 'none';
-        if (templatePanel) templatePanel.style.display = mode === 'template' ? '' : 'none';
-        // Persist the selection in the hidden form field
-        if (modeInput) modeInput.value = mode === 'template' ? 'template' : '';
+    _initModeSwitcher(switcher, propsPanel, templatePanel, modeInput, initialMode) {
+        initModeSwitcher(switcher, propsPanel, templatePanel, modeInput, initialMode);
     }
 
     // ── Property Tag Buttons (for HTML templates) ──
@@ -672,55 +727,7 @@ class StyleInstanceEditor {
         textarea.selectionStart = textarea.selectionEnd = start + text.length;
         textarea.dispatchEvent(new Event('input', { bubbles: true }));
     }
-
-    // ── Feature Info Template ──
-
-    _initFeatureInfoTemplate(popoverBody, row) {
-        if (popoverBody.dataset.featureInfoTemplateInit === 'true') return;
-        popoverBody.dataset.featureInfoTemplateInit = 'true';
-
-        const tagsContainer = popoverBody.querySelector('.featureinfo-prop-tags');
-        const textarea = popoverBody.querySelector('.featureinfo-template-textarea');
-        if (!tagsContainer || !textarea) return;
-
-        let propNames = [];
-        try { propNames = JSON.parse(row.dataset.properties || '[]'); } catch(e) {}
-        if (!Array.isArray(propNames)) propNames = [];
-
-        let propertyTitles = {};
-        try { propertyTitles = JSON.parse(row.dataset.propertyTitles || '{}'); } catch(e) {}
-
-        this._buildPropTags(tagsContainer, propNames, propertyTitles, textarea);
-    }
 }
 $(function() {
     new StyleInstanceEditor();
-    _initFeatureInfoModeSwitcher();
 });
-
-function _initFeatureInfoModeSwitcher() {
-    const switcher = document.querySelector('.featureinfo-mode-switcher');
-    if (!switcher) return;
-
-    const propsPanel = document.querySelector('.featureinfo-props-panel');
-    const templatePanel = document.querySelector('.featureinfo-template-panel');
-    const modeInput = document.querySelector('input[id$="_featureInfoMode"]');
-
-    // Determine initial mode: read from persisted hidden field
-    const initialMode = (modeInput && modeInput.value === 'template') ? 'template' : 'props';
-    _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, initialMode);
-
-    switcher.querySelectorAll('input[type="radio"]').forEach(radio => {
-        radio.addEventListener('change', () => {
-            _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, radio.value);
-        });
-    });
-}
-
-function _setFeatureInfoMode(switcher, propsPanel, templatePanel, modeInput, mode) {
-    switcher.querySelectorAll('input[type="radio"]').forEach(r => { r.checked = r.value === mode; });
-    if (propsPanel)    propsPanel.style.display    = mode === 'props'    ? '' : 'none';
-    if (templatePanel) templatePanel.style.display = mode === 'template' ? '' : 'none';
-    // Persist the selection in the hidden form field
-    if (modeInput) modeInput.value = mode === 'template' ? 'template' : '';
-}

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.de.yaml
@@ -46,6 +46,12 @@ mb:
         heading: Hover-Tooltip
         description: "Wählen Sie, welche Eigenschaften beim Überfahren von Features auf der Karte als Tooltip angezeigt werden sollen."
         no_properties: "Keine Eigenschaften verfügbar. Versuchen Sie, die Quelle neu zu laden."
+        mode_props: Eigenschaftsliste
+        mode_template: HTML-Vorlage
+        template_help: "HTML-Vorlage eingeben. ${Eigenschaftsname}-Platzhalter verwenden. Auf einen Eigenschafts-Tag klicken zum Einfügen."
+      featureinfo_template:
+        heading: Feature-Info-Vorlage
+        description: "HTML-Vorlage für das Feature-Info-Popup eingeben. ${Eigenschaftsname}-Platzhalter verwenden. Wenn gesetzt, überschreibt dies die instanzweite Eigenschaftszuordnung für diese Collection."
     metadata:
       title: Titel
       version: Version

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/translations/messages.en.yaml
@@ -46,6 +46,12 @@ mb:
         heading: Hover Tooltip
         description: "Select which properties are shown in a tooltip when hovering over features on the map."
         no_properties: "No properties available. Try reloading the source."
+        mode_props: Property list
+        mode_template: HTML template
+        template_help: "Enter an HTML template. Use ${propertyName} placeholders. Click a property tag to insert it."
+      featureinfo_template:
+        heading: Feature Info Template
+        description: "Enter an HTML template for the feature info popup. Use ${propertyName} placeholders. If set, this overrides the instance-level property map for this collection."
     metadata:
       title: Title
       version: Version

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/views/edit-instance.html.twig
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/views/edit-instance.html.twig
@@ -43,7 +43,19 @@
         </div>
     </div>
     <h4 class="mt-4">{{ 'mb.vectortiles.admin.featureinfo.heading' | trans }}</h4>
-    {{ form_row(form.featureInfoPropertyMap) }}
+    {{ form_widget(form.featureInfoMode) }}
+    <div class="btn-group btn-group-sm w-100 mb-2 featureinfo-mode-switcher" role="group">
+        <input type="radio" class="btn-check" name="featureinfo_mode" id="featureinfo_mode_props" value="props" autocomplete="off">
+        <label class="btn btn-outline-secondary" for="featureinfo_mode_props">{{ 'mb.ogcapifeatures.admin.tooltip.mode_props' | trans }}</label>
+        <input type="radio" class="btn-check" name="featureinfo_mode" id="featureinfo_mode_tmpl" value="template" autocomplete="off">
+        <label class="btn btn-outline-secondary" for="featureinfo_mode_tmpl">{{ 'mb.ogcapifeatures.admin.tooltip.mode_template' | trans }}</label>
+    </div>
+    <div class="featureinfo-props-panel">
+        {{ form_row(form.featureInfoPropertyMap) }}
+    </div>
+    <div class="featureinfo-template-panel" style="display:none">
+        {{ form_row(form.featureInfoTemplate) }}
+    </div>
 {% endblock %}
 
 {% block form_layers %}
@@ -183,9 +195,26 @@
                                     <hr class="my-2">
                                     <div class="tooltip-config-section">
                                         <label class="form-label fw-bold">{{ 'mb.ogcapifeatures.admin.tooltip.heading' | trans }}</label>
-                                        <p class="text-muted small mb-1">{{ 'mb.ogcapifeatures.admin.tooltip.description' | trans }}</p>
-                                        {{ form_widget(layer.tooltipPropertyMap) }}
-                                        <div class="tooltip-checkbox-list" data-empty-text="{{ 'mb.ogcapifeatures.admin.tooltip.no_properties' | trans }}"></div>
+                                        {{ form_widget(layer.tooltipMode) }}
+                                        {# Mode switcher #}
+                                        <div class="btn-group btn-group-sm w-100 mb-2 tooltip-mode-switcher" role="group">
+                                            <input type="radio" class="btn-check" name="tooltip_mode_{{ layer.vars.id }}" id="tooltip_mode_props_{{ layer.vars.id }}" value="props" autocomplete="off">
+                                            <label class="btn btn-outline-secondary btn-sm" for="tooltip_mode_props_{{ layer.vars.id }}">{{ 'mb.ogcapifeatures.admin.tooltip.mode_props' | trans }}</label>
+                                            <input type="radio" class="btn-check" name="tooltip_mode_{{ layer.vars.id }}" id="tooltip_mode_tmpl_{{ layer.vars.id }}" value="template" autocomplete="off">
+                                            <label class="btn btn-outline-secondary btn-sm" for="tooltip_mode_tmpl_{{ layer.vars.id }}">{{ 'mb.ogcapifeatures.admin.tooltip.mode_template' | trans }}</label>
+                                        </div>
+                                        {# Property list mode (existing) #}
+                                        <div class="tooltip-props-panel">
+                                            <p class="text-muted small mb-1">{{ 'mb.ogcapifeatures.admin.tooltip.description' | trans }}</p>
+                                            {{ form_widget(layer.tooltipPropertyMap) }}
+                                            <div class="tooltip-checkbox-list" data-empty-text="{{ 'mb.ogcapifeatures.admin.tooltip.no_properties' | trans }}"></div>
+                                        </div>
+                                        {# HTML template mode (new) #}
+                                        <div class="tooltip-template-panel" style="display:none">
+                                            <p class="text-muted small mb-1">{{ 'mb.ogcapifeatures.admin.tooltip.template_help' | trans }}</p>
+                                            <div class="template-prop-tags d-flex flex-wrap gap-1 mb-2"></div>
+                                            {{ form_widget(layer.tooltipTemplate) }}
+                                        </div>
                                     </div>
                                     <div class="text-end mt-2">
                                         <button type="button" class="btn btn-sm btn-primary -fn-confirm-style" data-toggle-target="#{{ _popover_id }}">

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/views/edit-instance.html.twig
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/views/edit-instance.html.twig
@@ -235,6 +235,7 @@
 {% block js %}
     {{ parent() }}
     <script src="{{ asset('bundles/mapbendermanager/js/style-utils.js') }}"></script>
+    <script src="{{ asset('bundles/mapbenderogcapifeatures/js/mode-switcher.js') }}"></script>
     <script src="{{ asset('bundles/mapbenderogcapifeatures/js/style-instance-editor.js') }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
- Improved Opacity Handling: Refactored the opacity logic for more consistent rendering.
- Enhanced Mapbox Variable Calculation: Fixed and optimized the calculation of variables derived from mathematical expressions within Mapbox styles.
- Added Required Field Validation: Required input fields now visually indicate missing values with a light red highlight.
- Supported Filtered Mapbox Styles: Enabled the display and rendering of features originating from filtered Mapbox styles.
- Adds/improves font styling options in the StyleEditor
- Popover on features adjust its size dynamically
- Optional HTML Templates for Popover and FeatureInfo
- Popover properties are sortable now
- Popover properties can be given a label that is used instead of the property name when given