### PR TITLE
fix(ui): overflowing basemap dropdown menu

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbBaseSourceSwitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbBaseSourceSwitcher.js
@@ -20,7 +20,7 @@
                 self.updateHighlights();
             });
             this.updateHighlights();
-            if (this.$element.parent(".toolbar").length) {
+            if (this.$element.closest(".toolBar").length) {
                 this.$element.on('mouseover click', '.basesourcegroup', (evt) => {
                     const $group = $(evt.target).closest('.basesourcegroup');
                     if (evt.type === 'click') {


### PR DESCRIPTION
Adresses internal ticket #13384

## Changes
If the button of the dropdown to change the basemap was too far on the left, the dropdown would overflow the screen and not be visible. During the fix it became clear that logic to address this issue was already in place but just didn't work quite right. So after a good bit of searching the fix in the end was quite small and now the dropdown will shift to the right if necessary, not overflowing the screen anymore.

## Screenshots
| Before | After |
| --- | --- |
| <img width="427" height="739" alt="image" src="https://github.com/user-attachments/assets/99d7ed17-8e71-49a4-8697-9c80271ac3f1" /> | <img width="577" height="681" alt="image" src="https://github.com/user-attachments/assets/27886030-1ec9-4f57-b899-756f7fb7b687" /> |