### PR TITLE
Replace checkbox with selectbox for menu type

### DIFF
--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -205,6 +205,7 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/VectorLayerPoolOl4.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/VectorLayerBridgeOl4.js',
                     '@MapbenderCoreBundle/Resources/public/elements/MapbenderElement.js',
+                    '@MapbenderCoreBundle/Resources/public/mapbender.responsive-menu.js',
                 ];
             case 'css':
                 return [

--- a/src/Mapbender/CoreBundle/Entity/RegionProperties.php
+++ b/src/Mapbender/CoreBundle/Entity/RegionProperties.php
@@ -138,6 +138,18 @@ class RegionProperties
      */
     public function getProperties()
     {
-        return $this->properties;
+        $properties = $this->properties;
+        // backwards compatibility: generate_button_menu used to be a boolean flag
+        if (array_key_exists('generate_button_menu', $properties)) {
+            $value = $properties['generate_button_menu'];
+            if ($value === true || $value === 1 || $value === '1') {
+                $properties['generate_button_menu'] = 'menu_mobile_desktop';
+            } elseif ($value === false || $value === 0 || $value === '') {
+                $properties['generate_button_menu'] = 'no_menu';
+            } elseif (!in_array($value, array('no_menu', 'menu_mobile_desktop', 'menu_mobile', 'menu_desktop'))) {
+                $properties['generate_button_menu'] = 'no_menu';
+            }
+        }
+        return $properties;
     }
 }

--- a/src/Mapbender/CoreBundle/Extension/ApplicationContentExtension.php
+++ b/src/Mapbender/CoreBundle/Extension/ApplicationContentExtension.php
@@ -127,9 +127,9 @@ class ApplicationContentExtension extends AbstractExtension
         ;
     }
 
-    public function toolbar_menu_content(Application $application, $regionName)
+    public function toolbar_menu_content(Application $application, $regionName, $forceLabel = false)
     {
-        return $this->renderer->renderToolbarMenuContent($application, $regionName);
+        return $this->renderer->renderToolbarMenuContent($application, $regionName, $forceLabel);
     }
 
     public function toolbar_inline_content(Application $application, $regionName)

--- a/src/Mapbender/CoreBundle/Form/Type/Template/BaseToolbarType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/Template/BaseToolbarType.php
@@ -24,8 +24,16 @@ class BaseToolbarType extends AbstractType
                 'mb.manager.toolbar.alignment.choice.center' => 'center',
             ),
         ));
-        $builder->add('generate_button_menu', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
-            'label' => 'mb.manager.toolbar.generate_button_menu',
+        $builder->add('generate_button_menu', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+            'label' => 'mb.manager.toolbar.menu_button.label',
+            'choices' => array(
+                'mb.manager.toolbar.menu_button.choice.no_menu' => 'no_menu',
+                'mb.manager.toolbar.menu_button.choice.menu_desktop' => 'menu_desktop',
+                'mb.manager.toolbar.menu_button.choice.menu_mobile' => 'menu_mobile',
+                'mb.manager.toolbar.menu_button.choice.menu_mobile_desktop' => 'menu_mobile_desktop',
+            ),
+            'required' => false,
+            'placeholder' => false,
         ));
         $builder->add('menu_label', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'required' => false,

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
@@ -1,0 +1,141 @@
+!(function($) {
+	const DESKTOP_BREAKPOINT = 1200;
+	const DROPDOWN_OFFSET = 3;
+
+	function getMenuItemMap(toolbar) {
+		const serialized = toolbar.dataset.menuItemMap || '[]';
+
+		if (toolbar._responsiveMenuMapSource !== serialized) {
+			toolbar._responsiveMenuMapSource = serialized;
+			try {
+				toolbar._responsiveMenuMap = JSON.parse(serialized);
+			} catch (error) {
+				toolbar._responsiveMenuMap = [];
+			}
+		}
+		return toolbar._responsiveMenuMap || [];
+	}
+
+	function isInlineMode(toolbar, screenWidth) {
+		if (toolbar.classList.contains('has-menu-mobile')) {
+			return screenWidth >= DESKTOP_BREAKPOINT;
+		}
+		if (toolbar.classList.contains('has-menu-desktop')) {
+			return screenWidth < DESKTOP_BREAKPOINT;
+		}
+		return false;
+	}
+
+	function resetMenuWrapperState(menuWrapper) {
+		const button = menuWrapper.querySelector('button');
+
+		menuWrapper.classList.remove('open');
+		if (!button) {
+			return;
+		}
+
+		button.classList.remove('active');
+		const icon = button.querySelector('i');
+		if (icon) {
+			icon.classList.add('fa-bars');
+			icon.classList.remove('fa-xmark');
+		}
+	}
+
+	function updateDropupLayout(menuWrapper) {
+		if (!menuWrapper || !menuWrapper.classList.contains('dropup')) {
+			return;
+		}
+
+		if (!menuWrapper.classList.contains('open')) {
+			menuWrapper.style.removeProperty('--dropdown-bottom');
+			menuWrapper.style.removeProperty('--dropdown-menu-max-height');
+			return;
+		}
+
+		const toolbar = menuWrapper.closest('.toolBar');
+		if (!toolbar) {
+			return;
+		}
+
+		const toolbarRect = toolbar.getBoundingClientRect();
+		const topToolbar = document.querySelector('.toolBar.top');
+		const topToolbarHeight = topToolbar ? topToolbar.getBoundingClientRect().height : 0;
+
+		menuWrapper.style.setProperty('--dropdown-bottom', (window.innerHeight - toolbarRect.top - DROPDOWN_OFFSET) + 'px');
+		menuWrapper.style.setProperty('--dropdown-menu-max-height', Math.max(0, toolbarRect.top - topToolbarHeight - DROPDOWN_OFFSET) + 'px');
+	}
+
+	function moveToolbarItems(toolbar, inlineMode) {
+		const inlineList = toolbar.querySelector('[data-toolbar-inline-list]');
+		const dropdownMenu = toolbar.querySelector('[data-toolbar-menu-list]');
+		const menuWrapper = dropdownMenu && dropdownMenu.closest('.menu-wrapper');
+
+		if (!inlineList || !dropdownMenu || !menuWrapper) {
+			return;
+		}
+
+		const inlineFragment = document.createDocumentFragment();
+		const menuFragment = document.createDocumentFragment();
+
+		getMenuItemMap(toolbar).forEach((item) => {
+			const element = document.getElementById(item.id);
+
+			if (!element || !toolbar.contains(element)) {
+				return;
+			}
+
+			if (inlineMode || item.type === 'inline_items') {
+				inlineFragment.appendChild(element);
+			} else {
+				menuFragment.appendChild(element);
+			}
+		});
+
+		inlineList.appendChild(inlineFragment);
+		dropdownMenu.appendChild(menuFragment);
+
+		if (inlineMode) {
+			resetMenuWrapperState(menuWrapper);
+			dropdownMenu.style.setProperty('display', 'none', 'important');
+			menuWrapper.style.setProperty('display', 'none', 'important');
+		} else {
+			dropdownMenu.style.removeProperty('display');
+			menuWrapper.style.removeProperty('display');
+		}
+
+		updateDropupLayout(menuWrapper);
+	}
+
+	function syncToolbar(toolbar) {
+		moveToolbarItems(toolbar, isInlineMode(toolbar, window.innerWidth));
+	}
+
+	function syncToolbars() {
+		document.querySelectorAll('.toolBar.has-menu-mobile, .toolBar.has-menu-desktop').forEach(syncToolbar);
+		document.querySelectorAll('.toolBar .menu-wrapper.dropup').forEach(updateDropupLayout);
+	}
+
+	let queued = false;
+	function queueSyncToolbars() {
+		if (queued) {
+			return;
+		}
+		queued = true;
+		window.requestAnimationFrame(() => {
+			queued = false;
+			syncToolbars();
+		});
+	}
+
+	$(syncToolbars);
+	$(window).on('resize', queueSyncToolbars);
+	$(document).on('click', '.toolBar .menu-wrapper.dropup > button', function() {
+		const menuWrapper = this.closest('.menu-wrapper');
+
+		window.requestAnimationFrame(() => {
+			updateDropupLayout(menuWrapper);
+		});
+	});
+}(jQuery));
+

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
@@ -119,6 +119,8 @@
 				menuWrapper.style.removeProperty('display');
 			}
 
+            $('.toolBarItem .forced-menu-label').toggleClass('d-none', menuWrapper.style.display === 'none');
+
 			this.updateDropupLayout(menuWrapper);
 		}
 

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.responsive-menu.js
@@ -1,141 +1,153 @@
 !(function($) {
-	const DESKTOP_BREAKPOINT = 1200;
-	const DROPDOWN_OFFSET = 3;
+	window.Mapbender = window.Mapbender || {};
 
-	function getMenuItemMap(toolbar) {
-		const serialized = toolbar.dataset.menuItemMap || '[]';
+	Mapbender.ResponsiveMenu = class ResponsiveMenu {
+		constructor() {
+			this.desktopBreakpoint = 1200;
+			this.dropdownOffset = 3;
+			this._queued = false;
+		}
 
-		if (toolbar._responsiveMenuMapSource !== serialized) {
-			toolbar._responsiveMenuMapSource = serialized;
-			try {
-				toolbar._responsiveMenuMap = JSON.parse(serialized);
-			} catch (error) {
-				toolbar._responsiveMenuMap = [];
+		init() {
+			$(() => this.syncToolbars());
+			$(window).on('resize', () => this.queueSyncToolbars());
+			$(document).on('click', '.toolBar .menu-wrapper.dropup > button', (event) => {
+				const menuWrapper = event.currentTarget.closest('.menu-wrapper');
+				window.requestAnimationFrame(() => this.updateDropupLayout(menuWrapper));
+			});
+		}
+
+		getMenuItemMap(toolbar) {
+			const serialized = toolbar.dataset.menuItemMap || '[]';
+
+			if (toolbar._responsiveMenuMapSource !== serialized) {
+				toolbar._responsiveMenuMapSource = serialized;
+				try {
+					toolbar._responsiveMenuMap = JSON.parse(serialized);
+				} catch (error) {
+					toolbar._responsiveMenuMap = [];
+				}
 			}
-		}
-		return toolbar._responsiveMenuMap || [];
-	}
-
-	function isInlineMode(toolbar, screenWidth) {
-		if (toolbar.classList.contains('has-menu-mobile')) {
-			return screenWidth >= DESKTOP_BREAKPOINT;
-		}
-		if (toolbar.classList.contains('has-menu-desktop')) {
-			return screenWidth < DESKTOP_BREAKPOINT;
-		}
-		return false;
-	}
-
-	function resetMenuWrapperState(menuWrapper) {
-		const button = menuWrapper.querySelector('button');
-
-		menuWrapper.classList.remove('open');
-		if (!button) {
-			return;
+			return toolbar._responsiveMenuMap || [];
 		}
 
-		button.classList.remove('active');
-		const icon = button.querySelector('i');
-		if (icon) {
-			icon.classList.add('fa-bars');
-			icon.classList.remove('fa-xmark');
-		}
-	}
-
-	function updateDropupLayout(menuWrapper) {
-		if (!menuWrapper || !menuWrapper.classList.contains('dropup')) {
-			return;
+		isInlineMode(toolbar, screenWidth) {
+			if (toolbar.classList.contains('has-menu-mobile')) {
+				return screenWidth >= this.desktopBreakpoint;
+			}
+			if (toolbar.classList.contains('has-menu-desktop')) {
+				return screenWidth < this.desktopBreakpoint;
+			}
+			return false;
 		}
 
-		if (!menuWrapper.classList.contains('open')) {
-			menuWrapper.style.removeProperty('--dropdown-bottom');
-			menuWrapper.style.removeProperty('--dropdown-menu-max-height');
-			return;
-		}
+		resetMenuWrapperState(menuWrapper) {
+			const button = menuWrapper.querySelector('button');
 
-		const toolbar = menuWrapper.closest('.toolBar');
-		if (!toolbar) {
-			return;
-		}
-
-		const toolbarRect = toolbar.getBoundingClientRect();
-		const topToolbar = document.querySelector('.toolBar.top');
-		const topToolbarHeight = topToolbar ? topToolbar.getBoundingClientRect().height : 0;
-
-		menuWrapper.style.setProperty('--dropdown-bottom', (window.innerHeight - toolbarRect.top - DROPDOWN_OFFSET) + 'px');
-		menuWrapper.style.setProperty('--dropdown-menu-max-height', Math.max(0, toolbarRect.top - topToolbarHeight - DROPDOWN_OFFSET) + 'px');
-	}
-
-	function moveToolbarItems(toolbar, inlineMode) {
-		const inlineList = toolbar.querySelector('[data-toolbar-inline-list]');
-		const dropdownMenu = toolbar.querySelector('[data-toolbar-menu-list]');
-		const menuWrapper = dropdownMenu && dropdownMenu.closest('.menu-wrapper');
-
-		if (!inlineList || !dropdownMenu || !menuWrapper) {
-			return;
-		}
-
-		const inlineFragment = document.createDocumentFragment();
-		const menuFragment = document.createDocumentFragment();
-
-		getMenuItemMap(toolbar).forEach((item) => {
-			const element = document.getElementById(item.id);
-
-			if (!element || !toolbar.contains(element)) {
+			menuWrapper.classList.remove('open');
+			if (!button) {
 				return;
 			}
 
-			if (inlineMode || item.type === 'inline_items') {
-				inlineFragment.appendChild(element);
-			} else {
-				menuFragment.appendChild(element);
+			button.classList.remove('active');
+			const icon = button.querySelector('i');
+			if (icon) {
+				icon.classList.add('fa-bars');
+				icon.classList.remove('fa-xmark');
 			}
-		});
-
-		inlineList.appendChild(inlineFragment);
-		dropdownMenu.appendChild(menuFragment);
-
-		if (inlineMode) {
-			resetMenuWrapperState(menuWrapper);
-			dropdownMenu.style.setProperty('display', 'none', 'important');
-			menuWrapper.style.setProperty('display', 'none', 'important');
-		} else {
-			dropdownMenu.style.removeProperty('display');
-			menuWrapper.style.removeProperty('display');
 		}
 
-		updateDropupLayout(menuWrapper);
-	}
+		updateDropupLayout(menuWrapper) {
+			if (!menuWrapper || !menuWrapper.classList.contains('dropup')) {
+				return;
+			}
 
-	function syncToolbar(toolbar) {
-		moveToolbarItems(toolbar, isInlineMode(toolbar, window.innerWidth));
-	}
+			if (!menuWrapper.classList.contains('open')) {
+				menuWrapper.style.removeProperty('--dropdown-bottom');
+				menuWrapper.style.removeProperty('--dropdown-menu-max-height');
+				return;
+			}
 
-	function syncToolbars() {
-		document.querySelectorAll('.toolBar.has-menu-mobile, .toolBar.has-menu-desktop').forEach(syncToolbar);
-		document.querySelectorAll('.toolBar .menu-wrapper.dropup').forEach(updateDropupLayout);
-	}
+			const toolbar = menuWrapper.closest('.toolBar');
+			if (!toolbar) {
+				return;
+			}
 
-	let queued = false;
-	function queueSyncToolbars() {
-		if (queued) {
-			return;
+			const toolbarRect = toolbar.getBoundingClientRect();
+			const topToolbar = document.querySelector('.toolBar.top');
+			const topToolbarHeight = topToolbar ? topToolbar.getBoundingClientRect().height : 0;
+
+			menuWrapper.style.setProperty('--dropdown-bottom', (window.innerHeight - toolbarRect.top - this.dropdownOffset) + 'px');
+			menuWrapper.style.setProperty('--dropdown-menu-max-height', Math.max(0, toolbarRect.top - topToolbarHeight - this.dropdownOffset) + 'px');
 		}
-		queued = true;
-		window.requestAnimationFrame(() => {
-			queued = false;
-			syncToolbars();
-		});
-	}
 
-	$(syncToolbars);
-	$(window).on('resize', queueSyncToolbars);
-	$(document).on('click', '.toolBar .menu-wrapper.dropup > button', function() {
-		const menuWrapper = this.closest('.menu-wrapper');
+		moveToolbarItems(toolbar, inlineMode) {
+			const inlineList = toolbar.querySelector('[data-toolbar-inline-list]');
+			const dropdownMenu = toolbar.querySelector('[data-toolbar-menu-list]');
+			const menuWrapper = dropdownMenu && dropdownMenu.closest('.menu-wrapper');
 
-		window.requestAnimationFrame(() => {
-			updateDropupLayout(menuWrapper);
-		});
+			if (!inlineList || !dropdownMenu || !menuWrapper) {
+				return;
+			}
+
+			const inlineFragment = document.createDocumentFragment();
+			const menuFragment = document.createDocumentFragment();
+
+			this.getMenuItemMap(toolbar).forEach((item) => {
+				const element = document.getElementById(item.id);
+
+				if (!element || !toolbar.contains(element)) {
+					return;
+				}
+
+				if (inlineMode || item.type === 'inline_items') {
+					inlineFragment.appendChild(element);
+				} else {
+					menuFragment.appendChild(element);
+				}
+			});
+
+			inlineList.appendChild(inlineFragment);
+			dropdownMenu.appendChild(menuFragment);
+
+			if (inlineMode) {
+				this.resetMenuWrapperState(menuWrapper);
+				dropdownMenu.style.setProperty('display', 'none', 'important');
+				menuWrapper.style.setProperty('display', 'none', 'important');
+			} else {
+				dropdownMenu.style.removeProperty('display');
+				menuWrapper.style.removeProperty('display');
+			}
+
+			this.updateDropupLayout(menuWrapper);
+		}
+
+		syncToolbar(toolbar) {
+			this.moveToolbarItems(toolbar, this.isInlineMode(toolbar, window.innerWidth));
+		}
+
+		syncToolbars() {
+			document.querySelectorAll('.toolBar.has-menu-mobile, .toolBar.has-menu-desktop').forEach((toolbar) => this.syncToolbar(toolbar));
+			document.querySelectorAll('.toolBar .menu-wrapper.dropup').forEach((menuWrapper) => this.updateDropupLayout(menuWrapper));
+		}
+
+		queueSyncToolbars() {
+			if (this._queued) {
+				return;
+			}
+			this._queued = true;
+			window.requestAnimationFrame(() => {
+				this._queued = false;
+				this.syncToolbars();
+			});
+		}
+	};
+
+	$(function() {
+		if (!Mapbender.responsiveMenu) {
+			Mapbender.responsiveMenu = new Mapbender.ResponsiveMenu();
+			Mapbender.responsiveMenu.init();
+		}
 	});
 }(jQuery));
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -106,6 +106,45 @@ ul.toolBar, .toolBar > ul {
   margin-left: 0.5rem;
 }
 
+// Renders the toolbar menu-supported items inline (expanded out of the burger
+// dropdown) instead of collapsed behind the burger button. The menu <ul> is
+// still only rendered once; this just changes its presentation.
+@mixin toolbar-menu-inline {
+    .menu-wrapper {
+        float: none !important;
+        display: inline-flex;
+        vertical-align: top;
+        margin-top: 0 !important;
+
+        // hide the burger toggle button
+        > .btn {
+            display: none;
+        }
+
+        // render the dropdown items inline as part of the toolbar
+        .dropdown-menu {
+            display: inline-flex !important;
+            flex-direction: row;
+            position: static !important;
+            inset: auto !important;
+            transform: none !important;
+            background: transparent;
+            border: none;
+            box-shadow: none;
+            margin: 0;
+            padding: 0;
+            min-width: 0;
+            max-height: none;
+            overflow: visible;
+        }
+
+        .toolBarItem {
+            display: inline-block;
+            margin: 0 0.25em;
+        }
+    }
+}
+
 .toolBar {
   z-index: 4;
   user-select: none;
@@ -200,7 +239,34 @@ ul.toolBar, .toolBar > ul {
       overflow-y: auto;
       overflow-x: hidden;
     }
+
+    &.dropup {
+      .dropdown-menu {
+        background: var(--toolbar-bottom-background);
+        top: auto;
+        bottom: var(--dropdown-bottom, 50px);
+      }
+    }
   }
+
+    // Responsive toolbar menu modes.
+    // The menu <ul> is rendered once (whenever the mode is not "no_menu").
+    // Depending on the configured mode and viewport width, the menu-supported
+    // items are either collapsed behind the burger button or shown inline
+    // (like the non-button-menu case).
+    //   menu_mobile_desktop -> always burger (no modifier class, never expanded)
+    //   menu_mobile  (.has-menu-mobile)  -> burger < 1200px, inline >= 1200px
+    //   menu_desktop (.has-menu-desktop) -> burger >= 1200px, inline < 1200px
+    @media (min-width: $desktopBreakpointWidth) {
+        &.has-menu-mobile {
+            @include toolbar-menu-inline;
+        }
+    }
+    @media (max-width: #{$desktopBreakpointWidth - 1px}) {
+        &.has-menu-desktop {
+            @include toolbar-menu-inline;
+        }
+    }
 }
 
 // Dropdown-style elements (SrsSelector, ScaleSelector, ApplicationSwitcher)

--- a/src/Mapbender/CoreBundle/Resources/views/Element/control_button.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/control_button.html.twig
@@ -3,4 +3,6 @@
   {%- endif -%}
   {%- if show_label or not icon -%}
   <span{% if icon %} class="hidden-sm hidden-xs hidden-md-down"{% endif %}>{{ label|trans }}</span>
+  {%- elseif force_menu_label is defined and force_menu_label -%}
+  <span class="forced-menu-label d-none">{{ label|trans }}</span>
   {%- endif -%}

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
@@ -1,6 +1,18 @@
 {% block region_wrapper %}
-<div class="{{ ('toolBar ' ~ region_class) | trim }}">
-    {%- if region_props['generate_button_menu'] -%}
+    {%- set menu_mode = region_props['generate_button_menu'] | default('no_menu') -%}
+    {#- backwards compatibility with the old boolean flag -#}
+    {%- if menu_mode is same as(true) or menu_mode == 1 or menu_mode == '1' -%}
+        {%- set menu_mode = 'menu_mobile_desktop' -%}
+    {%- elseif menu_mode is same as(false) or menu_mode == 0 or menu_mode == '' -%}
+        {%- set menu_mode = 'no_menu' -%}
+    {%- endif -%}
+    {%- set menu_mode_class = {
+        'menu_desktop': 'has-menu-desktop',
+        'menu_mobile': 'has-menu-mobile',
+    }[menu_mode] | default('') -%}
+    {%- set items_list_class = alignment_class | default('itemsRight') -%}
+    <div class="{{ ('toolBar ' ~ region_class ~ ' ' ~ menu_mode_class) | trim }}" data-toolbar-menu-mode="{{ menu_mode }}">
+    {%- if menu_mode != 'no_menu' %}
         {%- set inline_items = toolbar_inline_content(application, region_name) -%}
         {%- set menu_content = toolbar_menu_content(application, region_name) -%}
     {%- else -%}
@@ -16,17 +28,49 @@
                     {%- if not _menu_label -%} title="{{ 'mb.template.toolbar_menu_tooltip' | trans }}" {%-endif -%}>
                 {#- eat whitespace -#}
                 <i class="fa-solid fa-bars iconBig"></i></button>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu" data-toolbar-menu-list>
                 {{- menu_content | raw -}}
             </ul>
         </div>
     {%- endif -%}
     {% block item_list %}
-    <ul class="{{ alignment_class | default('itemsRight') }}">
+    <ul class="{{ items_list_class }}" data-toolbar-inline-list>
         {% block item_list_body %}
             {{- inline_items | raw -}}
         {% endblock %}
     </ul>
     {% endblock item_list %}
+    {%- if menu_mode != 'no_menu' and elements is defined and elements|length -%}
+        {%- set ordered_menu_item_ids = [] -%}
+        {%- for element in elements -%}
+            {%- set ordered_menu_item_ids = ordered_menu_item_ids | merge([element.id]) -%}
+        {%- endfor -%}
+        <script>
+            (function() {
+                const toolbar = document.currentScript.closest('.toolBar');
+                const inlineList = toolbar && toolbar.querySelector('[data-toolbar-inline-list]');
+                const dropdownMenu = toolbar && toolbar.querySelector('[data-toolbar-menu-list]');
+                const orderedIds = {{ ordered_menu_item_ids | json_encode | raw }};
+
+                if (!toolbar || !inlineList || !dropdownMenu) {
+                    return;
+                }
+
+                toolbar.dataset.menuItemMap = JSON.stringify(orderedIds.map((id, order) => {
+                    const item = document.getElementById(String(id));
+                    if (!item || !toolbar.contains(item)) {
+                        return null;
+                    }
+                    if (dropdownMenu.contains(item)) {
+                        return {id: String(id), order: order, type: 'menu_content'};
+                    }
+                    if (inlineList.contains(item)) {
+                        return {id: String(id), order: order, type: 'inline_items'};
+                    }
+                    return null;
+                }).filter(Boolean));
+            })();
+        </script>
+    {%- endif -%}
 </div>
 {% endblock region_wrapper %}

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
@@ -1,11 +1,5 @@
 {% block region_wrapper %}
     {%- set menu_mode = region_props['generate_button_menu'] | default('no_menu') -%}
-    {#- backwards compatibility with the old boolean flag -#}
-    {%- if menu_mode is same as(true) or menu_mode == 1 or menu_mode == '1' -%}
-        {%- set menu_mode = 'menu_mobile_desktop' -%}
-    {%- elseif menu_mode is same as(false) or menu_mode == 0 or menu_mode == '' -%}
-        {%- set menu_mode = 'no_menu' -%}
-    {%- endif -%}
     {%- set menu_mode_class = {
         'menu_desktop': 'has-menu-desktop',
         'menu_mobile': 'has-menu-mobile',

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
@@ -14,7 +14,7 @@
     <div class="{{ ('toolBar ' ~ region_class ~ ' ' ~ menu_mode_class) | trim }}" data-toolbar-menu-mode="{{ menu_mode }}">
     {%- if menu_mode != 'no_menu' %}
         {%- set inline_items = toolbar_inline_content(application, region_name) -%}
-        {%- set menu_content = toolbar_menu_content(application, region_name) -%}
+        {%- set menu_content = toolbar_menu_content(application, region_name, true) -%}
     {%- else -%}
         {%- set inline_items = region_content(application, region_name) -%}
         {%- set menu_content = '' -%}

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
@@ -152,29 +152,6 @@ class ApplicationMarkupRenderer
         $template = $this->templateRegistry->getApplicationTemplate($application);
         $props = $this->extractRegionProperties($application, $regionName);
         $props += $template->getRegionPropertiesDefaults($regionName);
-
-        // Resolve the configured button-menu mode into a boolean regarding the current screen type
-        if (!empty($props['generate_button_menu'])) {
-            $screenType = $props['screenType'];
-            $buttonMenu = $props['generate_button_menu'];
-            switch ($buttonMenu) {
-                case 'no_menu':
-                    $props['generate_button_menu'] = false;
-                    break;
-                case 'menu_desktop':
-                    $props['generate_button_menu'] = !(in_array($screenType, ['mobile', 'all']));
-                    break;
-                case 'menu_mobile':
-                    $props['generate_button_menu'] = !(in_array($screenType, ['desktop', 'all']));
-                    break;
-                case 'menu_mobile_desktop':
-                    $props['generate_button_menu'] = true;
-                    break;
-                default:
-                    $props['generate_button_menu'] = false;
-            }
-        }
-
         $classes = $template->getRegionClasses($application, $regionName);
         if ($this->allowResponsiveContainers) {
             switch (ArrayUtil::getDefault($props, 'screenType')) {

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
@@ -152,6 +152,29 @@ class ApplicationMarkupRenderer
         $template = $this->templateRegistry->getApplicationTemplate($application);
         $props = $this->extractRegionProperties($application, $regionName);
         $props += $template->getRegionPropertiesDefaults($regionName);
+
+        // Resolve the configured button-menu mode into a boolean regarding the current screen type
+        if (!empty($props['generate_button_menu'])) {
+            $screenType = $props['screenType'];
+            $buttonMenu = $props['generate_button_menu'];
+            switch ($buttonMenu) {
+                case 'no_menu':
+                    $props['generate_button_menu'] = false;
+                    break;
+                case 'menu_desktop':
+                    $props['generate_button_menu'] = !(in_array($screenType, ['mobile', 'all']));
+                    break;
+                case 'menu_mobile':
+                    $props['generate_button_menu'] = !(in_array($screenType, ['desktop', 'all']));
+                    break;
+                case 'menu_mobile_desktop':
+                    $props['generate_button_menu'] = true;
+                    break;
+                default:
+                    $props['generate_button_menu'] = false;
+            }
+        }
+
         $classes = $template->getRegionClasses($application, $regionName);
         if ($this->allowResponsiveContainers) {
             switch (ArrayUtil::getDefault($props, 'screenType')) {

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ApplicationMarkupRenderer.php
@@ -210,14 +210,14 @@ class ApplicationMarkupRenderer
         }
     }
 
-    public function renderToolbarMenuContent(Application $application, $regionName)
+    public function renderToolbarMenuContent(Application $application, $regionName, $forceLabel = false)
     {
         $elr = $this->elementRenderer;
         $elements = $this->getRegionElements($application, $regionName, function(Element $element) use ($elr) {
             return $elr->isMenuSupported($element);
         });
         if ($elements) {
-            return $this->elementRenderer->renderElements($elements);
+            return $this->elementRenderer->renderElements($elements, $forceLabel);
         } else {
             return '';
         }

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
@@ -146,8 +146,8 @@ class ElementMarkupRenderer
         }
         $attributes = $this->prepareAttributes($view->attributes, $baseAttributes);
         if ($view instanceof TemplateView) {
-            if ($forceLabel && array_key_exists('show_label', $view->variables)) {
-                $view->variables['show_label'] = true;
+            if ($forceLabel) {
+                $view->variables['force_menu_label'] = true;
             }
             $content = $this->templatingEngine->render($view->getTemplate(), $view->variables);
         } elseif ($view instanceof StaticView) {

--- a/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
+++ b/src/Mapbender/FrameworkBundle/Component/Renderer/ElementMarkupRenderer.php
@@ -55,9 +55,10 @@ class ElementMarkupRenderer
 
     /**
      * @param Element[] $elements
+     * @param bool $forceLabel force display of the element label, overriding the element's own configuration
      * @return string
      */
-    public function renderElements($elements)
+    public function renderElements($elements, $forceLabel = false)
     {
         $wrappers = array();
         $markupFragments = array();
@@ -76,10 +77,9 @@ class ElementMarkupRenderer
                     $wrapper['tagName'] = 'div';
                 }
             }
-
             $markupFragments[] = $this->renderContent($element, $wrapper['tagName'], array_filter(array(
                 'class' => $wrapper['class'],
-            )));
+            )), $forceLabel);
         }
         return implode('', $markupFragments);
     }
@@ -103,7 +103,7 @@ class ElementMarkupRenderer
         return $markup;
     }
 
-    protected function renderContent(Element $element, $wrapperTag, $attributes)
+    protected function renderContent(Element $element, $wrapperTag, $attributes, $forceLabel = false)
     {
         try {
             $view = $this->inventory->getFrontendHandler($element)->getView($element);
@@ -113,7 +113,7 @@ class ElementMarkupRenderer
                 } else {
                     return $this->renderView($view, $wrapperTag, $attributes + array(
                         'id' => $element->getId(),
-                    ));
+                    ), $forceLabel);
                 }
             } else {
                 return '';
@@ -135,9 +135,10 @@ class ElementMarkupRenderer
      * @param ElementView $view
      * @param string $wrapperTag
      * @param string[] $baseAttributes
+     * @param bool $forceLabel force display of the element label, overriding the element's own configuration
      * @return string
      */
-    protected function renderView(ElementView $view, $wrapperTag, $baseAttributes)
+    protected function renderView(ElementView $view, $wrapperTag, $baseAttributes, $forceLabel = false)
     {
         if (!$view->cacheable) {
             $baseAttributes += array('class' => '');
@@ -145,6 +146,9 @@ class ElementMarkupRenderer
         }
         $attributes = $this->prepareAttributes($view->attributes, $baseAttributes);
         if ($view instanceof TemplateView) {
+            if ($forceLabel && array_key_exists('show_label', $view->variables)) {
+                $view->variables['show_label'] = true;
+            }
             $content = $this->templatingEngine->render($view->getTemplate(), $view->variables);
         } elseif ($view instanceof StaticView) {
             $content = $view->getContent();

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -39,7 +39,13 @@ mb:
           left: Links
           right: Rechts
           center: Zentriert
-      generate_button_menu: 'Schaltflächen zu Menü zusammenfassen'
+      menu_button:
+          label: 'Menü'
+          choice:
+              no_menu: 'kein Menü'
+              menu_desktop: 'nur Desktop'
+              menu_mobile_desktop: 'Desktop + Mobil'
+              menu_mobile: 'nur Mobil'
       menu_label: Menütitel
     visibility: Sichtbarkeit
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -39,7 +39,13 @@ mb:
           left: Left
           right: Right
           center: Center
-      generate_button_menu: 'Generate menu for buttons'
+      menu_button:
+          label: 'Menu'
+          choice:
+              no_menu: 'no menu (default)'
+              menu_desktop: 'Show menu on desktop'
+              menu_mobile_desktop: 'Show menu on desktop+mobile'
+              menu_mobile: 'Show menu on mobile only'
       menu_label: 'Menu label'
     visibility: Visibility
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
@@ -39,7 +39,13 @@ mb:
           left: Izquierda
           right: Derecha
           center: Centrada
-      generate_button_menu: 'Generar un menú para botones'
+      menu_button:
+          label: 'Menú'
+          choice:
+              no_menu: 'sin menú (predeterminado)'
+              menu_desktop: 'Mostrar menú en escritorio'
+              menu_mobile_desktop: 'Mostrar menú en escritorio y móvil'
+              menu_mobile: 'Mostrar menú solo en móvil'
       menu_label: 'Título del menú'
     visibility: Visibilidad
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
@@ -39,7 +39,13 @@ mb:
           left: Sinistra
           right: Destra
           center: Centro
-      generate_button_menu: 'Genera menu per i pulsanti'
+      menu_button:
+          label: 'Menu'
+          choice:
+              no_menu: 'nessun menu (predefinito)'
+              menu_desktop: 'Mostra menu su desktop'
+              menu_mobile_desktop: 'Mostra menu su desktop+mobile'
+              menu_mobile: 'Mostra menu solo su mobile'
       menu_label: 'Menu label'
     visibility: Visibilità
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
@@ -39,7 +39,13 @@ mb:
           left: Lewo
           right: Prawo
           center: Środek
-      generate_button_menu: 'Generuj menu dla przycisków'
+      menu_button:
+          label: 'Menu'
+          choice:
+              no_menu: 'bez menu (domyślnie)'
+              menu_desktop: 'Pokaż menu na komputerze'
+              menu_mobile_desktop: 'Pokaż menu na komputerze i urządzeniach mobilnych'
+              menu_mobile: 'Pokaż menu tylko na urządzeniach mobilnych'
       menu_label: 'Etykieta menu'
     visibility: Widoczność
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
@@ -39,7 +39,13 @@ mb:
           left: Esquerda
           right: Direita
           center: Centralizado
-      generate_button_menu: 'Agrupar botões em um menu'
+      menu_button:
+          label: 'Menu'
+          choice:
+              no_menu: 'sem menu (padrão)'
+              menu_desktop: 'Mostrar menu no desktop'
+              menu_mobile_desktop: 'Mostrar menu no desktop e dispositivos móveis'
+              menu_mobile: 'Mostrar menu apenas em dispositivos móveis'
       menu_label: 'Rótulo do menu'
     visibility: Visibilidade
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
@@ -39,7 +39,13 @@ mb:
           left: Слева
           right: Справа
           center: 'По центру'
-      generate_button_menu: 'Объединять кнопки в меню'
+      menu_button:
+          label: 'Меню'
+          choice:
+              no_menu: 'без меню (по умолчанию)'
+              menu_desktop: 'Показывать меню на десктопе'
+              menu_mobile_desktop: 'Показывать меню на десктопе и мобильных'
+              menu_mobile: 'Показывать меню только на мобильных'
       menu_label: 'Заголовок меню'
     visibility: Видимость
     element:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
@@ -37,7 +37,13 @@ mb:
           left: Зліва
           right: Справа
           center: 'По центру'
-      generate_button_menu: 'Створити меню для кнопок'
+      menu_button:
+          label: 'Меню'
+          choice:
+              no_menu: 'без меню (за замовчуванням)'
+              menu_desktop: 'Показувати меню на комп’ютері'
+              menu_mobile_desktop: 'Показувати меню на комп’ютері та мобільних'
+              menu_mobile: 'Показувати меню лише на мобільних'
       menu_label: 'Мітка меню'
       visibility: Видимість
     element:


### PR DESCRIPTION
This PR replaces the checkbox that generated a menu for the toolbar-buttons with a selectbox with the options _no menu_, _Show menu on desktop_, _Show menu on mobile_ and _Show menu on desktop+mobile_.

See internal #13389

(Outdated) selectbox-values for YAML-Config:

```
no_menu
menu_desktop
menu_mobile
menu_mobile_desktop
```

Update after #1893: New values for YAML-Config:

```
no
yes
only_desktop
only_mobile
```