### PR TITLE
Fix/style opacity zero

### DIFF
--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
@@ -18,7 +18,7 @@ class StyleEditorPreview {
         const fw = s.fontWeight || 'regular';
         const prefix = fw === 'bold' ? 'bold ' : (fw === 'italic' ? 'italic ' : '');
         ctx.font = `${prefix}${parseInt(s.fontSize) || 11}px ${s.fontFamily || 'Arial, Helvetica, sans-serif'}`;
-        ctx.fillStyle = StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1);
+        ctx.fillStyle = StyleUtils.hexToRgba(s.fontColor || '#000000', this._normalizeOpacity(s.fontOpacity));
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(text, x, y);
@@ -26,8 +26,8 @@ class StyleEditorPreview {
 
     drawAll(visualStyle) {
         const s = visualStyle;
-        const fillStyle   = StyleUtils.hexToRgba(s.fillColor || '#3399CC', parseFloat(s.fillOpacity) || 1);
-        const strokeStyle = StyleUtils.hexToRgba(s.strokeColor || '#ffffff', parseFloat(s.strokeOpacity) || 1);
+        const fillStyle   = StyleUtils.hexToRgba(s.fillColor || '#3399CC', this._normalizeOpacity(s.fillOpacity));
+        const strokeStyle = StyleUtils.hexToRgba(s.strokeColor || '#ffffff', this._normalizeOpacity(s.strokeOpacity));
         const strokeWidth = parseFloat(s.strokeWidth) || 1;
         const pointRadius = parseFloat(s.pointRadius) || 6;
         const dashes = this.dashMap[s.strokeDashstyle] || [];
@@ -74,5 +74,10 @@ class StyleEditorPreview {
             ctx.closePath(); ctx.fill(); if (strokeWidth > 0) ctx.stroke();
             this.drawLabel(ctx, s, w/2, h/2);
         }
+    }
+
+    _normalizeOpacity(value) {
+        const alpha = parseFloat(value);
+        return isNaN(alpha) ? 1 : alpha;
     }
 }

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
@@ -15,7 +15,8 @@ class StyleUtils {
         const r = parseInt(hex.substring(0,2), 16);
         const g = parseInt(hex.substring(2,4), 16);
         const b = parseInt(hex.substring(4,6), 16);
-        return `rgba(${r},${g},${b},${parseFloat(opacity) || 1})`;
+        const alpha = parseFloat(opacity);
+        return `rgba(${r},${g},${b},${isNaN(alpha) ? 1 : alpha})`;
     }
 
     static extractMapboxPaint(styleJson, collectionId) {
@@ -61,8 +62,8 @@ class StyleUtils {
         }
         const s = styleJson || {};
         return {
-            fillStyle: StyleUtils.hexToRgba(s.fillColor || '#3399CC', parseFloat(s.fillOpacity) || 1),
-            strokeStyle: StyleUtils.hexToRgba(s.strokeColor || '#ffffff', parseFloat(s.strokeOpacity) || 1),
+            fillStyle: StyleUtils.hexToRgba(s.fillColor || '#3399CC', s.fillOpacity),
+            strokeStyle: StyleUtils.hexToRgba(s.strokeColor || '#ffffff', s.strokeOpacity),
             strokeWidth: parseFloat(s.strokeWidth) || 1,
             pointRadius: parseFloat(s.pointRadius) || 5,
             isMapbox: false

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -39,7 +39,8 @@ class OgcApiSource extends Mapbender.Source {
         const r = parseInt(hex.substring(0,2), 16);
         const g = parseInt(hex.substring(2,4), 16);
         const b = parseInt(hex.substring(4,6), 16);
-        return [r, g, b, parseFloat(opacity) || 1];
+        const alpha = isNaN(parseFloat(opacity)) ? 1 : parseFloat(opacity);
+        return [r, g, b, alpha];
     }
 
     _getDashArray(dashStyle) {


### PR DESCRIPTION
Fixed opacity value handling so an explicit 0 is preserved (instead of falling back to 1), ensuring transparent styles render correctly and consistently across previews.
internal Ticket 13390