### PR TITLE
Fix/style font weight style

### DIFF
--- a/src/Mapbender/ManagerBundle/Controller/StyleController.php
+++ b/src/Mapbender/ManagerBundle/Controller/StyleController.php
@@ -214,6 +214,7 @@ class StyleController extends ApplicationControllerBase
             'fontFamily' => 'Arial, Helvetica, sans-serif',
             'fontSize' => 11,
             'fontWeight' => 'regular',
+            'fontStyle' => 'normal',
             'fontColor' => '#333333',
             'fontOpacity' => 1,
         ];

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
@@ -13,12 +13,21 @@ class StyleEditorPreview {
     }
 
     drawLabel(ctx, s, x, y) {
-        const text = s.label || '';
-        if (!text) return;
+        const label = s.label || '';
+        const text = label;
         const fw = s.fontWeight || 'regular';
-        const prefix = fw === 'bold' ? 'bold ' : (fw === 'italic' ? 'italic ' : '');
-        ctx.font = `${prefix}${parseInt(s.fontSize) || 11}px ${s.fontFamily || 'Arial, Helvetica, sans-serif'}`;
-        ctx.fillStyle = StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1);
+        const fi = s.fontStyle || 'normal';
+        const isItalic = fi === 'italic';
+        const isBold = fw === 'bold';
+        const fontParts = [];
+        if (isItalic) fontParts.push('italic');
+        if (isBold) fontParts.push('bold');
+        fontParts.push(`${parseInt(s.fontSize) || 11}px`);
+        fontParts.push(s.fontFamily || 'Arial, Helvetica, sans-serif');
+        ctx.font = fontParts.join(' ');
+        ctx.fillStyle = label
+            ? StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1)
+            : 'rgba(0,0,0,0.35)';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(text, x, y);

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-editor-preview.js
@@ -14,7 +14,8 @@ class StyleEditorPreview {
 
     drawLabel(ctx, s, x, y) {
         const label = s.label || '';
-        const text = label;
+        if (!label)
+            return;
         const fw = s.fontWeight || 'regular';
         const fi = s.fontStyle || 'normal';
         const isItalic = fi === 'italic';
@@ -25,12 +26,10 @@ class StyleEditorPreview {
         fontParts.push(`${parseInt(s.fontSize) || 11}px`);
         fontParts.push(s.fontFamily || 'Arial, Helvetica, sans-serif');
         ctx.font = fontParts.join(' ');
-        ctx.fillStyle = label
-            ? StyleUtils.hexToRgba(s.fontColor || '#000000', parseFloat(s.fontOpacity) || 1)
-            : 'rgba(0,0,0,0.35)';
+        ctx.fillStyle = StyleUtils.hexToRgba(s.fontColor || '#000000', this._normalizeOpacity(s.fontOpacity));
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillText(text, x, y);
+        ctx.fillText(label, x, y);
     }
 
     drawAll(visualStyle) {
@@ -83,5 +82,10 @@ class StyleEditorPreview {
             ctx.closePath(); ctx.fill(); if (strokeWidth > 0) ctx.stroke();
             this.drawLabel(ctx, s, w/2, h/2);
         }
+    }
+
+    _normalizeOpacity(value) {
+        const alpha = parseFloat(value);
+        return isNaN(alpha) ? 1 : alpha;
     }
 }

--- a/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
+++ b/src/Mapbender/ManagerBundle/Resources/public/js/style-utils.js
@@ -15,7 +15,8 @@ class StyleUtils {
         const r = parseInt(hex.substring(0,2), 16);
         const g = parseInt(hex.substring(2,4), 16);
         const b = parseInt(hex.substring(4,6), 16);
-        return `rgba(${r},${g},${b},${parseFloat(opacity) || 1})`;
+        const alpha = parseFloat(opacity);
+        return `rgba(${r},${g},${b},${isNaN(alpha) ? 1 : alpha})`;
     }
 
     static extractMapboxPaint(styleJson, collectionId) {

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normal
           weight_bold: Fett
           weight_italic: Kursiv
+          font_style: Stil
+          style_normal: Normal
+          style_italic: Kursiv
           font_color: Schriftfarbe
           font_opacity: Schriftdeckkraft
           preview_legend: Vorschau

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -237,6 +237,9 @@ mb:
           weight_regular: Regular
           weight_bold: Bold
           weight_italic: Italic
+          font_style: Style
+          style_normal: Normal
+          style_italic: Italic
           font_color: Font Color
           font_opacity: Font Opacity
           preview_legend: Preview

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
@@ -233,6 +233,9 @@ mb:
           weight_regular: Normal
           weight_bold: Negrita
           weight_italic: Cursiva
+          font_style: Estilo
+          style_normal: Normal
+          style_italic: Cursiva
           font_color: Color de fuente
           font_opacity: Opacidad de fuente
           preview_legend: Vista previa

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
@@ -182,6 +182,9 @@ mb:
           weight_regular: Normal
           weight_bold: Gras
           weight_italic: Italique
+          font_style: Style
+          style_normal: Normal
+          style_italic: Italique
           font_color: Couleur de police
           font_opacity: Opacité de police
           preview_legend: Aperçu

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normale
           weight_bold: Grassetto
           weight_italic: Corsivo
+          font_style: Stile
+          style_normal: Normale
+          style_italic: Corsivo
           font_color: Colore del carattere
           font_opacity: Opacità del carattere
           preview_legend: Anteprima

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
@@ -182,6 +182,9 @@ mb:
           weight_regular: Normaal
           weight_bold: Vet
           weight_italic: Cursief
+          font_style: Stijl
+          style_normal: Normaal
+          style_italic: Cursief
           font_color: Letterkleur
           font_opacity: Letterdekking
           preview_legend: Voorbeeld

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
@@ -237,6 +237,9 @@ mb:
           weight_regular: Zwykły
           weight_bold: Pogrubiony
           weight_italic: Kursywa
+          font_style: Styl
+          style_normal: Normalny
+          style_italic: Kursywa
           font_color: Kolor czcionki
           font_opacity: Krycie czcionki
           preview_legend: Podgląd

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
@@ -235,6 +235,9 @@ mb:
           weight_regular: Normal
           weight_bold: Negrito
           weight_italic: Itálico
+          font_style: Estilo
+          style_normal: Normal
+          style_italic: Itálico
           font_color: Cor da fonte
           font_opacity: Opacidade da fonte
           preview_legend: Pré-visualização

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ro.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ro.yaml
@@ -234,6 +234,9 @@ mb:
           font_weight: Grosime
           weight_regular: Normal
           weight_bold: Aldin
+          font_style: Stil
+          style_normal: Normal
+          style_italic: Cursiv
           weight_italic: Cursiv
           font_color: 'Culoare font'
           font_opacity: 'Opacitate font'

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
@@ -232,6 +232,9 @@ mb:
           weight_regular: Обычный
           weight_bold: Полужирный
           weight_italic: Курсив
+          font_style: Стиль
+          style_normal: Обычный
+          style_italic: Курсив
           font_color: Цвет шрифта
           font_opacity: Непрозрачность шрифта
           preview_legend: Предпросмотр

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
@@ -177,6 +177,9 @@ mb:
           weight_regular: Normal
           weight_bold: Kalın
           weight_italic: İtalik
+          font_style: Stil
+          style_normal: Normal
+          style_italic: İtalik
           font_color: Yazı tipi rengi
           font_opacity: Yazı tipi opaklığı
           preview_legend: Önizleme

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
@@ -222,6 +222,9 @@ mb:
           weight_regular: Звичайний
           weight_bold: Напівжирний
           weight_italic: Курсив
+          font_style: Стиль
+          style_normal: Звичайний
+          style_italic: Курсив
           font_color: Колір шрифту
           font_opacity: Непрозорість шрифту
           preview_legend: Попередній перегляд

--- a/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
@@ -155,7 +155,7 @@
                             <input data-prop="label" type="text" class="form-control" value="{{ _visual.label ?? '' }}" placeholder="e.g. ${name}">
                         </div>
                         <div class="row">
-                            <div class="col-sm-6">
+                            <div class="col-sm-4">
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_family' | trans }}</label>
                                     <select data-prop="fontFamily" class="form-select">
@@ -178,7 +178,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="col-sm-3">
+                            <div class="col-sm-2">
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_size' | trans }}</label>
                                     <input data-prop="fontSize" type="number" min="5" max="30" class="form-control" value="{{ _visual.fontSize ?? 11 }}">
@@ -188,9 +188,19 @@
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_weight' | trans }}</label>
                                     <select data-prop="fontWeight" class="form-select">
-                                        <option value="regular"{{ _visual.fontWeight == 'regular' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
-                                        <option value="bold"{{ _visual.fontWeight == 'bold' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_bold' | trans }}</option>
-                                        <option value="italic"{{ _visual.fontWeight == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_italic' | trans }}</option>
+                                        <option value="regular"{{ (_visual.fontWeight ?? 'regular') not in ['bold'] ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
+                                        <option value="bold"{{ (_visual.fontWeight ?? '') == 'bold' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_bold' | trans }}</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-sm-3">
+                                <div class="mb-3">
+                                    <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_style' | trans }}</label>
+                                    {# backward compat: old styles stored italic in fontWeight #}
+                                    {% set _effectiveFontStyle = _visual.fontStyle ?? (_visual.fontWeight == 'italic' ? 'italic' : 'normal') %}
+                                    <select data-prop="fontStyle" class="form-select">
+                                        <option value="normal"{{ _effectiveFontStyle != 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_normal' | trans }}</option>
+                                        <option value="italic"{{ _effectiveFontStyle == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_italic' | trans }}</option>
                                     </select>
                                 </div>
                             </div>

--- a/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
@@ -196,11 +196,9 @@
                             <div class="col-sm-3">
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_style' | trans }}</label>
-                                    {# backward compat: old styles stored italic in fontWeight #}
-                                    {% set _effectiveFontStyle = _visual.fontStyle ?? (_visual.fontWeight == 'italic' ? 'italic' : 'normal') %}
-                                    <select data-prop="fontStyle" class="form-select">
-                                        <option value="normal"{{ _effectiveFontStyle != 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_normal' | trans }}</option>
-                                        <option value="italic"{{ _effectiveFontStyle == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_italic' | trans }}</option>
+                                      <select data-prop="fontStyle" class="form-select">
+                                          <option value="normal"{{ (_visual.fontStyle ?? 'normal') != 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_normal' | trans }}</option>
+                                          <option value="italic"{{ (_visual.fontStyle ?? 'normal') == 'italic' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.style_italic' | trans }}</option>
                                     </select>
                                 </div>
                             </div>

--- a/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Style/edit.html.twig
@@ -188,7 +188,7 @@
                                 <div class="mb-3">
                                     <label class="form-label fw-bold">{{ 'mb.manager.admin.style.editor.font_weight' | trans }}</label>
                                     <select data-prop="fontWeight" class="form-select">
-                                        <option value="regular"{{ (_visual.fontWeight ?? 'regular') not in ['bold'] ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
+                                        <option value="normal"{{ (_visual.fontWeight ?? 'normal') not in ['bold'] ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_regular' | trans }}</option>
                                         <option value="bold"{{ (_visual.fontWeight ?? '') == 'bold' ? ' selected' : '' }}>{{ 'mb.manager.admin.style.editor.weight_bold' | trans }}</option>
                                     </select>
                                 </div>

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -113,8 +113,8 @@ class OgcApiSource extends Mapbender.Source {
         }
 
         const labelTemplate = s.label;
-        const fontWeight = s.fontWeight === 'bold' ? 'bold' : 'normal';
-        const fontStyle = s.fontStyle === 'italic' ? 'italic' : 'normal';
+        const fontWeight = s.fontWeight ?? 'normal';
+        const fontStyle = s.fontStyle ?? 'normal';
         const textBaseOptions = {
             font: fontStyle + ' ' + fontWeight + ' ' + (s.fontSize || 12) + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
             fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -114,7 +114,7 @@ class OgcApiSource extends Mapbender.Source {
 
         const labelTemplate = s.label;
         const fontWeight = s.fontWeight === 'bold' ? 'bold' : 'normal';
-        const fontStyle = s.fontStyle === 'italic' ? 'italic' : (s.fontWeight === 'italic' ? 'italic' : 'normal');
+        const fontStyle = s.fontStyle === 'italic' ? 'italic' : 'normal';
         const textBaseOptions = {
             font: fontStyle + ' ' + fontWeight + ' ' + (s.fontSize || 12) + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
             fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -113,8 +113,10 @@ class OgcApiSource extends Mapbender.Source {
         }
 
         const labelTemplate = s.label;
+        const fontWeight = s.fontWeight === 'bold' ? 'bold' : 'normal';
+        const fontStyle = s.fontStyle === 'italic' ? 'italic' : (s.fontWeight === 'italic' ? 'italic' : 'normal');
         const textBaseOptions = {
-            font: (s.fontSize || '12') + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
+            font: fontStyle + ' ' + fontWeight + ' ' + (s.fontSize || 12) + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
             fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),
         };
 

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -114,11 +114,17 @@ class OgcApiSource extends Mapbender.Source {
         }
 
         const labelTemplate = s.label;
-        const fontWeight = s.fontWeight ?? 'normal';
-        const fontStyle = s.fontStyle ?? 'normal';
+        // Normalize font values - fallback to 'normal' if invalid CSS values
+        const isValidFontWeight = (val) => val === 'normal' || val === 'bold' || !isNaN(parseInt(val));
+        const isValidFontStyle = (val) => val === 'normal' || val === 'italic' || val === 'oblique';
+        const fontWeight = isValidFontWeight(s.fontWeight) ? (s.fontWeight || 'normal') : 'normal';
+        const fontStyle = isValidFontStyle(s.fontStyle) ? (s.fontStyle ?? 'normal') : 'normal';
+        const fontSize = (s.fontSize || 12) + 'px';
+        const fontFamily = s.fontFamily || 'Arial, Helvetica, sans-serif';
+        const fontColor = s.fontColor || '#000000';
         const textBaseOptions = {
-            font: fontStyle + ' ' + fontWeight + ' ' + (s.fontSize || 12) + 'px ' + (s.fontFamily || 'Arial, Helvetica, sans-serif'),
-            fill: new ol.style.Fill({ color: s.fontColor || '#000000' }),
+            font: fontStyle + ' ' + fontWeight + ' ' + fontSize + ' ' + fontFamily,
+            fill: new ol.style.Fill({ color: fontColor }),
         };
 
         if (!/\$\{[^}]+\}/.test(labelTemplate)) {


### PR DESCRIPTION
Style Editor: fixes font weight/style handling so bold, italic, and bold+italic render correctly.
Custom style labels now render consistently between editor preview and runtime rendering.

(internal Ticket 13393)