### PR TITLE
[ApplicationSwitcher] Fix various issues

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
+++ b/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
@@ -113,6 +113,14 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
                         $appConfig['img_url'] = $this->router->getContext()->getBaseUrl() . $imgPath;
                     }
                 }
+                if (!empty($appConfig['add_wms'])) {
+                    if (isset($appConfig['add_wms']['mb_layer_merge'])) {
+                        $appConfig['add_wms']['mb_layer_merge'] = ($appConfig['add_wms']['mb_layer_merge']) ? 1 : 0;
+                    }
+                    if (isset($appConfig['add_wms']['mb_wms_merge'])) {
+                        $appConfig['add_wms']['mb_wms_merge'] = ($appConfig['add_wms']['mb_wms_merge']) ? 1 : 0;
+                    }
+                }
                 $preparedAppConfig[$group][$slug] = $appConfig;
             } catch (AccessDeniedException | NotFoundHttpException $e) {
                 // external app (neither yaml nor database app)

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
@@ -19,7 +19,12 @@
         _initEvents() {
             $('a', this.$element).on('click', (e) => {
                 e.preventDefault();
-                this._switchApplication($(e.currentTarget).attr('href'));
+                const $a = $(e.currentTarget);
+                // no need to switch application, when Application Switcher is used to add a WMS
+                if (typeof $a.attr('data-mb-url') !== 'undefined') {
+                    return;
+                }
+                this._switchApplication($a.attr('href'));
             });
             $('select', this.$element).on('change', (e) => {
                 const slug = $(e.target).val();

--- a/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
@@ -30,10 +30,10 @@
                         {% if app.add_wms.mb_wms_layers is defined and app.add_wms.mb_wms_layers %}
                             data-mb-wms-layers="{{ app.add_wms.mb_wms_layers }}"
                         {% endif %}
-                        {% if app.add_wms.mb_layer_merge is defined and app.add_wms.mb_layer_merge %}
+                        {% if app.add_wms.mb_layer_merge is defined %}
                             data-mb-layer-merge="{{ app.add_wms.mb_layer_merge }}"
                         {% endif %}
-                        {% if app.add_wms.mb_wms_merge is defined and app.add_wms.mb_wms_merge %}
+                        {% if app.add_wms.mb_wms_merge is defined %}
                             data-mb-wms-merge="{{ app.add_wms.mb_wms_merge }}"
                         {% endif %}
                         {% if app.add_wms.mb_infoformat is defined and app.add_wms.mb_infoformat %}


### PR DESCRIPTION
Fixes the following issues with the application switcher:

- when a WMS is added the application now remains and is not opened in a new browser-tab
- issues with the attributes `data-mb-layer-merge` and `data-mb-wms-merge` are now fixed and work properly
- when a WMS is added the bounding box of the map now remains the same an is not changed to the start extent