### PR TITLE
fix: conversion between free assignments and bound instances

### DIFF
--- a/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
+++ b/src/Mapbender/ManagerBundle/Controller/ApplicationController.php
@@ -289,55 +289,35 @@ class ApplicationController extends ApplicationControllerBase
         ));
     }
 
-    /**
-     * @param Request $request
-     * @param SourceInstance $instance
-     * @param Layerset $layerset
-     * @return Response
-     */
-    #[ManagerRoute('/instance/{instance}/copy-into-layerset/{layerset}', methods: ['GET'])]
-    public function sharedinstancecopy(SourceInstance $instance, Layerset $layerset)
+    #[ManagerRoute('/assignment/{assignmentId}/convert-to-bound', methods: ['GET'])]
+    public function convertFreeAssignmentToBoundInstance(int $assignmentId): Response
     {
+        $assignment = $this->em->getRepository(ReusableSourceInstanceAssignment::class)->find($assignmentId);
+        if ($assignment === null) {
+            throw $this->createNotFoundException("Assignment not found");
+        }
+        $instance = $assignment->getInstance();
+        $layerset = $assignment->getLayerset();
+
         if ($instance->getLayerset()) {
             throw new \LogicException("Instance is already owned by a Layerset");
         }
         $application = $layerset->getApplication();
         $this->denyAccessUnlessGranted(ResourceDomainApplication::ACTION_EDIT, $application);
         $instanceCopy = clone $instance;
-        $this->em->persist($instanceCopy);
         $instanceCopy->setLayerset($layerset);
-        $instanceCopy->setWeight(-1);
-        $layerset->addInstance($instanceCopy);
+        $instanceCopy->setWeight($assignment->getWeight());
+        $instanceCopy->setEnabled($assignment->getEnabled());
+        $this->em->persist($instanceCopy);
         $this->em->flush();
 
-        /**
-         * remove original shared instance from layerset
-         * @todo: finding the right assignment requires more information than is currently passed on by
-         * @see RepositoryController::instanceAction. We simply remove all assignments of the instance.
-         */
-        $reusablePartitions = $layerset->getReusableInstanceAssignments()->partition(function ($_, $assignment) use ($instance) {
-            /** @var SourceInstanceAssignment $assignment */
-            return $assignment->getInstance() !== $instance;
-        });
-        foreach ($reusablePartitions[1] as $removableAssignment) {
-            /** @var SourceInstanceAssignment $removableAssignment */
-            $instanceCopy->setEnabled($removableAssignment->getEnabled());
-            $this->permissionManager->movePermissions($removableAssignment, $instanceCopy, true);
-            $this->em->remove($removableAssignment);
-            $assignmentWeight = $removableAssignment->getWeight();
-            if ($instanceCopy->getWeight() < 0 && $assignmentWeight >= 0) {
-                $instanceCopy->setWeight($assignmentWeight);
-            }
-        }
-        $layerset->setReusableInstanceAssignments($reusablePartitions[0]);
-        WeightSortedCollectionUtil::reassignWeights($layerset->getCombinedInstanceAssignments());
-        $this->em->persist($layerset);
-        $this->em->persist($application);
+        $this->permissionManager->movePermissions($assignment, $instanceCopy, true);
+        $this->em->remove($assignment);
+
         $application->setUpdated(new \DateTime('now'));
         $this->em->flush();
         $this->addFlash('success', 'mb.manager.source.instance.converted_to_bound');
         return $this->redirectToRoute('mapbender_manager_repository_instance', array(
-            "slug" => $application->getSlug(),
             "instanceId" => $instanceCopy->getId(),
         ));
     }
@@ -375,9 +355,8 @@ class ApplicationController extends ApplicationControllerBase
         $instance->setLayerset(null);
         $this->em->flush();
         $this->addFlash('success', 'mb.manager.source.instance.reusable_assigned_to_application');
-        return $this->redirectToRoute("mapbender_manager_repository_instance", array(
-            "slug" => $application->getSlug(),
-            "instanceId" => $instance->getId(),
+        return $this->redirectToRoute("mapbender_manager_repository_unowned_instance_scoped", array(
+            "assignmentId" => $assignment->getId(),
         ));
     }
 

--- a/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
+++ b/src/Mapbender/ManagerBundle/Controller/SourceInstanceController.php
@@ -41,32 +41,26 @@ class SourceInstanceController extends ApplicationControllerBase
         parent::__construct($em);
     }
 
-    /**
-     * @param Request $request
-     * @param string|null $slug
-     * @param string $instanceId
-     * @param Layerset|null $layerset
-     * @return Response
-     */
-    #[Route('/application/{slug}/instance/{instanceId}', name: 'mapbender_manager_repository_instance')]
-    #[Route('/instance/{instanceId}', name: 'mapbender_manager_repository_unowned_instance', requirements: ['instanceId' => '\d+'])]
-    #[Route('/instance/{instanceId}/layerset/{layerset}', name: 'mapbender_manager_repository_unowned_instance_scoped', requirements: ['instanceId' => '\d+'])]
-    public function edit(Request $request, $instanceId, $slug = null, ?Layerset $layerset = null)
+    #[Route('/instance/{instanceId}', name: 'mapbender_manager_repository_instance', requirements: ['instanceId' => '\d+'])]
+    #[Route('/instanceassignment/{assignmentId}', name: 'mapbender_manager_repository_unowned_instance_scoped', requirements: ['assignmentId' => '\d+'])]
+    public function edit(Request $request, ?int $instanceId = null, ?int $assignmentId = null)
     {
-        /** @var SourceInstance|null $instance */
-        $instance = $this->em->getRepository(SourceInstance::class)->find($instanceId);
-        $applicationRepository = $this->getDbApplicationRepository();
-        if (!$layerset) {
-            if ($slug) {
-                $application = $applicationRepository->findOneBy(array(
-                    'slug' => $slug,
-                ));
-            } else {
-                $application = null;
+        if ($assignmentId !== null) {
+            $assignment = $this->em->getRepository(ReusableSourceInstanceAssignment::class)->find($assignmentId);
+            if ($assignment === null) {
+                throw $this->createNotFoundException();
             }
+            $instance = $assignment->getInstance();
+            $layerset = $assignment->getLayerset();
         } else {
-            $application = $layerset->getApplication();
+            $instance = $this->em->getRepository(SourceInstance::class)->find($instanceId);
+            if ($instance === null) {
+                throw $this->createNotFoundException();
+            }
+            $layerset = $instance->getLayerset();
         }
+        $application = $layerset?->getApplication();
+
         /** @var Application|null $application */
         if ($application) {
             $this->denyAccessUnlessGranted(ResourceDomainApplication::ACTION_EDIT, $application);
@@ -90,6 +84,7 @@ class SourceInstanceController extends ApplicationControllerBase
         if ($form->isSubmitted() && $form->isValid()) {
             $this->em->persist($instance);
             $dtNow = new \DateTime('now');
+            $applicationRepository = $this->getDbApplicationRepository();
             foreach ($applicationRepository->findWithSourceInstance($instance) as $affectedApplication) {
                 $this->em->persist($affectedApplication);
                 $affectedApplication->setUpdated($dtNow);
@@ -107,6 +102,7 @@ class SourceInstanceController extends ApplicationControllerBase
             "form" => $form->createView(),
             "instance" => $form->getData(),
             'layerset' => $layerset,
+            "assignment" => $assignment ?? null,
             'edit_shared_instances' => $this->isGranted(ResourceDomainInstallation::ACTION_EDIT_FREE_INSTANCES),
         ));
     }
@@ -178,18 +174,12 @@ class SourceInstanceController extends ApplicationControllerBase
         $newInstance = $this->createNewSourceInstance($application, $sourceId, $layersetId, $this->em);
         $this->addFlash('success', 'mb.manager.source.instance.created');
         return $this->redirectToRoute("mapbender_manager_repository_instance", array(
-            "slug" => $slug,
             "instanceId" => $newInstance->getId(),
         ));
     }
 
-    /**
-     * @param Request $request
-     * @param Source $source
-     * @return Response
-     */
     #[Route('/instance/createshared/{source}', methods: ['GET', 'POST'])]
-    public function createshared(Source $source)
+    public function createshared(Source $source): Response
     {
         $this->denyAccessUnlessGranted(ResourceDomainInstallation::ACTION_EDIT_FREE_INSTANCES);
         // @todo: only act on post
@@ -198,18 +188,13 @@ class SourceInstanceController extends ApplicationControllerBase
         $this->em->persist($instance);
         $this->em->flush();
         $this->addFlash('success', 'mb.manager.source.instance.created_reusable');
-        return $this->redirectToRoute('mapbender_manager_repository_unowned_instance', array(
+        return $this->redirectToRoute('mapbender_manager_repository_instance', array(
             'instanceId' => $instance->getId(),
         ));
     }
 
-    /**
-     * @param Request $request
-     * @param SourceInstance $instance
-     * @return Response
-     */
     #[Route('/instance/{instance}/promotetoshared', name: 'mapbender_manager_repository_promotetosharedinstance')]
-    public function promotetoshared(SourceInstance $instance)
+    public function promotetoshared(SourceInstance $instance): Response
     {
         $this->denyAccessUnlessGranted(ResourceDomainInstallation::ACTION_EDIT_FREE_INSTANCES);
         $layerset = $instance->getLayerset();
@@ -238,9 +223,8 @@ class SourceInstanceController extends ApplicationControllerBase
         $this->em->flush();
 
         $this->addFlash('success', $this->trans->trans('mb.manager.admin.instance.converted_to_shared'));
-        return $this->redirectToRoute('mapbender_manager_repository_instance', array(
-            'instanceId' => $instance->getId(),
-            'slug' => $layerset->getApplication()->getSlug(),
+        return $this->redirectToRoute('mapbender_manager_repository_unowned_instance_scoped', array(
+            'assignmentId' => $assignment->getId(),
         ));
     }
 

--- a/src/Mapbender/ManagerBundle/Resources/views/Application/form-layersets.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Application/form-layersets.html.twig
@@ -78,8 +78,8 @@
                   : path('mapbender_manager_repository_instanceweight', {'slug': application.slug,'layersetId': layerset.id, 'instanceId': assignment.instance.id})
               ,
               '_edit_url': _is_reusable
-                  ? (edit_shared_instances ? path("mapbender_manager_repository_unowned_instance_scoped", {"instanceId": instance.id, "layerset": layerset }) : null)
-                  : path("mapbender_manager_repository_instance",{"slug": application.slug, "instanceId": instance.id})
+                  ? (edit_shared_instances ? path("mapbender_manager_repository_unowned_instance_scoped", {"assignmentId": assignment.id}) : null)
+                  : path("mapbender_manager_repository_instance",{"instanceId": instance.id})
                   ,
               '_security_url': _is_reusable
                   ? path("mapbender_manager_sharedinstance_security", {"assignmentId": assignment.id, "layersetId": layerset.id })

--- a/src/Mapbender/ManagerBundle/Resources/views/Repository/instance.html.twig
+++ b/src/Mapbender/ManagerBundle/Resources/views/Repository/instance.html.twig
@@ -54,7 +54,7 @@
           </p>
           <p>
             {%- if _is_reusable_instance and layerset is defined and layerset -%}
-            <a class="btn btn-sm btn-info" href="{{ path('mapbender_manager_application_sharedinstancecopy', {'instance': instance, 'layerset': layerset}) }}"><i class="fas fa-anchor"></i>&nbsp;{{ 'mb.manager.source.instance.convert_to_bound' | trans }}</a>
+            <a class="btn btn-sm btn-info" href="{{ path('mapbender_manager_application_convertfreeassignmenttoboundinstance', {'assignmentId': assignment.id}) }}"><i class="fas fa-anchor"></i>&nbsp;{{ 'mb.manager.source.instance.convert_to_bound' | trans }}</a>
             {%- endif -%}
             {%- if not _is_reusable_instance and edit_shared_instances -%}
             <a class="btn btn-sm btn-info" href="{{ path('mapbender_manager_repository_promotetosharedinstance', {'instance': instance}) }}"><i class="fas fa-wifi"></i>&nbsp;{{ 'mb.manager.source.instance.convert_to_reusable' | trans }}</a>


### PR DESCRIPTION
Addresses  parts of internal ticket 12348

## Issue
This PR addresses a problem when converting source instances (for map layers) between being bound to a layerset and being a reusable and freely assignable. The main difference being:
- **Reusable instance**: An instance which can be be added to multiple layersets (or multiple times to the same layerset). The instances is the same across all usages, so changes to the instance will be reflected everywhere it is used / assigned.
- **Bound instance**: An instance created and used exactly once.

Instances can be converted between the two states. However when a reusable instance was converted to a bound instance, all occurrences of it where automatically converted to bound instances. This was not the intended behaviour, instead only the currently active usage of the instance should be converted to a bound instance while all other usages should stay reusable instances.

## Changes / Fix
- The logic was adjusted to reflect the desired behaviour: Changing a specific usage of a reusable instance to a a bound instance only changes this one specific usage, not all references to the instance
- Adjusting this logic required changing several routes and redirects
- The main logic was refactored, slimmed down and made more readable
- Redundant documentation strings where removed on all functions which were edited.