### PR TITLE
Hide loading spinner when a layer is deactivated in the layer tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## next bugfix release
-* 
+* Do not show loading spinner in layer tree indefinetely when disabling source while it's loading ([#PR1886](https://github.com/mapbender/mapbender/pull/1886))
 
 ## v4.2.6
 Features:

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -203,7 +203,7 @@ window.Mapbender.MapModelOl4 = (function() {
                 });
             }
         });
-        nativeSource.on(["tileloadend", "imageloadend"], function() {
+        nativeSource.on(["tileloadend", "imageloadend", "sourcedeactivated"], function() {
             tmp.pendingLoads = Math.max(0, tmp.pendingLoads - 1);
             if (!tmp.pendingLoads) {
                 mbMap.element.trigger('mbmapsourceloadend', {

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -236,6 +236,7 @@ window.Mapbender = Mapbender || {};
             }
             if (!targetVisibility) {
                 engine.setLayerVisibility(olLayer, false);
+                olLayer.getSource().dispatchEvent("sourcedeactivated");
             } else {
                 var newParams = {
                     LAYERS: layers,


### PR DESCRIPTION
When a source is deactivated in the layertree while it was still loading, the loading spinner was shown indefinetly. This PR fixes that and instantly hides the loading spinner when a source was deactivated.