### PR TITLE
Fix print order when ogc api features sources are involved

### DIFF
--- a/docs/sources/custom-source-frontend.md
+++ b/docs/sources/custom-source-frontend.md
@@ -21,13 +21,14 @@ can be toggled individually. For example, in a WMS service within one url there 
 When extending from `Mapbender.Source` you need to implement the following methods:
 
 - `createNativeLayers(srsName, mapOptions)`: Eventually your data will be rendered on an [OpenLayers map](https://openlayers.org/).
-  Create and return the native layers you need here. For example, for a single vector layer:
+  Create and return the native layers you need here. For vector layers, call `nativeLayer.set('geojson-mblayer', true)`, otherwise the layer order will not be respected in print, but instead be added at the top, along with e.g. the sketches. For example, for a single vector layer:
 
 ```js
-createNativeLayers(srsName, mapOptions) {
-    this.nativeLayers = [new ol.layer.Vector({
-        source: new ol.source.Vector()
-    })];
+createNativeLayers(srsName, mapOptions)
+{
+    const vectorLayer = new ol.layer.Vector({source: new ol.source.Vector()});
+    vectorLayer.set("geojson-mb-layer", true);
+    this.nativeLayers = [vectorLayer];
     return this.nativeLayers;
 }
 ```
@@ -59,7 +60,7 @@ Also, you can override the following methods:
   modifies runtime settings you might need for your source. By default, this is only opacity.
 - `getConfiguredSettings()`: returns the initial settings set during initialisation
 - `checkRecreateOnSrsSwitch(oldProj, newProj)`: indicates whether this source should be recreated when a srs change occurs
-- `getPrintConfigs(bounds, scale, srsName)`: Returns information that is passed to the printing service when printing or exporting a map
+- `getPrintConfigs(bounds, scale, srsName)`: Returns information that is passed to the printing service when printing or exporting a map. For vector layers, use Mapbender.Model.dumpVectorLayerGeometriesForExport.
 
 The following methods are also available to be used which you probably don't need to override:
 
@@ -110,10 +111,10 @@ This works with the following code:
 
 ```js
 const source = Mapbender.Source.factory(sourceDef);
-Mapbender.model.addSource(source);
+Mapbender.Model.addSource(source);
 
 // shortcut
-const source2 = Mapbender.model.addSourceFromConfig(sourceDef);
+const source2 = Mapbender.Model.addSourceFromConfig(sourceDef);
 ```
 
 The sourceDef needs to be an JS object with the following properties:

--- a/docs/sources/custom-source-frontend.md
+++ b/docs/sources/custom-source-frontend.md
@@ -21,7 +21,7 @@ can be toggled individually. For example, in a WMS service within one url there 
 When extending from `Mapbender.Source` you need to implement the following methods:
 
 - `createNativeLayers(srsName, mapOptions)`: Eventually your data will be rendered on an [OpenLayers map](https://openlayers.org/).
-  Create and return the native layers you need here. For vector layers, call `nativeLayer.set('geojson-mblayer', true)`, otherwise the layer order will not be respected in print, but instead be added at the top, along with e.g. the sketches. For example, for a single vector layer:
+  Create and return the native layers you need here. For vector layers, call `nativeLayer.set('geojson-mb-layer', true)`, otherwise the layer order will not be respected in print, but instead be added at the top, along with e.g. the sketches. For example, for a single vector layer:
 
 ```js
 createNativeLayers(srsName, mapOptions)

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
@@ -94,7 +94,7 @@
 
         /**
          * Creates the native OpenLayers layers required for this source and stores them in the class variable nativeLayers
-         * For vector layers, call `nativeLayer.set('geojson-mblayer', true), otherwise the layer order will not be respected in print
+         * For vector layers, call `nativeLayer.set('geojson-mb-layer', true), otherwise the layer order will not be respected in print
          * @abstract
          * @param {String} srsName
          * @param {Object} [mapOptions]

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
@@ -94,6 +94,7 @@
 
         /**
          * Creates the native OpenLayers layers required for this source and stores them in the class variable nativeLayers
+         * For vector layers, call `nativeLayer.set('geojson-mblayer', true), otherwise the layer order will not be respected in print
          * @abstract
          * @param {String} srsName
          * @param {Object} [mapOptions]
@@ -356,6 +357,7 @@
 
         /**
          * Returns information that is passed to the printing service when printing or exporting a map
+         * For vector layers, use Mapbender.Model.dumpVectorLayerGeometriesForExport
          * @param {Number[]} bounds
          * @param {Number} scale
          * @param {String} srsName

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -427,7 +427,7 @@ window.Mapbender.MapModelOl4 = (function() {
     },
     /**
      * @param {ol.layer.Vector[]} vectorLayers the layers whose geometries should be converted to geojson
-     * @param {function(ol.feature.Feature): boolean} [featureFilter] a filter function to exclude certain features
+     * @param {function(ol.Feature): boolean} [featureFilter] a filter function to exclude certain features
      */
     dumpVectorLayerGeometriesForExport(vectorLayers, featureFilter) {
         const dataOut = [];

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender.model.js
@@ -413,6 +413,44 @@ window.Mapbender.MapModelOl4 = (function() {
     featureToGeoJsonGeometry: function(feature) {
         return this._geojsonFormat.writeFeatureObject(feature).geometry;
     },
+
+    _dumpFeatureGeometries(layer, features, resolution) {
+        return this.dumpGeoJsonFeatures(features, layer, resolution, true)
+            .map(function (gjFeature) {
+                // Legacy data format quirks (not actually GeoJson):
+                // 1) Strip "type: 'Feature'" outer container object
+                // 2) move style into geometry object
+                return Object.assign({}, gjFeature.geometry, {
+                    style: gjFeature.style
+                });
+            });
+    },
+    /**
+     * @param {ol.layer.Vector[]} vectorLayers the layers whose geometries should be converted to geojson
+     * @param {function(ol.feature.Feature): boolean} [featureFilter] a filter function to exclude certain features
+     */
+    dumpVectorLayerGeometriesForExport(vectorLayers, featureFilter) {
+        const dataOut = [];
+        for (let li = 0; li < vectorLayers.length; ++li) {
+            const layer = vectorLayers[li];
+
+            let features = layer.getSource().getFeatures();
+            if (featureFilter) {
+                features = features.filter(featureFilter);
+            }
+
+            if (!features.length) {
+                continue;
+            }
+            const layerFeatureData = this._dumpFeatureGeometries(layer, features);
+            dataOut.push({
+                "type": "GeoJSON+Style",
+                "opacity": layer.getOpacity(),
+                "geometries": layerFeatureData
+            });
+        }
+        return dataOut;
+    },
     dumpGeoJsonFeatures: function(features, layer, resolution, includeStyle) {
         // Sort features like the canvas renderer would
         /** @see https://github.com/openlayers/openlayers/blob/v6.4.3/src/ol/renderer/canvas/VectorLayer.js#L651 */

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.source.js
@@ -27,10 +27,18 @@ class OgcApiSource extends Mapbender.Source {
             const styleDef = this._getStyleDef(child);
             this._applyStyle(vectorLayer, styleDef, collectionId);
             vectorLayer.set('_activeStyle', child.options.style || null);
+            vectorLayer.set('geojson-mb-layer', true);
             this.nativeLayers.push(vectorLayer);
         });
         this.setOpacity(this.options.opacity);
         return this.nativeLayers;
+    }
+
+    getPrintConfigs(bounds, scale, srsName) {
+        const layers = this.getNativeLayers().filter((l) => l.getVisible() && l.getOpacity());
+        if (!layers.length) return super.getPrintConfigs();
+
+        return Mapbender.Model.dumpVectorLayerGeometriesForExport(layers);
     }
 
     _hexToRgba(hex, opacity) {

--- a/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
@@ -189,58 +189,6 @@
         }
 
         /**
-         * Should return true if the given feature geometry should be included in export.
-         *
-         * @param geometry
-         * @returns {boolean}
-         * @private
-         */
-        _filterFeatureGeometry(geometry) {
-            if (geometry.style.fillOpacity > 0 || geometry.style.strokeOpacity > 0) {
-                return true;
-            }
-            if (geometry.style.externalGraphic) {
-                return true;
-            }
-            if (geometry.style.label !== undefined) {
-                return true;
-            }
-            return false;
-        }
-
-        _dumpFeatureGeometries(layer, features, resolution) {
-            return this.map.model.dumpGeoJsonFeatures(features, layer, resolution, true)
-                .map(function (gjFeature) {
-                    // Legacy data format quirks (not actually GeoJson):
-                    // 1) Strip "type: 'Feature'" outer container object
-                    // 2) move style into geometry object
-                    return Object.assign({}, gjFeature.geometry, {
-                        style: gjFeature.style
-                    });
-                })
-                ;
-        }
-
-        /**
-         * Should return export data (sent to backend) for the given geometry layer. Given layer is guaranteed
-         * to have passsed through the _filterGeometryLayer check positively.
-         *
-         * @param {OpenLayers.Layer.Vector|OpenLayers.Layer} layer
-         * @returns VectorLayerData~export
-         * @private
-         */
-        _extractGeometryLayerData(layer) {
-            var postFilter = this._filterFeatureGeometry.bind(this);
-            var features = layer.features.filter(this._filterFeature.bind(this))
-            var geometries = this._dumpFeatureGeometries(layer, features);
-            return {
-                type: 'GeoJSON+Style',
-                opacity: 1,
-                geometries: geometries.filter(postFilter)
-            };
-        }
-
-        /**
          * Hook method to filter vector layers before including them in export.
          * Override this in subclasses to exclude specific layers.
          *
@@ -249,7 +197,7 @@
          * @private
          */
         _filterVectorLayer(layer) {
-            return true;
+            return !layer.get("geojson-mb-layer");
         }
 
         _collectGeometryLayers() {
@@ -270,32 +218,17 @@
                     }
                 }
             }
-
             this.map.model.olMap.getLayers().getArray().forEach(processLayer);
-            var dataOut = [];
-            for (var li = 0; li < vectorLayers.length; ++li) {
-                var layer = vectorLayers[li];
-                var features = this.filterFeatures(layer.getSource().getFeatures());
-                if (!features.length) {
-                    continue;
-                }
-                var layerFeatureData = this._dumpFeatureGeometries(layer, features);
-                dataOut.push({
-                    "type": "GeoJSON+Style",
-                    "opacity": layer.getOpacity(),
-                    "geometries": layerFeatureData
-                });
-            }
-            return dataOut;
+            return Mapbender.Model.dumpVectorLayerGeometriesForExport(vectorLayers, this.filterFeature.bind(this));
         }
 
         /**
          * Filters a set of features for export. Override this in subclasses to exclude specific features.
-         * @param {ol.Feature[]} features
-         * @return {ol.Feature[]}
+         * @param {ol.feature.Feature} feature
+         * @return {boolean}
          */
-        filterFeatures(features) {
-            return features;
+        filterFeature(feature) {
+            return true;
         }
         /**
          * Should return export data (sent to backend) for the given geometry layer. Given layer is guaranteed

--- a/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
@@ -223,8 +223,8 @@
         }
 
         /**
-         * Filters a set of features for export. Override this in subclasses to exclude specific features.
-         * @param {ol.feature.Feature} feature
+         * Checks whether a feature should be exported. Override this in subclasses to exclude specific features.
+         * @param {ol.Feature} feature
          * @return {boolean}
          */
         filterFeature(feature) {

--- a/src/Mapbender/PrintBundle/Resources/public/element/MbBatchPrintClient.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/MbBatchPrintClient.js
@@ -1,7 +1,7 @@
 (function() {
     /**
      * Batch Print Client Widget
-     * 
+     *
      * Extends MbPrint with multiframe/serial printing support:
      * - Multiple print frame selection with mouse-following
      * - Click to pin frames to map
@@ -12,58 +12,58 @@
     class MbBatchPrintClient extends Mapbender.Element.MbPrint {
         // Frame management (initialized in constructor)
         frameManager = null;
-        
+
         // Rotation controller (initialized in constructor)
         rotationController = null;
-        
+
         // Table controller (initialized in constructor)
         tableController = null;
-        
+
         // Mouse-following state
         mouseFollowActive = false;
         mouseMoveHandler = null;
         mouseClickHandler = null;
         mapHoverHandler = null;
-        
+
         // Layer constants
         PINNED_FRAMES_LAYER = 1;  // Layer index for pinned frame features
         PINNED_FRAMES_ZINDEX = 1000;  // Top layer - actual print frames
         ROTATION_ZINDEX = 999;         // Middle layer - interactive rotation controls
         TRACK_LAYER_ZINDEX = 998;      // Bottom layer - reference track/guide layer
-        
+
         // Interaction tolerances
         hitToleranceFrame = 5;
         hitToleranceRotation = 10;
-        
+
         // Animation and timing
         dragEndDelay = 50;
         tabSwitchDelay = 50;
-        
+
         // Map view settings
         trackFitPadding = [100, 100, 100, 100];
         trackFitDuration = 500;
         trackFitMaxZoom = 16;
-        
+
         // Style configuration (initialized in constructor)
         styleConfig = null;
 
         constructor(configuration, $element) {
             super(configuration, $element);
-            
+
             // Defer initialization until parent setup is complete
             var self = this;
             Mapbender.elementRegistry.waitReady('.mb-element-map').then(function(mbMap) {
                 self._setupBatchPrint(mbMap);
             });
         }
-        
+
         /**
          * Override _setup to handle geofile section visibility
          * @private
          */
         _setup() {
             super._setup();
-            
+
             // In dialog mode, show geofile upload section
             // In sidepane mode, hide it until frame is activated
             if (this.useDialog_) {
@@ -72,17 +72,17 @@
                 $('.-fn-geofile-upload', this.$element).hide();
             }
         }
-        
+
         /**
          * Setup batch print functionality after map is ready
          * @private
          */
         _setupBatchPrint(mbMap) {
             var self = this;
-            
+
             // Initialize style configuration
             this.styleConfig = new Mapbender.BatchPrintStyleConfig();
-            
+
             // Initialize frame manager
             this.frameManager = new Mapbender.BatchPrintFrameManager({
                 styleConfig: this.styleConfig,
@@ -97,7 +97,7 @@
                     layerBridge.removeNativeFeatures([frameData.feature]);
                 }
             });
-            
+
             // Initialize rotation controller
             this.rotationController = new Mapbender.BatchPrintRotationController({
                 map: this.map.getModel().olMap,
@@ -113,7 +113,7 @@
                     self.tableController.updateTable();
                 }
             });
-            
+
             // Initialize table controller
             this.tableController = new Mapbender.BatchPrintTableController({
                 $element: this.$element,
@@ -135,16 +135,16 @@
                     self.frameManager.reorder(newOrder);
                 }
             });
-            
+
             // Setup property proxies for backward compatibility
             this._setupPropertyProxies();
-            
+
             // Add unique class identifier
             this.$element.addClass('mb-element-batchprintclient');
 
             // Remove rotation control (form row containing the rotation input)
             $('input[name="rotation"]', this.$element).parent().remove();
-            
+
             // Initialize geofile handler
             this.geofileHandler = new Mapbender.BatchPrintGeofileHandler({
                 $element: this.$element,
@@ -159,26 +159,26 @@
                     return self._placeFrameAtPosition(coord, bearing, previousRotation);
                 }
             });
-            
+
             // Mark element layers as internal for print filtering
             var selectionLayer = Mapbender.vectorLayerPool.getElementLayer(this, 0);
             if (selectionLayer && selectionLayer.getNativeLayer()) {
                 selectionLayer.getNativeLayer().set('batchPrintClientInternal', true);
             }
-            
+
             var pinnedLayer = Mapbender.vectorLayerPool.getElementLayer(this, this.PINNED_FRAMES_LAYER);
             if (pinnedLayer && pinnedLayer.getNativeLayer()) {
                 pinnedLayer.getNativeLayer().set('batchPrintClientInternal', true);
             }
-            
+
             // Change submit button text
             $('input[type="submit"]', this.$element).val(Mapbender.trans('mb.print.printclient.batchprint.btn.submit'));
-            
+
             // Setup delete all frames button
             $('.-fn-delete-all-frames', this.$element).on('click', function() {
                 self._deleteAllFrames();
             });
-            
+
             // Stop mouse-follow when mouse enters widget
             this.$element.on('mouseenter', function() {
                 if (self.mouseFollowActive) {
@@ -189,7 +189,7 @@
                     self.feature.setStyle(self.styleConfig.createEmptyStyle());  // Make invisible
                 }
             });
-            
+
             // Restart mouse-follow when mouse leaves widget
             this.$element.on('mouseleave', function() {
                 if (self.selectionActive && !self.mouseFollowActive) {
@@ -202,26 +202,26 @@
                 }
             });
         }
-        
+
         /**
          * Setup property proxies for backward compatibility
          * @private
          */
         _setupPropertyProxies() {
             var self = this;
-            
+
             Object.defineProperty(this, 'pinnedFeatures', {
                 get: function() { return self.frameManager.getFrames(); },
                 configurable: true
             });
-            
+
             Object.defineProperty(this, 'featureCounter', {
                 get: function() { return self.frameManager.frameCounter; },
                 set: function(value) { self.frameManager.frameCounter = value; },
                 configurable: true
             });
         }
-        
+
         /**
          * Filter out internal BatchPrintClient layers from print output
          * All internal layers are marked with 'batchPrintClientInternal' property
@@ -230,9 +230,9 @@
          * @private
          */
         _filterVectorLayer(layer) {
-            return layer.get('batchPrintClientInternal') !== true;
+            return layer.get('batchPrintClientInternal') !== true && super._filterVectorLayer(layer);
         }
-        
+
         /**
          * Override parent's _pickScale to select a scale two steps bigger (more zoomed out)
          * than the current map scale for batch printing
@@ -240,26 +240,26 @@
         _pickScale(closestToMapScale) {
             // Get the scale that the parent would choose (current map scale or smallest that fits)
             const parentScale = super._pickScale(closestToMapScale);
-            
+
             // Get available scales from options
             var scales = this.options.scales;
             if (!scales || !scales.length) {
                 return parentScale;
             }
-            
+
             // Find the index of the parent's chosen scale
             var currentIndex = scales.indexOf(parentScale);
             if (currentIndex === -1) {
                 return parentScale;
             }
-            
+
             // Move two steps backward in the array (bigger scale = more zoomed out)
             // Using 2 steps provides a good balance between coverage and detail for batch printing
             var SCALE_STEPS_ZOOM_OUT = 2;
             var targetIndex = Math.max(currentIndex - SCALE_STEPS_ZOOM_OUT, 0);
             return scales[targetIndex];
         }
-        
+
         /**
          * Override parent's _activateSelection to start mouse-following
          */
@@ -269,66 +269,66 @@
             Mapbender.vectorLayerPool.getElementLayer(this, 0).clear();
             Mapbender.vectorLayerPool.raiseElementLayers(this);
             Mapbender.vectorLayerPool.showElementLayers(this);
-            
+
             // Show geofile upload section when frame is activated (only in sidepane mode)
             if (!this.useDialog_) {
                 $('.-fn-geofile-upload', this.$element).show();
             }
-            
+
             var self = this;
             this._getTemplateSize().then(function() {
                 self.selectionActive = true;
                 self._setScale();
-                
+
                 // Create initial feature at map center
                 var model = self.map.getModel();
                 var center = model.getCurrentMapCenter();
                 self.feature = self._createFeature(self._getPrintScale(), center, self.inputRotation_);
                 self._redrawSelectionFeatures();
-                
+
                 // Start mouse follow instead of drag interaction
                 self._startMouseFollow();
-                
+
                 $('input[type="submit"]', self.$form).removeClass('hidden');
             });
         }
-        
+
         /**
          * Override parent's _deactivateSelection to cleanup
          */
         _deactivateSelection() {
             this._stopMouseFollow();
             this._clearPinnedFeatures();
-            
+
             // Hide geofile upload section when frame is deactivated (only in sidepane mode)
             if (!this.useDialog_) {
                 $('.-fn-geofile-upload', this.$element).hide();
             }
-            
+
             // Cleanup geofile handler
             if (this.geofileHandler) {
                 this.geofileHandler.clear();
             }
-            
+
             // Cleanup controllers
             if (this.tableController) {
                 this.tableController.destroy();
             }
-            
+
             // Remove map hover handler
             if (this.mapHoverHandler) {
                 var map = this.map.getModel().olMap;
                 map.un('pointermove', this.mapHoverHandler);
                 this.mapHoverHandler = null;
             }
-            
+
             this.featureCounter = 0;
             if (this.tableController) {
                 this.tableController.updateTable();
             }
             super._deactivateSelection();
         }
-        
+
         /**
          * Start mouse-following behavior for frame placement
          */
@@ -336,60 +336,60 @@
             if (this.mouseFollowActive) {
                 return;
             }
-            
+
             this.mouseFollowActive = true;
-            
+
             var self = this;
             var map = this.map.getModel().olMap;
             var $mapElement = $(map.getTargetElement());
-            
+
             // Use OpenLayers click event - fires immediately on click
             this.mouseClickHandler = function(evt) {
                 if (!self.mouseFollowActive || self.rotationController.isCurrentlyRotating()) {
                     return;
                 }
-                
+
                 // Pin the current frame
                 self._pinCurrentFrame();
             };
-            
+
             map.on('click', this.mouseClickHandler);
-            
+
             // Mouse move handler - update feature position
             this.mouseMoveHandler = function(evt) {
                 if (!self.mouseFollowActive || !self.feature) {
                     return;
                 }
-                
+
                 var pixel = map.getEventPixel(evt.originalEvent);
                 var coordinate = map.getCoordinateFromPixel(pixel);
-                
+
                 // Hide mouse-move-frame when hovering over any feature (excluding the selection frame itself)
                 var hasOtherFeature = map.forEachFeatureAtPixel(pixel, function(mapFeature) {
                     return mapFeature !== self.feature;
                 });
-                
+
                 if (hasOtherFeature) {
                     self.feature.setStyle(self.styleConfig.createEmptyStyle());  // Make invisible
                 } else {
                     self.feature.setStyle(null);  // Reset to default style
                     self._redrawSelectionFeatures();
                 }
-                
+
                 if (coordinate) {
                     self._moveFeatureToCoordinate(coordinate);
                 }
             };
-            
+
             $mapElement.on('mousemove', this.mouseMoveHandler);
-            
+
             // Hide feature when mouse leaves map and enters any widget
             $mapElement.on('mouseleave', function() {
                 if (self.feature) {
                     self.feature.setStyle(self.styleConfig.createEmptyStyle());  // Make invisible
                 }
             });
-            
+
             $mapElement.on('mouseenter', function() {
                 if (self.feature && self.mouseFollowActive) {
                     self.feature.setStyle(null);  // Reset to default style
@@ -397,7 +397,7 @@
                 }
             });
         }
-        
+
         /**
          * Stop mouse-following behavior
          */
@@ -405,23 +405,23 @@
             if (!this.mouseFollowActive) {
                 return;
             }
-            
+
             this.mouseFollowActive = false;
-            
+
             var map = this.map.getModel().olMap;
             var $mapElement = $(map.getTargetElement());
-            
+
             if (this.mouseMoveHandler) {
                 $mapElement.off('mousemove', this.mouseMoveHandler);
                 this.mouseMoveHandler = null;
             }
-            
+
             if (this.mouseClickHandler) {
                 map.un('click', this.mouseClickHandler);
                 this.mouseClickHandler = null;
             }
         }
-        
+
         /**
          * Move the current selection feature to a coordinate
          */
@@ -429,23 +429,23 @@
             if (!this.feature || !coordinate) {
                 return;
             }
-            
+
             var geom = this.feature.getGeometry();
             if (!geom) {
                 return;
             }
-            
+
             var currentCenter = this.map.getModel().getFeatureCenter(this.feature);
             if (!currentCenter) {
                 return;
             }
-            
+
             var dx = coordinate[0] - currentCenter[0];
             var dy = coordinate[1] - currentCenter[1];
-            
+
             geom.translate(dx, dy);
         }
-        
+
         /**
          * Rotate the current selection feature by a bearing in degrees
          * @param {number} bearingDegrees - Bearing in degrees from East (0 = East, 90 = North, -90 = South)
@@ -455,42 +455,42 @@
             if (!this.feature) {
                 return;
             }
-            
+
             var geom = this.feature.getGeometry();
             if (!geom) {
                 return;
             }
-            
+
             var entry = this._getFeatureEntry(this.feature);
             if (!entry) {
                 return;
             }
-            
+
             // The bearing represents the direction of the track (angle from East)
             // We want to rotate the frame so this direction is parallel to one of its axes
-            
+
             // Normalize bearing to -180 to 180 range
             var normalizedBearing = ((bearingDegrees + 180) % 360) - 180;
-            
+
             // Calculate two possible target rotations:
             // Portrait: Track aligned with horizontal axis
             var portrait = normalizedBearing;
             // Landscape: Track aligned with vertical axis (90° rotated)
             var landscape = normalizedBearing - 90;
             if (landscape < -180) landscape += 360;
-            
+
             var targetRotation;
-            
+
             if (previousRotation !== null) {
                 // Choose the option that is closer to the previous frame's rotation
                 // to maintain smooth transitions and avoid sudden jumps
                 var diff1 = Math.abs(portrait - previousRotation);
                 var diff2 = Math.abs(landscape - previousRotation);
-                
+
                 // Handle wraparound at -180/180 boundary
                 if (diff1 > 180) diff1 = 360 - diff1;
                 if (diff2 > 180) diff2 = 360 - diff2;
-                
+
                 targetRotation = (diff1 < diff2) ? portrait : landscape;
             } else {
                 // First frame: choose based on whether track is more horizontal or vertical
@@ -503,27 +503,27 @@
                     targetRotation = landscape;
                 }
             }
-            
+
             // Calculate current total rotation
             var currentRotationRadians = entry.rotationBias + entry.tempRotation;
-            
+
             // Convert target rotation to radians
             var targetRotationRadians = targetRotation * (Math.PI / 180);
-            
+
             // Calculate rotation delta needed
             var rotationDelta = targetRotationRadians - currentRotationRadians;
-            
+
             // Get feature center as rotation anchor
             var center = this.map.getModel().getFeatureCenter(this.feature);
-            
+
             // Apply rotation to geometry
             geom.rotate(rotationDelta, center);
-            
+
             // Update the feature entry's rotation bias
             entry.rotationBias = targetRotationRadians;
             entry.tempRotation = 0;
         }
-        
+
         /**
          * Pin the current frame to the map (create static copy)
          */
@@ -531,26 +531,26 @@
             if (!this.feature) {
                 return;
             }
-            
+
             // Clone the current feature geometry
             var geom = this.feature.getGeometry().clone();
             var pinnedFeature = new ol.Feature(geom);
-            
+
             // Get current rotation from feature entry (in radians) and convert to degrees
             var entry = this._getFeatureEntry(this.feature);
             var totalRotationRadians = entry.rotationBias + entry.tempRotation;
             var totalRotationDegrees = totalRotationRadians * (180 / Math.PI);
-            
+
             // Get extent from feature geometry
             var extent = this.feature.getGeometry().getExtent();
             var extentWidth = extent[2] - extent[0];
             var extentHeight = extent[3] - extent[1];
-            
+
             // Get template value and label
             var $templateSelect = $('select[name="template"]', this.$form);
             var templateValue = $templateSelect.val();
             var templateLabel = $templateSelect.find('option:selected').text();
-            
+
             // Create frame data and add to manager
             var frameData = {
                 feature: pinnedFeature,
@@ -565,22 +565,22 @@
                     height: extentHeight
                 }
             };
-            
+
             // Add frame through manager (assigns ID and triggers callbacks)
             this.frameManager.addFrame(frameData);
-            
+
             // Update frame tracking table
             this.tableController.updateTable();
-            
+
             // Create new selection feature at same position for next frame
             var center = this.map.getModel().getFeatureCenter(this.feature);
             this._resetSelectionFeature();
             this._moveFeatureToCoordinate(center);
-            
+
             // Refresh all rotation control overlays
             this.rotationController.refreshAll();
         }
-        
+
         /**
          * Get default style for pinned features
          * @returns {ol.style.Style} Default style with black outline and white fill
@@ -588,46 +588,46 @@
         _getDefaultStyle() {
             return this.styleConfig.createDefaultFrameStyle();
         }
-        
+
         /**
          * Add pinned feature to map with thin black border
          */
         _addPinnedFeatureToMap(feature) {
             var layerBridge = Mapbender.vectorLayerPool.getElementLayer(this, this.PINNED_FRAMES_LAYER);
             var nativeLayer = layerBridge.getNativeLayer();
-            
+
             // Ensure pinned frames layer has higher z-index than rotation overlay
             nativeLayer.setZIndex(this.PINNED_FRAMES_ZINDEX);
-            
+
             // Set custom style with thin black border
             var style = this._getDefaultStyle();
             feature.setStyle(style);
             layerBridge.addNativeFeatures([feature]);
-            
+
             // Add rotation handle overlay for this feature
             var frameData = this.frameManager.getFrameByFeature(feature);
             if (frameData) {
                 this.rotationController.addHandle(frameData.id, feature);
             }
         }
-        
+
         /**
          * Delete a pinned frame by ID
          */
         _deleteFrame(frameId) {
             var frameData = this.frameManager.removeFrame(frameId);
-            
+
             if (frameData) {
                 // Frame removal callbacks already handled by frameManager
                 // Just update the UI
                 this.tableController.updateTable();
-                
+
                 if (this.selectionActive && !this.mouseFollowActive) {
                     this._startMouseFollow();
                 }
             }
         }
-        
+
         /**
          * Clear all pinned features
          */
@@ -636,15 +636,15 @@
             if (this.rotationController) {
                 this.rotationController.clearAll();
             }
-            
+
             // Clear pinned features from map layer
             var layerBridge = Mapbender.vectorLayerPool.getElementLayer(this, this.PINNED_FRAMES_LAYER);
             layerBridge.clear();
-            
+
             // Clear frame manager data
             this.frameManager.clear();
         }
-        
+
         /**
          * Override _resetSelectionFeature to prevent drag interaction
          */
@@ -657,19 +657,19 @@
             this._redrawSelectionFeatures();
         }
 
-        
+
         /**
          * Override _onSubmit to collect and submit all pinned frames
          */
         async _onSubmit(evt) {
             evt.preventDefault();
-            
+
             if (!this._validateSubmission()) {
                 return false;
             }
-            
+
             var selectionCenter = this.feature ? this.map.getModel().getFeatureCenter(this.feature) : null;
-            
+
             try {
                 var jobs = await this._collectAllJobData();
                 this._submitBatchJobs(jobs);
@@ -677,10 +677,10 @@
             } catch (error) {
                 this._handleSubmissionError(error, selectionCenter);
             }
-            
+
             return false;
         }
-        
+
         /**
          * Validate submission requirements
          * @returns {boolean} True if validation passes, false otherwise
@@ -689,15 +689,15 @@
             if (!this.selectionActive) {
                 return false;
             }
-            
+
             if (this.pinnedFeatures.length === 0) {
                 Mapbender.info(Mapbender.trans('mb.print.printclient.batchprint.alert.noframes'));
                 return false;
             }
-            
+
             return true;
         }
-        
+
         /**
          * Collect job data for all pinned frames
          * @returns {Promise<Array>} Array of job data objects
@@ -706,47 +706,47 @@
             if (!this.$form || !this.$form.length) {
                 throw new Error('Form element not found');
             }
-            
+
             var jobs = [];
             var $scaleSelect = $('select[name="scale_select"]', this.$form);
             var $templateSelect = $('select[name="template"]', this.$form);
             var $qualitySelect = $('select[name="quality"]', this.$form);
-            
+
             if (!$scaleSelect.length || !$templateSelect.length || !$qualitySelect.length) {
                 throw new Error('Required form elements not found');
             }
-            
+
             for (var i = 0; i < this.pinnedFeatures.length; i++) {
                 var frameData = this.pinnedFeatures[i];
-                
+
                 // Store original form values
                 var originalScale = $scaleSelect.val();
                 var originalTemplate = $templateSelect.val();
                 var originalQuality = $qualitySelect.val();
-                
+
                 try {
                     // Temporarily apply frame-specific settings
                     $scaleSelect.val(frameData.scale);
                     if (frameData.template) $templateSelect.val(frameData.template);
                     if (frameData.quality) $qualitySelect.val(frameData.quality);
-                    
+
                     // Collect job data using parent's method
                     this.feature = frameData.feature;
                     var job = await Mapbender.Element.MbPrint.prototype._collectJobData.call(this);
-                    
+
                     // Apply frame-specific adjustments
                     job.rotation = -frameData.rotation;  // CRITICAL: Negate for backend
                     if (frameData.template) job.template = frameData.template;
                     if (frameData.quality) job.quality = frameData.quality;
                     job.scale_select = frameData.scale;
-                    
+
                     if (frameData.extent) {
                         job.extent = {
                             width: frameData.extent.width,
                             height: frameData.extent.height
                         };
                     }
-                    
+
                     jobs.push(job);
                 } catch (error) {
                     console.error('Failed to collect job data for frame ' + (i + 1) + ':', error);
@@ -758,11 +758,11 @@
                     $qualitySelect.val(originalQuality);
                 }
             }
-            
+
             this.feature = null;
             return jobs;
         }
-        
+
         /**
          * Submit batch jobs via form submission
          * @param {Array} jobs - Array of job data objects
@@ -772,35 +772,35 @@
                 console.error('Cannot submit: form element not found');
                 throw new Error('Form element not found');
             }
-            
+
             var $hiddenFields = $('.-fn-hidden-fields', this.$form);
             if (!$hiddenFields.length) {
                 console.error('Cannot submit: hidden fields container not found');
                 throw new Error('Hidden fields container not found');
             }
-            
+
             $hiddenFields.empty();
-            
+
             var $dataField = $('<input type="hidden" name="data">');
             $dataField.val(JSON.stringify(jobs));
             $hiddenFields.append($dataField);
-            
+
             this.$form[0].submit();
         }
-        
+
         /**
          * Restore UI state after successful submission
          * @param {Array} selectionCenter - Center coordinates to restore selection feature
          */
         _restoreUIState(selectionCenter) {
             var self = this;
-            
+
             // Restore selection feature position
             if (selectionCenter) {
                 this._resetSelectionFeature();
                 this._moveFeatureToCoordinate(selectionCenter);
             }
-            
+
             // Switch to results tab after short delay
             var $tabs = $('.tab-container', this.$element);
             if ($tabs.length) {
@@ -809,7 +809,7 @@
                 }, this.tabSwitchDelay);
             }
         }
-        
+
         /**
          * Place a frame at a specific position (called by geofileHandler)
          * @param {Array} coord - Coordinates [x, y]
@@ -821,24 +821,24 @@
         _placeFrameAtPosition(coord, bearing, previousRotation) {
             // Move current feature to this position
             this._moveFeatureToCoordinate(coord);
-            
+
             // Rotate if bearing provided
             if (bearing !== null) {
                 this._rotateCurrentFeature(bearing, previousRotation);
             }
-            
+
             // Pin the frame
             this._pinCurrentFrame();
-            
+
             // Get and return current rotation for next frame
             if (bearing !== null) {
                 var entry = this._getFeatureEntry(this.feature);
                 return entry ? (entry.rotationBias + entry.tempRotation) * (180 / Math.PI) : previousRotation;
             }
-            
+
             return previousRotation;
         }
-        
+
         /**
          * Handle submission errors
          * @param {Error} error - The error that occurred
@@ -846,17 +846,17 @@
          */
         _handleSubmissionError(error, selectionCenter) {
             console.error('Batch print submission failed:', error);
-            
+
             // Restore selection feature on error
             if (selectionCenter) {
                 this._resetSelectionFeature();
                 this._moveFeatureToCoordinate(selectionCenter);
             }
-            
+
             var errorMessage = Mapbender.trans('mb.print.printclient.batchprint.alert.error') + ': ' + error.message;
             Mapbender.error(errorMessage);
         }
-        
+
         /**
          * Delete all frames at once
          */
@@ -864,22 +864,22 @@
             if (this.frameManager.getCount() === 0) {
                 return;
             }
-            
+
             // Clear all pinned features from the map
             var layerBridge = Mapbender.vectorLayerPool.getElementLayer(this, this.PINNED_FRAMES_LAYER);
             layerBridge.clear();
-            
+
             // Clear rotation controller
             if (this.rotationController) {
                 this.rotationController.clearAll();
             }
-            
+
             // Clear frame manager
             this.frameManager.clear();
-            
+
             // Update table and UI
             this.tableController.updateTable();
-            
+
             // Show success message only after frames were actually deleted
             $('.-fn-geofile-status', this.$element)
                 .text(Mapbender.trans('mb.print.printclient.batchprint.alldeleted'))

--- a/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
@@ -99,7 +99,7 @@
         }
 
         /**
-         * Filter features for print: exclude the print frame polygon itself
+         * Filter a features for print: exclude the print frame polygon itself
          * and any features outside the print frame extent (spatial filter).
          */
         filterFeature(feature) {

--- a/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
@@ -102,17 +102,15 @@
          * Filter features for print: exclude the print frame polygon itself
          * and any features outside the print frame extent (spatial filter).
          */
-        filterFeatures(features) {
-            if (!this.feature || !this.feature.getGeometry()) {
-                return features.filter(f => f !== this.feature);
-            }
-            var frameExtent = this.feature.getGeometry().getExtent();
-            return features.filter(f => {
-                if (f === this.feature) return false;
-                var geom = f.getGeometry();
-                if (!geom) return false;
-                return geom.intersectsExtent(frameExtent);
-            });
+        filterFeature(feature) {
+            if (feature === this.feature) return false;
+            var geom = feature.getGeometry();
+            if (!geom) return false;
+
+            var frameExtent = this.feature?.getGeometry()?.getExtent();
+            if (!frameExtent) return true;
+
+            return geom.intersectsExtent(frameExtent);
         }
 
         closeByButton() {


### PR DESCRIPTION
OGC API Features was always printed on top, even when in the layer tree is was not on top.

Reason: The Vector Layers were manually added after all the other layers in the MbImageExport::_collectGeometryLayers method.

Solution: Add a flag `geojson-mblayer` for vector layers that are actual sources and ignore them in MbImageExport::_collectGeometryLayers. Add a printConfig for OGC API Features so the layers are exported at the right position. Extract dumping of vector layer data to geojson to Mapbender.Model to avoid code duplication.

see internal ticket 13630