### PR TITLE
Responsive option sidebar closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Features:
 * [MetadataDialog] Make MetadataURL and DataUrl available and add twig filter linkify ([#PR1818](https://github.com/mapbender/mapbender/pull/1818))
 * [SearchRouter] Extend SQLSearchEngine to support multiple search values separated by configurable delimiters ([#PR1836](https://github.com/mapbender/mapbender/pull/1836))
 * [LayerTree] Also show metadata for YAML applications ([#PR1849](https://github.com/mapbender/mapbender/pull/1849))
+* Region properties "generate menu" (for toolbar and footer) and "start closed" (sidepane) can now be set differently for mobile and desktop ([#PR1874](https://github.com/mapbender/mapbender/pull/1874), [#PR1893](https://github.com/mapbender/mapbender/pull/1893))
 
 Bugfixes:
 * When duplicating applications, also duplicate element permissions ([#PR1812](https://github.com/mapbender/mapbender/pull/1812))

--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -176,6 +176,7 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/MapModelBase.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.application.js',
                     '@MapbenderCoreBundle/Resources/public/mb-action.js',
+                    '@MapbenderCoreBundle/Resources/public/mapbender.responsive-menu.js',
                     '@MapbenderCoreBundle/Resources/public/init/element-sidepane.js',
                     '@MapbenderCoreBundle/Resources/public/widgets/toolbar-menu.js',
                     '/components/datatables/core/js/dataTables.min.js',
@@ -205,7 +206,6 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/VectorLayerPoolOl4.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/VectorLayerBridgeOl4.js',
                     '@MapbenderCoreBundle/Resources/public/elements/MapbenderElement.js',
-                    '@MapbenderCoreBundle/Resources/public/mapbender.responsive-menu.js',
                 ];
             case 'css':
                 return [

--- a/src/Mapbender/CoreBundle/Entity/RegionProperties.php
+++ b/src/Mapbender/CoreBundle/Entity/RegionProperties.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mapbender\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -41,43 +42,23 @@ class RegionProperties
     #[ORM\Column(type: 'json', nullable: true)]
     protected $properties;
 
-    /**
-     * RegionProperties constructor.
-     */
     public function __construct()
     {
         $this->properties = [];
     }
 
-    /**
-     * Set id. DANGER
-     *
-     * @param integer $id
-     * @return $this
-     */
-    public function setId($id): static
+    public function setId(string|int $id): static
     {
         $this->id = $id;
 
         return $this;
     }
 
-    /**
-     * Get id
-     *
-     * @return integer
-     */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     * @return $this
-     */
     public function setName($name): static
     {
         $this->name = $name;
@@ -85,22 +66,11 @@ class RegionProperties
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set Application
-     *
-     * @param Application $application
-     * @return $this
-     */
     public function setApplication(Application $application): static
     {
         $this->application = $application;
@@ -108,22 +78,11 @@ class RegionProperties
         return $this;
     }
 
-    /**
-     * Get application
-     *
-     * @return Application
-     */
-    public function getApplication()
+    public function getApplication(): Application
     {
         return $this->application;
     }
 
-    /**
-     * Set properties
-     *
-     * @param array $properties
-     * @return $this
-     */
     public function setProperties(array $properties = []): static
     {
         $this->properties = $properties === null || !is_array($properties) ? [] : $properties;
@@ -131,25 +90,34 @@ class RegionProperties
         return $this;
     }
 
-    /**
-     * Get properties
-     *
-     * @return array
-     */
-    public function getProperties()
+    public function getProperties(): array
     {
         $properties = $this->properties;
-        // backwards compatibility: generate_button_menu used to be a boolean flag
-        if (array_key_exists('generate_button_menu', $properties)) {
-            $value = $properties['generate_button_menu'];
-            if ($value === true || $value === 1 || $value === '1') {
-                $properties['generate_button_menu'] = 'menu_mobile_desktop';
-            } elseif ($value === false || $value === 0 || $value === '') {
-                $properties['generate_button_menu'] = 'no_menu';
-            } elseif (!in_array($value, ['no_menu', 'menu_mobile_desktop', 'menu_mobile', 'menu_desktop'])) {
-                $properties['generate_button_menu'] = 'no_menu';
+        return $this->convertLegacyBooleanFlagsToResponsiveOptions($properties, ['generate_button_menu']);
+    }
+
+    private function convertLegacyBooleanFlagsToResponsiveOptions(array $properties, array $legacyParameters): array
+    {
+        foreach ($legacyParameters as $param) {
+            if (array_key_exists($param, $properties)) {
+                $value = $properties[$param];
+                if ($value === true || $value === 1 || $value === '1') {
+                    $properties[$param] = 'yes';
+                } elseif (!in_array($value, ['no', 'yes', 'only_mobile', 'only_desktop'])) {
+                    $properties[$param] = 'no';
+                }
             }
         }
         return $properties;
+    }
+
+    public static function responsiveOptions(): array
+    {
+        return [
+            'mb.manager.responsive_options.no' => 'no',
+            'mb.manager.responsive_options.only_desktop' => 'only_desktop',
+            'mb.manager.responsive_options.only_mobile' => 'only_mobile',
+            'mb.manager.responsive_options.yes' => 'yes',
+        ];
     }
 }

--- a/src/Mapbender/CoreBundle/Entity/RegionProperties.php
+++ b/src/Mapbender/CoreBundle/Entity/RegionProperties.php
@@ -54,7 +54,7 @@ class RegionProperties
         return $this;
     }
 
-    public function getId(): string|int
+    public function getId(): string|int|null
     {
         return $this->id;
     }

--- a/src/Mapbender/CoreBundle/Entity/RegionProperties.php
+++ b/src/Mapbender/CoreBundle/Entity/RegionProperties.php
@@ -93,7 +93,7 @@ class RegionProperties
     public function getProperties(): array
     {
         $properties = $this->properties;
-        return $this->convertLegacyBooleanFlagsToResponsiveOptions($properties, ['generate_button_menu']);
+        return $this->convertLegacyBooleanFlagsToResponsiveOptions($properties, ['generate_button_menu', 'closed']);
     }
 
     private function convertLegacyBooleanFlagsToResponsiveOptions(array $properties, array $legacyParameters): array

--- a/src/Mapbender/CoreBundle/Form/Type/Template/BaseToolbarType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/Template/BaseToolbarType.php
@@ -4,6 +4,7 @@
 namespace Mapbender\CoreBundle\Form\Type\Template;
 
 
+use Mapbender\CoreBundle\Entity\RegionProperties;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\AbstractType;
@@ -28,12 +29,7 @@ class BaseToolbarType extends AbstractType
         ]);
         $builder->add('generate_button_menu', ChoiceType::class, [
             'label' => 'mb.manager.toolbar.menu_button.label',
-            'choices' => [
-                'mb.manager.toolbar.menu_button.choice.no_menu' => 'no_menu',
-                'mb.manager.toolbar.menu_button.choice.menu_desktop' => 'menu_desktop',
-                'mb.manager.toolbar.menu_button.choice.menu_mobile' => 'menu_mobile',
-                'mb.manager.toolbar.menu_button.choice.menu_mobile_desktop' => 'menu_mobile_desktop',
-            ],
+            'choices' => RegionProperties::responsiveOptions(),
             'required' => false,
             'placeholder' => false,
         ]);

--- a/src/Mapbender/CoreBundle/Form/Type/Template/Fullscreen/SidepaneSettingsType.php
+++ b/src/Mapbender/CoreBundle/Form/Type/Template/Fullscreen/SidepaneSettingsType.php
@@ -3,6 +3,7 @@
 namespace Mapbender\CoreBundle\Form\Type\Template\Fullscreen;
 
 
+use Mapbender\CoreBundle\Entity\RegionProperties;
 use Mapbender\CoreBundle\Form\Type\Template\RegionSettingsType;
 use Mapbender\CoreBundle\Element\Type\MapbenderTypeTrait;
 use Mapbender\ManagerBundle\Form\Type\ScreentypeType;
@@ -72,9 +73,10 @@ class SidepaneSettingsType extends AbstractType
             'placeholder' => false,
             'empty_data' => 'left',
         ]);
-        $builder->add('closed', CheckboxType::class, [
-            'required' => false,
+        $builder->add('closed', ChoiceType::class, [
+            'required' => true,
             'label' => 'mb.manager.sidepane.closed',
+            'choices' => RegionProperties::responsiveOptions(),
         ]);
     }
 }

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -250,13 +250,13 @@ ul.toolBar, .toolBar > ul {
   }
 
     // Responsive toolbar menu modes.
-    // The menu <ul> is rendered once (whenever the mode is not "no_menu").
+    // The menu <ul> is rendered once (whenever the menu mode is not "no").
     // Depending on the configured mode and viewport width, the menu-supported
     // items are either collapsed behind the burger button or shown inline
     // (like the non-button-menu case).
-    //   menu_mobile_desktop -> always burger (no modifier class, never expanded)
-    //   menu_mobile  (.has-menu-mobile)  -> burger < 1200px, inline >= 1200px
-    //   menu_desktop (.has-menu-desktop) -> burger >= 1200px, inline < 1200px
+    //   yes -> always burger (no modifier class, never expanded)
+    //   only_mobile  (.has-menu-mobile)  -> burger < 1200px, inline >= 1200px
+    //   only_desktop (.has-menu-desktop) -> burger >= 1200px, inline < 1200px
     @media (min-width: $desktopBreakpointWidth) {
         &.has-menu-mobile {
             @include toolbar-menu-inline;

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -127,14 +127,30 @@ $(function () {
         }
 
         _setupInitialState() {
-            if (this.$element.hasClass('closed')) {
-                this.isOpen = false;
+            this.isOpen = this._getResponsiveDefaultOpen();
+
+            if (this.isOpen) {
+                this.$element.css('left', 'initial').css('right', 'initial');
+                this.$element.removeClass('closed');
+            } else {
+                this.$element.addClass('closed');
                 if (this.$element.hasClass("right")) {
                     this.$element.css({right: (this.$element.outerWidth(true) * -1) + "px"});
                 } else {
                     this.$element.css({left: (this.$element.outerWidth(true) * -1) + "px"});
                 }
             }
+        }
+
+        _getResponsiveDefaultOpen() {
+            if (this.$element.hasClass('-js-closed-no')) return true;
+            if (this.$element.hasClass('-js-closed-yes')) return false;
+
+            const isMobile = window.innerWidth < Mapbender.responsiveMenu.desktopBreakpoint;
+            return (
+                (this.$element.hasClass('-js-closed-only_desktop') && isMobile) ||
+                (this.$element.hasClass('-js-closed-only_mobile') && !isMobile)
+            );
         }
 
         _setupEvents() {

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -2,8 +2,9 @@
 <div class="{{ 'sidePane flex-fill ' ~ region_class | trim }}{% if region_props.resizable %} resizable{% endif %}
      {%- if region_props.width | default('') -%}
          {{ ' -js-closed-' ~ (region_props.closed | default('no')) }}" style="width: {{ region_props.width }};
-     {%- if (region_props.closed | default(false)) != 'no' -%}
-        {{ 'left' in region_class ? 'left' : 'right' }}: -{{ region_props.width }};"{% endif %}
+        {%- if (region_props.closed | default(false)) != 'no' -%}
+            {{ 'left' in region_class ? 'left' : 'right' }}: -{{ region_props.width }};
+        {% endif %}
      {%- endif -%}
 ">
   <div class="sideContent">

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/sidepane.html.twig
@@ -1,13 +1,11 @@
 {%- set return_text = 'mb.actions.back' -%}
-<div class="{{ 'sidePane flex-fill ' ~ region_class | trim }}{% if region_props.resizable %} resizable{% endif %}"
+<div class="{{ 'sidePane flex-fill ' ~ region_class | trim }}{% if region_props.resizable %} resizable{% endif %}
      {%- if region_props.width | default('') -%}
-         {%- if region_props.closed | default(false) -%}
-             {{ ' ' }}style="width: {{ region_props.width }}; {{ 'left' in region_class ? 'left' : 'right' }}: -{{ region_props.width }};"
-         {%- else -%}
-             {{ ' ' }}style="width: {{ region_props.width }};"
-         {%- endif -%}
+         {{ ' -js-closed-' ~ (region_props.closed | default('no')) }}" style="width: {{ region_props.width }};
+     {%- if (region_props.closed | default(false)) != 'no' -%}
+        {{ 'left' in region_class ? 'left' : 'right' }}: -{{ region_props.width }};"{% endif %}
      {%- endif -%}
->
+">
   <div class="sideContent">
   {%- if region_props.name in ['tabs', 'accordion', 'list'] -%}
       {%- set _visible = [] -%}

--- a/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Template/region/toolbar.html.twig
@@ -1,12 +1,12 @@
 {% block region_wrapper %}
-    {%- set menu_mode = region_props['generate_button_menu'] | default('no_menu') -%}
+    {%- set menu_mode = region_props['generate_button_menu'] | default('no') -%}
     {%- set menu_mode_class = {
-        'menu_desktop': 'has-menu-desktop',
-        'menu_mobile': 'has-menu-mobile',
+        'only_desktop': 'has-menu-desktop',
+        'only_mobile': 'has-menu-mobile',
     }[menu_mode] | default('') -%}
     {%- set items_list_class = alignment_class | default('itemsRight') -%}
     <div class="{{ ('toolBar ' ~ region_class ~ ' ' ~ menu_mode_class) | trim }}" data-toolbar-menu-mode="{{ menu_mode }}">
-    {%- if menu_mode != 'no_menu' %}
+    {%- if menu_mode != 'no' %}
         {%- set inline_items = toolbar_inline_content(application, region_name) -%}
         {%- set menu_content = toolbar_menu_content(application, region_name, true) -%}
     {%- else -%}
@@ -34,7 +34,7 @@
         {% endblock %}
     </ul>
     {% endblock item_list %}
-    {%- if menu_mode != 'no_menu' and elements is defined and elements|length -%}
+    {%- if menu_mode != 'no' and elements is defined and elements|length -%}
         {%- set ordered_menu_item_ids = [] -%}
         {%- for element in elements -%}
             {%- set ordered_menu_item_ids = ordered_menu_item_ids | merge([element.id]) -%}

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.de.yaml
@@ -43,12 +43,12 @@ mb:
           center: Zentriert
       menu_button:
           label: 'Menü'
-          choice:
-              no_menu: 'kein Menü'
-              menu_desktop: 'nur Desktop'
-              menu_mobile_desktop: 'Desktop + Mobil'
-              menu_mobile: 'nur Mobil'
       menu_label: Menütitel
+    responsive_options:
+      no: 'Nein'
+      only_desktop: 'nur Desktop'
+      yes: 'Desktop + Mobil'
+      only_mobile: 'nur Mobil'
     visibility: Sichtbarkeit
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.en.yaml
@@ -43,12 +43,12 @@ mb:
           center: Center
       menu_button:
           label: 'Menu'
-          choice:
-              no_menu: 'no menu (default)'
-              menu_desktop: 'Show menu on desktop'
-              menu_mobile_desktop: 'Show menu on desktop+mobile'
-              menu_mobile: 'Show menu on mobile only'
       menu_label: 'Menu label'
+    responsive_options:
+      no: 'No'
+      only_desktop: 'Desktop only'
+      yes: 'Desktop + mobile'
+      only_mobile: 'Mobile only'
     visibility: Visibility
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.es.yaml
@@ -43,12 +43,12 @@ mb:
           center: Centrada
       menu_button:
           label: 'Menú'
-          choice:
-              no_menu: 'sin menú (predeterminado)'
-              menu_desktop: 'Mostrar menú en escritorio'
-              menu_mobile_desktop: 'Mostrar menú en escritorio y móvil'
-              menu_mobile: 'Mostrar menú solo en móvil'
       menu_label: 'Título del menú'
+    responsive_options:
+      no: 'No'
+      only_desktop: 'Solo escritorio'
+      yes: 'Escritorio + móvil'
+      only_mobile: 'Solo móvil'
     visibility: Visibilidad
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.fr.yaml
@@ -24,6 +24,11 @@ mb:
   manager:
     autoActivate: 'Activer automatiquement'
     autoOpen: 'Ouverture automatique'
+    responsive_options:
+      no: 'Non'
+      only_desktop: 'Bureau uniquement'
+      yes: 'Bureau + mobile'
+      only_mobile: 'Mobile uniquement'
     admin:
       map:
         max_extent: 'Étendue maximum'

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.it.yaml
@@ -43,12 +43,12 @@ mb:
           center: Centro
       menu_button:
           label: 'Menu'
-          choice:
-              no_menu: 'nessun menu (predefinito)'
-              menu_desktop: 'Mostra menu su desktop'
-              menu_mobile_desktop: 'Mostra menu su desktop+mobile'
-              menu_mobile: 'Mostra menu solo su mobile'
       menu_label: 'Menu label'
+    responsive_options:
+      no: 'No'
+      only_desktop: 'Solo desktop'
+      yes: 'Desktop + mobile'
+      only_mobile: 'Solo mobile'
     visibility: Visibilità
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.nl.yaml
@@ -24,6 +24,11 @@ mb:
   manager:
     autoActivate: 'Automatisch geactiveerd'
     autoOpen: 'Automatisch openen'
+    responsive_options:
+      no: 'Nee'
+      only_desktop: 'Alleen desktop'
+      yes: 'Desktop + mobiel'
+      only_mobile: 'Alleen mobiel'
     admin:
       map:
         max_extent: 'Max. omvang (extent)'

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pl.yaml
@@ -43,12 +43,12 @@ mb:
           center: Środek
       menu_button:
           label: 'Menu'
-          choice:
-              no_menu: 'bez menu (domyślnie)'
-              menu_desktop: 'Pokaż menu na komputerze'
-              menu_mobile_desktop: 'Pokaż menu na komputerze i urządzeniach mobilnych'
-              menu_mobile: 'Pokaż menu tylko na urządzeniach mobilnych'
       menu_label: 'Etykieta menu'
+    responsive_options:
+      no: 'Nie'
+      only_desktop: 'Tylko komputer'
+      yes: 'Komputer + urządzenia mobilne'
+      only_mobile: 'Tylko urządzenia mobilne'
     visibility: Widoczność
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.pt.yaml
@@ -43,12 +43,12 @@ mb:
           center: Centralizado
       menu_button:
           label: 'Menu'
-          choice:
-              no_menu: 'sem menu (padrão)'
-              menu_desktop: 'Mostrar menu no desktop'
-              menu_mobile_desktop: 'Mostrar menu no desktop e dispositivos móveis'
-              menu_mobile: 'Mostrar menu apenas em dispositivos móveis'
       menu_label: 'Rótulo do menu'
+    responsive_options:
+      no: 'Não'
+      only_desktop: 'Apenas desktop'
+      yes: 'Desktop + dispositivos móveis'
+      only_mobile: 'Apenas dispositivos móveis'
     visibility: Visibilidade
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ro.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ro.yaml
@@ -41,6 +41,11 @@ mb:
           center: Centru
       generate_button_menu: 'Grupează butoanele într-un meniu'
       menu_label: 'Titlu meniu'
+    responsive_options:
+      no: 'Nu'
+      only_desktop: 'Doar desktop'
+      yes: 'Desktop + mobil'
+      only_mobile: 'Doar mobil'
     visibility: Vizibilitate
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.ru.yaml
@@ -43,12 +43,12 @@ mb:
           center: 'По центру'
       menu_button:
           label: 'Меню'
-          choice:
-              no_menu: 'без меню (по умолчанию)'
-              menu_desktop: 'Показывать меню на десктопе'
-              menu_mobile_desktop: 'Показывать меню на десктопе и мобильных'
-              menu_mobile: 'Показывать меню только на мобильных'
       menu_label: 'Заголовок меню'
+    responsive_options:
+      no: 'Нет'
+      only_desktop: 'Только десктоп'
+      yes: 'Десктоп и мобильные'
+      only_mobile: 'Только мобильные'
     visibility: Видимость
     element:
       screentype:

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.tr.yaml
@@ -24,6 +24,11 @@ mb:
   manager:
     autoActivate: 'Otomatik etkinleştir'
     autoOpen: 'Otomatik aç'
+    responsive_options:
+      no: 'Hayır'
+      only_desktop: 'Yalnızca masaüstü'
+      yes: 'Masaüstü + mobil'
+      only_mobile: 'Yalnızca mobil'
     admin:
       map:
         max_extent: 'Maks. kapsam'

--- a/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
+++ b/src/Mapbender/ManagerBundle/Resources/translations/messages+intl-icu.uk.yaml
@@ -41,13 +41,13 @@ mb:
           center: 'По центру'
       menu_button:
           label: 'Меню'
-          choice:
-              no_menu: 'без меню (за замовчуванням)'
-              menu_desktop: 'Показувати меню на комп’ютері'
-              menu_mobile_desktop: 'Показувати меню на комп’ютері та мобільних'
-              menu_mobile: 'Показувати меню лише на мобільних'
       menu_label: 'Мітка меню'
       visibility: Видимість
+    responsive_options:
+      no: 'Ні'
+      only_desktop: 'Лише комп’ютер'
+      yes: 'Комп’ютер і мобільні'
+      only_mobile: 'Лише мобільні'
     element:
       screentype:
         mobile: 'Показати на екранах мобільних пристроїв'


### PR DESCRIPTION
analogous to #1874, the region property "sidebar closed" can now be set differently for mobile and desktop versions.

Also, now using generic responsive wording and yaml flags for both the "generate_menu" and "closed" options:


```
no
yes
only_desktop
only_mobile
```