### PR TITLE
Increase backend popup size and make it configurable

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
@@ -38,6 +38,10 @@
     --content-element-padding-horizontal: 50px;
     --popup-modal-width: #{$popupModalWidth};
 
+    --backend-popup-max-width: 800px;
+    // allows popups to grow bigger than --backend-popup-max-width on large screens
+    --backend-max-width-override: 65vw;
+
     // ---- Backgrounds ----
     --background-color: #{$backgroundColor};
 

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
@@ -40,7 +40,7 @@
 
     --backend-popup-max-width: 800px;
     // allows popups to grow bigger than --backend-popup-max-width on large screens
-    --backend-max-width-override: 65vw;
+    --backend-popup-max-width-override: 65vw;
 
     // ---- Backgrounds ----
     --background-color: #{$backgroundColor};

--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss
@@ -6,6 +6,7 @@
 // Use CSS custom properties (--var-name) instead for runtime overrides.
 // SCSS variables remain as compile-time defaults that feed into CSS vars.
 // Client projects should override CSS variables in :root or component scope.
+// CSS Variables are set in _css_custom_properties.scss
 
 //------------------------------------------------------------------font
 $fontFamily: "Open Sans", "Calluna Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_popup.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_popup.scss
@@ -176,8 +176,9 @@ body.popup-resizing {
   @include absolute(70px 0 $space*3 0);
 }
 
+/** Backend dialogs, e.g. for element edit **/
 .modal-dialog:not(.modal-lg):not(.modal-xl) {
-    max-width: 700px;
+    max-width: min(100vw, max(var(--backend-popup-max-width-override), var(--backend-popup-max-width)));
 }
 
 @media (max-width: $mobileBreakpoint) {

--- a/src/Mapbender/CoreBundle/Resources/public/util.js
+++ b/src/Mapbender/CoreBundle/Resources/public/util.js
@@ -104,6 +104,15 @@ Mapbender.restrictPopupPositioning = function ($dialogElement) {
         if (ui.position.left > window.innerWidth - 50) forcedX = window.innerWidth - 50;
         if (forcedX !== null) $target.css('left', forcedX);
         if (forcedY !== null) $target.css('top', forcedY);
+
+        const newX = forcedX ?? ui.position.left;
+        const newY = forcedY ?? ui.position.top;
+        if ((newX + $target.width()) > window.innerWidth) {
+            $target.css("width", window.innerWidth - newX);
+        }
+        if ((newY + $target.height()) > window.innerHeight) {
+            $target.css("height", window.innerHeight - newY);
+        }
     });
 };
 


### PR DESCRIPTION
- Increase backend popup size and make it configurable

new CSS Variables:

```css
    --backend-popup-max-width: 800px;
    // allows popups to grow bigger than --backend-popup-max-width on large screens
    --backend-popup-max-width-override: 65vw;
```

- When restricting frontend popup placement after movement, also restrict size