### PR TITLE
Fix TypeError in mobile popup when toolbars are missing

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/mapbender.popup.js
@@ -450,7 +450,10 @@
             var viewportHeight = window.innerHeight;
 
             // Calculate available space considering toolbars
-            var toolbarHeight = $('.toolBar.top')[0].getBoundingClientRect().height + $('.toolBar.bottom')[0].getBoundingClientRect().height;
+            var $topBar = $('.toolBar.top');
+            var $bottomBar = $('.toolBar.bottom');
+            var toolbarHeight = ($topBar.length ? $topBar[0].getBoundingClientRect().height : 0)
+                + ($bottomBar.length ? $bottomBar[0].getBoundingClientRect().height : 0);
             var maxAvailableHeight = (viewportHeight * this.mobileMaxHeightRatio) - toolbarHeight;
 
             // Check if popup is currently larger than available space and adjust height if necessary


### PR DESCRIPTION
The popup size adjustment for mobile viewports accessed
`.toolBar.top` and `.toolBar.bottom` via `[0].getBoundingClientRect()`
without checking whether the elements actually exist. On pages
without a bottom (or top) toolbar this threw a TypeError and broke
the popup layout on mobile.
