### PR TITLE
Support external graphics in SearchRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 * [ApplicationSwitcher] Enhance application switcher, e.g. to work in popup and allow external applications ([#PR1793](https://github.com/mapbender/mapbender/pull/1793))
 * [Copyright] Add "Don't show again" option ([#PR1800](https://github.com/mapbender/mapbender/pull/1800))
 * [Map] Improve form validation in backend ([#PR1851](https://github.com/mapbender/mapbender/pull/1851))
+* [SearchRouter] Support external graphics as style option ([#PR1897](https://github.com/mapbender/mapbender/pull/1897))
 * [SearchRouter] Extend SQLSearchEngine with support for dates, numbers and greater/lower than operators ([#PR1796](https://github.com/mapbender/mapbender/pull/1796))
 * [InteractiveHelp] Add new Interactive Help element ([#PR1808](https://github.com/mapbender/mapbender/pull/1808))
 * [Print] Support custom fonts and improve configuration options ([#PR1887](https://github.com/mapbender/mapbender/pull/1887))
@@ -34,6 +35,7 @@ Other:
 * Added romanian translation ([#PR1878](https://github.com/mapbender/mapbender/pull/1878)) 
 * [Develop] New shared File utility module for geospatial file handling (KML, GeoJSON, GPX, GML) ([#PR1799](https://github.com/mapbender/mapbender/pull/1799)) 
 * [Develop] Extract downloadFile function to Mapbender.FileUtil ([PR#1890](https://github.com/mapbender/mapbender/pull/1890))
+* [Develop] Add ExternalGraphicUtil (previously part of the digitizer module) ([PR#1897](https://github.com/mapbender/mapbender/pull/1897))
 * In applications tab in source infos, use same symbology for public/not public as elsewhere in Mapbender ([#PR1812](https://github.com/mapbender/mapbender/pull/1812)) 
 * Changed default login-backdrop image ([PR#1845](https://github.com/mapbender/mapbender/pull/1845))
 

--- a/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
+++ b/src/Mapbender/CoreBundle/Asset/ApplicationAssetService.php
@@ -195,6 +195,7 @@ class ApplicationAssetService
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/sourcetree-util.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/StyleUtil.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/FileUtil.js',
+                    '@MapbenderCoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender.element.map.mapaxisorder.js',
                     '@MapbenderCoreBundle/Resources/public/init/projection.js',
                     '@MapbenderCoreBundle/Resources/public/mapbender-model/MapEngine.js',

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
@@ -519,7 +519,7 @@
 
             // no dynamic contents => return fixed style
             if (!placeholderProps.length > 0) {
-                new ol.style.Style({
+                return new ol.style.Style({
                     image: imageStyle,
                     fill: fill,
                     stroke: stroke,

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
     class MbSearchRouter extends MapbenderElement {
         constructor(configuration, $element) {
             super(configuration, $element);
@@ -34,11 +34,11 @@
             const routeSelect = $('select#search_routes_route', $element);
             routeSelect.closest('.dropdown').css('display', this.options.routes.length > 1 ? 'block' : 'none');
 
-            $element.on('submit', '.search-forms form', function(evt) {
+            $element.on('submit', '.search-forms form', function (evt) {
                 evt.preventDefault();
                 widget._search();
             });
-            $element.on('reset', '.search-forms form', function() {
+            $element.on('reset', '.search-forms form', function () {
                 widget.removeLastResults();
             });
             // Prepare autocompletes
@@ -49,7 +49,7 @@
 
             // Listen to changes of search select (switching and forms resetting)
             routeSelect.on('change', this._selectSearch.bind(this));
-            $element.on('click', '.search-action-buttons [data-action]', function() {
+            $element.on('click', '.search-action-buttons [data-action]', function () {
                 switch ($(this).attr('data-action')) {
                     case ('reset'):
                         widget._reset();
@@ -133,7 +133,7 @@
         _selectSearch(event) {
             const selected = this.selected = $(event.target).val();
 
-            $('form', this.$element).each(function() {
+            $('form', this.$element).each(function () {
                 const form = $(this);
                 if (form.attr('name') === selected) {
                     form.show();
@@ -176,10 +176,10 @@
                 classes: {
                     'ui-autocomplete': 'dropdownList'
                 },
-                source: function(request, response) {
-                    self._autocompleteSource($input).then(function(data) {
+                source: function (request, response) {
+                    self._autocompleteSource($input).then(function (data) {
                         response(data.results);
-                    }, function() {
+                    }, function () {
                         response([]);
                     });
                 }
@@ -403,17 +403,17 @@
         initTableEvents_() {
             const self = this;
             $('.search-results', this.$element)
-                .on('click', 'tbody tr', function() {
+                .on('click', 'tbody tr', function () {
                     const feature = $(this).data('feature');
                     self._highlightFeature(feature, 'select');
                     self._hideMobile();
                     self._highlightTableRow($(this));
                 })
-                .on('mouseenter', 'tbody tr', function() {
+                .on('mouseenter', 'tbody tr', function () {
                     const feature = $(this).data('feature');
                     self._highlightFeature(feature, 'temporary');
                 })
-                .on('mouseleave', 'tbody tr', function() {
+                .on('mouseleave', 'tbody tr', function () {
                     const feature = $(this).data('feature');
                     const styleName = feature === self.currentFeature ? 'select' : 'default';
                     self._highlightFeature(feature, styleName);
@@ -427,10 +427,7 @@
                 }
                 this.currentFeature = feature;
             }
-            let featureStyle = this.featureStyles[style].clone();
-            const label = this._getLabelValue(feature, style);
-            featureStyle.getText().setText(label);
-            feature.setStyle(featureStyle);
+            feature.setStyle(this.featureStyles[style]);
         }
 
         _showResultState(results) {
@@ -476,37 +473,10 @@
             this.csvExport.export(features, this.getCurrentRoute().results.headers);
         }
 
-        /**
-         * read the feature map label from feature properties
-         * @param feature
-         * @param style
-         * @returns {string}
-         * @private
-         */
-        _getLabelValue(feature, style) {
-            const currentRoute = this.getCurrentRoute();
-            const labelWithRegex = currentRoute?.results?.styleMap?.[style]?.label;
-            if (!labelWithRegex) return '';
-
-            return this._labelReplaceRegex(labelWithRegex, feature);
-        }
-
-        _labelReplaceRegex(labelWithRegex, feature) {
-            let regex = /\${([^}]+)}/g;
-            let match = [];
-            let label = labelWithRegex;
-
-            while ((match = regex.exec(labelWithRegex)) !== null) {
-                let featureValue = (feature.get(match[1])) ? feature.get(match[1]).toString() : '';
-                label = label.replace(match[0], featureValue);
-            }
-            return label;
-        }
-
         _createTextStyle(options) {
-            const fontweight = options.fontWeight  || 'normal';
-            const fontsize = options.fontSize  || '18px';
-            const fontfamily = options.fontFamily  || 'arial';
+            const fontweight = options.fontWeight || 'normal';
+            const fontsize = options.fontSize || '18px';
+            const fontfamily = options.fontFamily || 'arial';
 
             const textfill = new ol.style.Fill({
                 color: Mapbender.StyleUtil.svgToCssColorRule(options, 'fontColor', '1')
@@ -535,6 +505,9 @@
                 color: Mapbender.StyleUtil.svgToCssColorRule(options, 'strokeColor', 'strokeOpacity'),
                 width: options.strokeWidth || 2
             });
+            const textStyle = this._createTextStyle(options);
+
+            const placeholderProps = Mapbender.StyleUtil.detectDataPlaceholders(options, ['externalGraphic', 'label']);
 
             const imageStyle = options.externalGraphic
                 ? Mapbender.Util.ExternalGraphicUtil.getIconStyle(options, true)
@@ -544,15 +517,44 @@
                     radius: options.pointRadius || 5
                 });
 
-            return new ol.style.Style({
-                image: imageStyle,
-                fill: fill,
-                stroke: stroke,
-                text: this._createTextStyle(options),
+            // no dynamic contents => return fixed style
+            if (!placeholderProps.length > 0) {
+                new ol.style.Style({
+                    image: imageStyle,
+                    fill: fill,
+                    stroke: stroke,
+                    text: textStyle,
+                });
+            }
+
+            const resolvePlaceholders = Mapbender.StyleUtil.getPlaceholderResolver(options, placeholderProps, function (feature) {
+                return feature.getProperties() || {};
             });
+
+            return (feature) => {
+                const resolvedStyle = resolvePlaceholders(options, feature);
+
+                let _textStyle = textStyle;
+                if (placeholderProps.includes("label")) {
+                    _textStyle = textStyle.clone();
+                    _textStyle.setText(resolvedStyle.label);
+                }
+
+                let _imageStyle = imageStyle;
+                if (placeholderProps.includes("externalGraphic")) {
+                    _imageStyle = Mapbender.Util.ExternalGraphicUtil.getIconStyle(resolvedStyle, true);
+                }
+
+                return new ol.style.Style({
+                    image: _imageStyle,
+                    fill: fill,
+                    stroke: stroke,
+                    text: _textStyle,
+                });
+            }
         }
 
-        _createStyleMap (styles) {
+        _createStyleMap(styles) {
             return {
                 default: this._createSingleStyle(styles.default),
                 select: this._createSingleStyle(styles.select),
@@ -624,7 +626,7 @@
 
         _getFormValues(form) {
             const values = {};
-            $(':input', form).each(function(index, input) {
+            $(':input', form).each(function (index, input) {
                 const $input = $(input);
                 const name = $input.attr('name').replace(/^[^[]*\[/, '').replace(/[\]].*$/, '');
                 values[name] = $input.val();

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbSearchRouter.js
@@ -536,12 +536,16 @@
                 width: options.strokeWidth || 2
             });
 
-            return new ol.style.Style({
-                image: new ol.style.Circle({
+            const imageStyle = options.externalGraphic
+                ? Mapbender.Util.ExternalGraphicUtil.getIconStyle(options, true)
+                : new ol.style.Circle({
                     fill: fill,
                     stroke: stroke,
                     radius: options.pointRadius || 5
-                }),
+                });
+
+            return new ol.style.Style({
+                image: imageStyle,
                 fill: fill,
                 stroke: stroke,
                 text: this._createTextStyle(options),

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
@@ -10,7 +10,7 @@ window.Mapbender.Util.ExternalGraphicUtil = class {
     /**
      * Creates an ol style (or iconStyle) that displays an external graphic
      * @param {{externalGraphic: string, graphicWidth: ?int, graphicHeight: ?int}} styleConfig
-     * @param {true|undefined} [iconStyleOnly] if set to false, only the IconStyle instead of the full ol style is returned
+     * @param {boolean} [iconStyleOnly=false] if true, only the IconStyle instead of the full ol style is returned
      * @return {ol.Style|ol.style.Icon}
      */
     static getIconStyle(styleConfig, iconStyleOnly) {

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
@@ -1,0 +1,87 @@
+window.Mapbender = Mapbender || {};
+window.Mapbender.Util = Mapbender.Util || {};
+
+/**
+ * Utilities for handling external graphics in OpenLayers.
+ * In most cases, just getIconStyle needs to be called externally
+ */
+window.Mapbender.Util.ExternalGraphicUtil = class {
+
+    /**
+     * Creates an ol style (or iconStyle) that displays an external graphic
+     * @param {{externalGraphic: string, graphicWidth: ?int, graphicHeight: ?int}} styleConfig
+     * @param {true|undefined} [iconStyleOnly] if set to false, only the IconStyle instead of the full ol style is returned
+     * @return {ol.Style|ol.style.Icon}
+     */
+    static getIconStyle(styleConfig, iconStyleOnly) {
+        const iconStyle = new ol.style.Icon({
+            src: styleConfig.externalGraphic
+        });
+        if (styleConfig.graphicWidth || styleConfig.graphicHeight) {
+            const onload = Mapbender.Util.ExternalGraphicUtil.getIconScaleHandler(iconStyle, styleConfig);
+            // see https://github.com/openlayers/openlayers/blob/main/src/ol/ImageState.js
+            if (iconStyle.getImageState() === 2) {
+                // already loaded
+                onload();
+            } else {
+                iconStyle.listenImageChange(onload);
+            }
+        }
+        return iconStyleOnly === true ? iconStyle : Mapbender.Util.ExternalGraphicUtil.expandIconStyle(iconStyle);
+    }
+
+    static getIconScaleHandler(iconStyle, styleConfig) {
+        return (function (styleConfig) {
+            return function () {
+                /** @this ol.style.Image */
+                if (this.getImageState() === 2) {
+                    // Now loaded
+                    // see https://github.com/openlayers/openlayers/blob/main/src/ol/ImageState.js
+                    const naturalSize = this.getImageSize();
+                    let scale;
+                    if (!styleConfig.graphicHeight) {
+                        scale = styleConfig.graphicWidth / naturalSize[0];
+                    } else if (!styleConfig.graphicWidth) {
+                        scale = styleConfig.graphicHeight / naturalSize[1];
+                    } else {
+                        scale = [styleConfig.graphicWidth / naturalSize[0], styleConfig.graphicHeight / naturalSize[1]];
+                    }
+                    this.setScale(scale);
+                }
+            }.bind(iconStyle);
+        }(styleConfig));
+    }
+
+    /**
+     * @param {ol.style.Image} iconStyle
+     * @return {ol.style.Style}
+     * @private
+     */
+    static expandIconStyle(iconStyle) {
+        return new ol.style.Style({
+            // Icons are only rendered on point geometries.
+            // => We must use a geometry function to make points out of
+            // polygons and lines.
+            // @see https://gis.stackexchange.com/questions/361817/openlayers-displaying-polygon-with-icon-style
+            geometry: Mapbender.Util.ExternalGraphicUtil.iconStyleGeometryFunction,
+            image: iconStyle
+        });
+    }
+
+    static iconStyleGeometryFunction(feature) {
+        const geometry = feature.getGeometry();
+        switch (geometry && geometry.getType()) {
+            case 'Polygon':
+                return geometry.getInteriorPoint();
+            case 'MultiPolygon':
+                return geometry.getInteriorPoints();
+            case 'LineString':
+                return new ol.geom.Point(geometry.getFlatMidpoint(), geometry.getLayout());
+            case 'MultiLineString':
+                return new ol.geom.MultiPoint(geometry.getFlatMidpoints(), geometry.getLayout());
+            default:
+                return geometry;
+        }
+    }
+
+};

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/ExternalGraphicUtil.js
@@ -14,6 +14,8 @@ window.Mapbender.Util.ExternalGraphicUtil = class {
      * @return {ol.Style|ol.style.Icon}
      */
     static getIconStyle(styleConfig, iconStyleOnly) {
+        if (!styleConfig.externalGraphic) return null;
+
         const iconStyle = new ol.style.Icon({
             src: styleConfig.externalGraphic
         });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
@@ -274,7 +274,7 @@ window.Mapbender.StyleUtil = (function() {
                     const valuesOut = Object.assign({}, styleConfig);
                     const data = dataCallback(feature);
                     propertyNames.forEach(function (prop) {
-                        valuesOut[prop] = styleConfig[prop].replace(placeholderRegex, function (match, dataProp) {
+                        valuesOut[prop] = styleConfig[prop]?.replace(placeholderRegex, function (match, dataProp) {
                             const dataValue = data[dataProp];
                             return dataValue || (prop === 'label' ? '' : dataValue);
                         });
@@ -282,8 +282,8 @@ window.Mapbender.StyleUtil = (function() {
                     return valuesOut;
                 }
             } else {
-                return function (original) {
-                    return original;
+                return function (styleConfig) {
+                    return styleConfig;
                 }
             }
         },
@@ -295,7 +295,7 @@ window.Mapbender.StyleUtil = (function() {
          */
         resolvePlaceholders: function(styleConfig, featureData) {
             const placeholderProps = Mapbender.StyleUtil.detectDataPlaceholders(styleConfig);
-            const resolver = Mapbender.StyleUtil.getPlaceholderResolver_(styleConfig, placeholderProps, function() {
+            const resolver = Mapbender.StyleUtil.getPlaceholderResolver(styleConfig, placeholderProps, function() {
                 return featureData;
             });
             return resolver(styleConfig);

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
@@ -1,7 +1,8 @@
 window.Mapbender = Mapbender || {};
 window.Mapbender.StyleUtil = (function() {
-    var _svgStyleDefaults, cssKeywordColors, _svgCallbackDefaultProps;
-    var stripAssetUrlRxp = /^.*?(\/)(bundles\/.*)/;
+    let _svgStyleDefaults, cssKeywordColors, _svgCallbackDefaultProps;
+    let stripAssetUrlRxp = /^.*?(\/)(bundles\/.*)/;
+    let placeholderRegex = /\${([^}]+)}/g;
 
     var methods = {
         /**
@@ -71,10 +72,15 @@ window.Mapbender.StyleUtil = (function() {
         },
         fixSvgStyleAssetUrls: function(style) {
             if (style && style.externalGraphic) {
-                style.externalGraphic = this._fixAssetPath(style.externalGraphic);
+                style.externalGraphic = this.fixAssetPath(style.externalGraphic);
             }
         },
-        _fixAssetPath: function(url) {
+        /**
+         * Convert potentially absolute URL to web-local url pointing somewhere into bundles/
+         * @param {String} url
+         * @returns {String|boolean}
+         */
+        fixAssetPath: function(url) {
             var urlOut = url.replace(stripAssetUrlRxp, '$2');
             if (urlOut === url && (urlOut || '').indexOf('bundles/') !== 0) {
                 console.warn("Asset path could not be resolved to local bundles reference", url);
@@ -239,6 +245,62 @@ window.Mapbender.StyleUtil = (function() {
 
             return new ol.style.Style(options);
         },
+
+                /**
+         *
+         * @param {Object} data
+         * @param {string[]} [candidates] to limit scanning to specifically named properties (default: scan all properties)
+         * @return {string[]}
+         */
+        detectDataPlaceholders: function(data, candidates) {
+            return (candidates || Object.keys(data)).filter(function(prop) {
+                // Reset global-flagged RegExp state.
+                // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#using_test_on_a_regex_with_the_global_flag
+                placeholderRegex.lastIndex = 0;
+                return placeholderRegex.test(data[prop] || '');
+            });
+        },
+
+        /**
+         * @param {Object} original
+         * @param {Array<String>} propertyNames
+         * @param {function} dataCallback
+         * @return {function}
+         * @private
+         */
+        getPlaceholderResolver: function(original, propertyNames, dataCallback) {
+            if (propertyNames.length) {
+                return function (styleConfig, feature) {
+                    const valuesOut = Object.assign({}, styleConfig);
+                    const data = dataCallback(feature);
+                    propertyNames.forEach(function (prop) {
+                        valuesOut[prop] = styleConfig[prop].replace(placeholderRegex, function (match, dataProp) {
+                            const dataValue = data[dataProp];
+                            return dataValue || (prop === 'label' ? '' : dataValue);
+                        });
+                    });
+                    return valuesOut;
+                }
+            } else {
+                return function (original) {
+                    return original;
+                }
+            }
+        },
+
+        /**
+         * @param {object} styleConfig
+         * @param {object} featureData
+         * @return {object}
+         */
+        resolvePlaceholders: function(styleConfig, featureData) {
+            const placeholderProps = Mapbender.StyleUtil.detectDataPlaceholders(styleConfig);
+            const resolver = Mapbender.StyleUtil.getPlaceholderResolver_(styleConfig, placeholderProps, function() {
+                return featureData;
+            });
+            return resolver(styleConfig);
+        },
+
     };
 
     _svgStyleDefaults = {

--- a/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
@@ -183,7 +183,7 @@
             var geometry = this.map.model.featureToGeoJsonGeometry(feature);
             geometry.style = this.map.model.extractSvgFeatureStyle(layer, feature);
             if (geometry.style && geometry.style.externalGraphic) {
-                geometry.style.externalGraphic = this._fixAssetPath(geometry.style.externalGraphic);
+                geometry.style.externalGraphic = Mapbender.Util.StyleUtil.fixAssetPath(geometry.style.externalGraphic);
             }
             return geometry;
         }
@@ -243,7 +243,7 @@
             for (var i = 0; i < layer.markers.length; ++i) {
                 var marker = layer.markers[i];
                 var originalUrl = marker.icon && marker.icon.url;
-                var internalUrl = this._fixAssetPath(originalUrl);
+                var internalUrl = Mapbender.Util.StyleUtil.fixAssetPath(originalUrl);
                 if (!internalUrl) {
                     continue;
                 }
@@ -266,23 +266,6 @@
                 opacity: layer.opacity,
                 markers: markerData
             };
-        }
-
-        /**
-         * Convert potentially absolute URL to web-local url pointing somewhere into bundles/
-         * @param {String} url
-         * @returns {String|boolean}
-         * @private
-         */
-        _fixAssetPath(url) {
-            // @todo: fold copy&paste vs Mapbender.StyleUtil
-            var urlOut = url.replace(/^.*?(\/)(bundles\/.*)/, '$2');
-            if (urlOut === url && (urlOut || '').indexOf('bundles/') !== 0) {
-                console.warn("Asset path could not be resolved to local bundles reference", url);
-                return false;
-            } else {
-                return urlOut;
-            }
         }
     }
 

--- a/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
+++ b/src/Mapbender/PrintBundle/Resources/public/MbImageExport.js
@@ -183,7 +183,7 @@
             var geometry = this.map.model.featureToGeoJsonGeometry(feature);
             geometry.style = this.map.model.extractSvgFeatureStyle(layer, feature);
             if (geometry.style && geometry.style.externalGraphic) {
-                geometry.style.externalGraphic = Mapbender.Util.StyleUtil.fixAssetPath(geometry.style.externalGraphic);
+                geometry.style.externalGraphic = Mapbender.StyleUtil.fixAssetPath(geometry.style.externalGraphic);
             }
             return geometry;
         }
@@ -243,7 +243,7 @@
             for (var i = 0; i < layer.markers.length; ++i) {
                 var marker = layer.markers[i];
                 var originalUrl = marker.icon && marker.icon.url;
-                var internalUrl = Mapbender.Util.StyleUtil.fixAssetPath(originalUrl);
+                var internalUrl = Mapbender.StyleUtil.fixAssetPath(originalUrl);
                 if (!internalUrl) {
                     continue;
                 }


### PR DESCRIPTION
Analogous to the configuration in the digitizer element ([documentation](https://doc.mapbender.org/de/elements/editing/digitizer/digitizer_configuration.html#darstellung-styles)), it is now possible to use external graphics when styling search results on the map. 

Example configuration:

```yaml
results:
  styleMap:
    default:
      externalGraphic: 'https://schulung.foss.academy/symbols/hospital.png'
      graphicWidth: 20
      graphicHeight: 20
      graphicOffsetX: 10
      graphicOffsetY: -10
```

`externalGraphic` may be an absolute or relative url. `graphicWidth` and `graphicHeight` are optional and default to the image's native size. graphicOffsetX / graphicOffsetY allow to displace the icon by the given pixel amount to the right/top (negative values possible) (optional, added in #1899)

An external graphic can also be used in temporary or select styles.

You can also use placeholders for the externalGraphic url in the form of `${columnName}`. The referenced column must be included in the `attributes` section.  Example:

```yaml
class_options:
  connection: search_db
  relation: my_table
  attributes:
    - type
results:
  styleMap:
    default:
      externalGraphic: 'images/${type}.png'
      graphicWidth: 20
      graphicHeight: 20
```