### PR TITLE
Add new option mapbender.application.sortorder for sorting of application list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Other:
 * [Develop] Add ExternalGraphicUtil (previously part of the digitizer module) ([PR#1897](https://github.com/mapbender/mapbender/pull/1897))
 * In applications tab in source infos, use same symbology for public/not public as elsewhere in Mapbender ([#PR1812](https://github.com/mapbender/mapbender/pull/1812)) 
 * Changed default login-backdrop image ([PR#1845](https://github.com/mapbender/mapbender/pull/1845))
+* Default sort order of application list changed to db first, but made configurable ([PR#1898](https://github.com/mapbender/mapbender/pull/1898))
 
 ## v4.2.6
 Features:

--- a/src/Mapbender/CoreBundle/Controller/WelcomeController.php
+++ b/src/Mapbender/CoreBundle/Controller/WelcomeController.php
@@ -55,10 +55,6 @@ class WelcomeController extends AbstractController
             }
         }
 
-        $dates = array_map(function ($application) {
-                return $application->getUpdated();
-        }, $allowedApplications);
-
         if ($this->sortOrder === 'date' || $this->sortOrder === 'title') {
             usort($allowedApplications, function (Application $a, Application $b) {
                 if ($this->sortOrder === 'date') {

--- a/src/Mapbender/CoreBundle/Controller/WelcomeController.php
+++ b/src/Mapbender/CoreBundle/Controller/WelcomeController.php
@@ -24,7 +24,11 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 class WelcomeController extends AbstractController
 {
-    public function __construct(protected ApplicationYAMLMapper $yamlRepository, protected ManagerRegistry $doctrine)
+    public function __construct(
+        protected ApplicationYAMLMapper $yamlRepository,
+        protected ManagerRegistry $doctrine,
+        protected string $sortOrder,
+    )
     {
     }
 
@@ -39,13 +43,32 @@ class WelcomeController extends AbstractController
             'title' => 'ASC',
         ]);
         /** @var Application[] $allApplications */
-        $allApplications = array_merge($yamlApplications, $dbApplications);
+        $allApplications = match($this->sortOrder) {
+            'yaml-first' => array_merge($yamlApplications, $dbApplications),
+            default => array_merge($dbApplications, $yamlApplications),
+        };
+
         $allowedApplications = [];
         foreach ($allApplications as $application) {
             if ($this->isGranted(ResourceDomainApplication::ACTION_VIEW, $application)) {
                 $allowedApplications[] = $application;
             }
         }
+
+        $dates = array_map(function ($application) {
+                return $application->getUpdated();
+        }, $allowedApplications);
+
+        if ($this->sortOrder === 'date' || $this->sortOrder === 'title') {
+            usort($allowedApplications, function (Application $a, Application $b) {
+                if ($this->sortOrder === 'date') {
+                    return $b->getUpdated() <=> $a->getUpdated();
+                } else {
+                    return strcasecmp($a->getTitle(), $b->getTitle());
+                }
+            });
+        }
+
         return $this->render('@MapbenderCore/Welcome/list.html.twig', [
             'applications' => $allowedApplications,
             'create_permission' => $this->isGranted(ResourceDomainInstallation::ACTION_CREATE_APPLICATIONS),

--- a/src/Mapbender/CoreBundle/Controller/WelcomeController.php
+++ b/src/Mapbender/CoreBundle/Controller/WelcomeController.php
@@ -45,6 +45,8 @@ class WelcomeController extends AbstractController
         /** @var Application[] $allApplications */
         $allApplications = match($this->sortOrder) {
             'yaml-first' => array_merge($yamlApplications, $dbApplications),
+            'db-only' => $dbApplications,
+            'yaml-only' => $yamlApplications,
             default => array_merge($dbApplications, $yamlApplications),
         };
 

--- a/src/Mapbender/CoreBundle/Resources/config/controllers.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/controllers.xml
@@ -37,6 +37,7 @@
                  public="true">
             <argument type="service" id="mapbender.application.yaml_entity_repository" />
             <argument type="service" id="doctrine" />
+            <argument>%mapbender.application.sortorder%</argument>
             <tag name="container.service_subscriber" />
             <call method="setContainer">
                 <argument type="service" id="Psr\Container\ContainerInterface" />

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -14,6 +14,8 @@
              Caching machinery can only be safely enabled after these cases have been adressed properly -->
         <parameter key="cachable.mapbender.application.config">false</parameter>
         <parameter key="mapbender.application.yaml_entity_repository.class">Mapbender\CoreBundle\Component\ApplicationYAMLMapper</parameter>
+        <!-- available options: db-first, yaml-first, yaml-only, date, title -->
+        <parameter key="mapbender.application.sortorder">db-first</parameter>
         <parameter key="mapbender.source.typedirectory.service.class">Mapbender\CoreBundle\Component\Source\TypeDirectoryService</parameter>
         <parameter key="mapbender.uploads_manager.service.class">Mapbender\CoreBundle\Component\UploadsManager</parameter>
         <parameter key="mapbender.application_importer.service.class">Mapbender\ManagerBundle\Component\ImportHandler</parameter>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
              Caching machinery can only be safely enabled after these cases have been adressed properly -->
         <parameter key="cachable.mapbender.application.config">false</parameter>
         <parameter key="mapbender.application.yaml_entity_repository.class">Mapbender\CoreBundle\Component\ApplicationYAMLMapper</parameter>
-        <!-- available options: db-first, yaml-first, date, title -->
+        <!-- available options: db-first, yaml-first, db-only, yaml-only, date, title -->
         <parameter key="mapbender.application.sortorder">db-first</parameter>
         <parameter key="mapbender.source.typedirectory.service.class">Mapbender\CoreBundle\Component\Source\TypeDirectoryService</parameter>
         <parameter key="mapbender.uploads_manager.service.class">Mapbender\CoreBundle\Component\UploadsManager</parameter>

--- a/src/Mapbender/CoreBundle/Resources/config/services.xml
+++ b/src/Mapbender/CoreBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
              Caching machinery can only be safely enabled after these cases have been adressed properly -->
         <parameter key="cachable.mapbender.application.config">false</parameter>
         <parameter key="mapbender.application.yaml_entity_repository.class">Mapbender\CoreBundle\Component\ApplicationYAMLMapper</parameter>
-        <!-- available options: db-first, yaml-first, yaml-only, date, title -->
+        <!-- available options: db-first, yaml-first, date, title -->
         <parameter key="mapbender.application.sortorder">db-first</parameter>
         <parameter key="mapbender.source.typedirectory.service.class">Mapbender\CoreBundle\Component\Source\TypeDirectoryService</parameter>
         <parameter key="mapbender.uploads_manager.service.class">Mapbender\CoreBundle\Component\UploadsManager</parameter>


### PR DESCRIPTION
To avoid having the demo application always on top of the (usually more useful) db apps, the default sorting of the application list was changed to having the db applications shown first. However, the parameter `mapbender.application.sortorder` was added to control this behaviour:

| Parameter Value | Description                                                                                                                                                                                                                                                                              |
|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| db-first        | New default: Db applications are shown first, then yaml applications. Internally sorted by title                                                                                                                                                                                         |
| yaml-first      | Previous default: Yaml applications are shown first, then db applications. Internally sorted by title                                                                                                                                                                                    |
| db-only         | Only db applications are shown in the applications list, yaml applications are hidden. :warning: yaml applications are still accessible by calling `/application/<slug>`, to completely remove yaml applications, delete the from the `config/applications` directory in the filesystem. |
| yaml-only       | Only yaml applications are shown in the applications list, db applications are hidden. :warning: db applications are still accessible by calling `/application/<slug>`, to completely remove db applications, temporarily change the parameter value back and delete the applications    |
| title           | Applications are sorted by title, independant of origin                                                                                                                                                                                                                                  |
| date            | Applications are sorted by most recent update, independant of origin                                                                                                                                                                                                                     |