### PR TITLE
Fix mapbender:wms:assign command

### DIFF
--- a/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
+++ b/src/Mapbender/WmsBundle/Command/SourceAssignCommand.php
@@ -60,7 +60,7 @@ class SourceAssignCommand extends AbstractSourceCommand
 
         $sourceId = $input->getArgument(self::ARGUMENT_SOURCE);
 
-        $this->sourceInstanceController->createNewSourceInstance($application, $sourceId, $layerset->getId(), $this->getEntityManager());
+        $this->sourceInstanceController->createNewSourceInstance($application, $sourceId, $layerset->getId(), $input->getOptions());
         $io->success("New source instance added.");
         return Command::SUCCESS;
     }


### PR DESCRIPTION
Fixes the `mapbender:wms:assign` command: Now passes the correct parameter

see internal issue #13820