### PR TITLE
Fix schema update failure for legacy json_array columns on PostgreSQL

### DIFF
--- a/src/Mapbender/CoreBundle/Command/DatabaseUpgradeCommand.php
+++ b/src/Mapbender/CoreBundle/Command/DatabaseUpgradeCommand.php
@@ -201,6 +201,8 @@ class DatabaseUpgradeCommand extends Command
         // Columns to migrate from Doctrine 'array'/'object' type to JSON
         // format: tableName => [columnName, ...]
         $jsonMigrations = [
+            'fom_user_log'                    => ['context'],
+            'mb_print_queue'                  => ['payload'],
             'mb_core_application'             => ['extra_assets'],
             'mb_core_element'                 => ['configuration'],
             'mb_core_regionproperties'        => ['properties'],


### PR DESCRIPTION
This fix adds two more columns to the mapbender:database:upgrade command that need to be migrated to the native JSON type.

When upgrading installations that were created before the switch from `json_array` type to the native `json` type, 
running `doctrine:schema:update` failed on PostgreSQL with:

    SQLSTATE[42804]: Datatype mismatch: column "context" cannot be cast
    automatically to type json
    HINT: You might need to specify "USING context::json".