### PR TITLE
Add css variable for toolbar menu text color

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
@@ -70,6 +70,7 @@
     --toolbar-background: #{$toolBarBackgroundColor};
     --toolbar-opacity: #{$toolBarOpacity};
     --toolbar-text-color: var(--text-color);
+    --toolbar-menu-text-color: var(--toolbar-text-color);
     --toolbar-button-hover-opacity: #{$toolBarButtonHoverOpacity};
     --toolbar-button-active-opacity: #{$toolBarButtonActiveOpacity};
     --toolbar-button-active-background-color: #{$toolBarButtonActiveBackgroundColor};

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -50,6 +50,10 @@ $hoverEffects: true !default;
 .toolBarColors, .toolBar {
   background-color: var(--toolbar-background);
   color: var(--toolbar-text-color);
+
+  .dropdown-menu {
+    --bs-dropdown-color: var(--toolbar-menu-text-color);
+  }
 }
 
 .toolbar-button-hover-effect {
@@ -183,7 +187,7 @@ ul.toolBar, .toolBar > ul {
   }
   .menu-wrapper {
     .btn {
-        color: var(--bs-secondary-color);
+        color: var(--toolbar-text-color);
         border: none;
         .iconBig {
           width: 1.25em;


### PR DESCRIPTION
Makes the default colour for the toolbar menu `--toolbar-text-color`. It is possible to override the text color for the menu only be the new variable `toolbar-menu-text-color`.

Example:

```css
:root {
  --toolbar-text-color: orange;
  --toolbar-menu-text-color: green;
}
```