### PR TITLE
Make content element spacing dependant on sidebar position, fix sidepane right

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/libs/_css_custom_properties.scss
@@ -35,8 +35,17 @@
 
     // ---- Layout ----
     --space: #{$space};
-    --content-element-padding-horizontal: 50px;
     --popup-modal-width: #{$popupModalWidth};
+    --content-element-padding-horizontal: 20px;
+    --content-element-padding-top: var(--space);
+    --content-element-padding-bottom: var(--space);
+    @media(min-width: $desktopBreakpointWidth) {
+        --content-element-padding-horizontal: 30px;
+        --content-element-padding-top: calc(var(--space) * 1.5);
+    }
+    // overridden when the sidepane is present (see _sidepane.scss)
+    --content-spacing-right: 0px;
+    --content-spacing-left: 0px;
 
     --backend-popup-max-width: 800px;
     // allows popups to grow bigger than --backend-popup-max-width on large screens

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -1,5 +1,13 @@
 // CSS custom properties for sidepane are emitted by libs/_css_custom_properties.scss (:root block)
 
+:root:has(.sidePane.left) {
+    --content-spacing-left: 40px;
+}
+
+:root:has(.sidePane.right) {
+    --content-spacing-right: 40px;
+}
+
 .sidePane {
     color: var(--sidepane-text-color);
     background: var(--sidepane-background-color);

--- a/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/modules/_sidepane.scss
@@ -1,10 +1,10 @@
 // CSS custom properties for sidepane are emitted by libs/_css_custom_properties.scss (:root block)
 
-:root:has(.sidePane.left) {
+:root:has(.sidePane.left:not(.hidden)) {
     --content-spacing-left: 40px;
 }
 
-:root:has(.sidePane.right) {
+:root:has(.sidePane.right:not(.hidden)) {
     --content-spacing-right: 40px;
 }
 
@@ -236,4 +236,3 @@
         }
     }
 }
-

--- a/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
+++ b/src/Mapbender/CoreBundle/Resources/public/sass/theme/mapbender3.scss
@@ -445,18 +445,18 @@ div.notifyjs-container > div.notifyjs-bootstrap-base > span{
     margin-top: 0.5rem;
   }
   &.anchored-element-wrap-lt, &.anchored-element-wrap-lb {
-    left: var(--content-element-padding-horizontal);
+    left: calc(var(--content-element-padding-horizontal) + var(--content-spacing-left));
     text-align: left;
   }
   &.anchored-element-wrap-rt, &.anchored-element-wrap-rb {
-    right: var(--content-element-padding-horizontal);
+    right: calc(var(--content-element-padding-horizontal) + var(--content-spacing-right));
     text-align: right;
   }
   &.anchored-element-wrap-lt, &.anchored-element-wrap-rt {
-    top: calc(var(--space) * 2);
+    top: var(--content-element-padding-top);
   }
   &.anchored-element-wrap-lb, &.anchored-element-wrap-rb {
-    bottom: var(--space);
+    bottom: var(--content-element-padding-bottom);
   }
 }
 

--- a/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
+++ b/src/Mapbender/CoreBundle/Resources/public/widgets/sidepane.js
@@ -130,14 +130,14 @@ $(function () {
             this.isOpen = this._getResponsiveDefaultOpen();
 
             if (this.isOpen) {
-                this.$element.css('left', 'initial').css('right', 'initial');
+                this.$element.css('left', 'initial').css('right', this.isLeft ? 'initial' : '0px');
                 this.$element.removeClass('closed');
             } else {
                 this.$element.addClass('closed');
-                if (this.$element.hasClass("right")) {
-                    this.$element.css({right: (this.$element.outerWidth(true) * -1) + "px"});
-                } else {
+                if (this.isLeft) {
                     this.$element.css({left: (this.$element.outerWidth(true) * -1) + "px"});
+                } else {
+                    this.$element.css({right: (this.$element.outerWidth(true) * -1) + "px"});
                 }
             }
         }
@@ -230,8 +230,9 @@ $(function () {
             const allowedWidth = Math.floor(window.innerWidth * this.MAX_SIZE_WINDOW_PERCENTAGE);
             if (this.sidePaneWidth() > allowedWidth) {
                 this.element.style.width = allowedWidth + "px";
-                if (!this.isOpen && this.element.style.left && this.element.style.left !== "0px") {
-                    this.element.style.left = "-" + allowedWidth + "px";
+                const orientationString = this.isLeft ? 'left' : 'right';
+                if (!this.isOpen && this.element.style[orientationString] && this.element.style[orientationString] !== "0px") {
+                    this.element.style[orientationString] = "-" + allowedWidth + "px";
                 }
             }
         }


### PR DESCRIPTION
The spacing of positionend content elements (like the zoombar) was fixed to 50px. it is now flexible and depends on …
- screen size: The default changed to 20px (mobile) and 30px (Desktop, where there's more space)
- sidepane position: On the side where the sidepane is located, 40px are added to the margin to account for the size of the icon bar of the closed side pane)

The following css variables are now available for content element positioning (with their default values):

```css
--content-element-padding-horizontal: 20px;
--content-element-padding-top: 20px;
--content-element-padding-bottom: 20px;

@media(min-width: 1200px) {
    --content-element-padding-horizontal: 30px;
    --content-element-padding-top: 30px;
}

--content-spacing-right: 0px; // 40px if sidepane is on the right
--content-spacing-left: 0px; // 40px if sidepane is on the left

```

Also, the right-aligned sidepane was broken, it's now fixed.

see internal ticket 13846