### PR TITLE
Fix OgcApiFeaturesLayerSource had no id and was therefore ignored when exporting or duplicating a YAML application

### DIFF
--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesInstanceFactory.php
@@ -107,6 +107,7 @@ class OgcApiFeaturesInstanceFactory extends SourceInstanceFactory
                 continue;
             }
             $layerSource = new OgcApiFeaturesLayerSource();
+            $layerSource->setId($layer['collectionId']);
             $layerSource->setSource($source);
             $layerSource->setTitle($layer['title'] ?? '');
             $layerSource->setCollectionId($layer['collectionId']);


### PR DESCRIPTION
for testing: duplicate the new mapbender_user.yaml (from https://github.com/mapbender/mapbender-starter/pull/175)