### PR TITLE
Do not show title in feature info custom html

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
@@ -5,6 +5,8 @@ window.Mapbender.StyleUtil = (function () {
     let placeholderRegex = /\${([^}]+)}/g;
 
     var methods = {
+            recentReplacementCount: 0,
+            recentReplacementVariables: 0,
         /**
          * @param {Object} style
          * @param {String} colorProp
@@ -270,6 +272,7 @@ window.Mapbender.StyleUtil = (function () {
          * @private
          */
         getPlaceholderResolver: function (original, propertyNames, dataCallback, escapeHtml) {
+            const self = this;
             const fnEscapeHtml = (input) => {
                 if (input === undefined || input === null) return '';
                 return (input + '')
@@ -282,6 +285,8 @@ window.Mapbender.StyleUtil = (function () {
 
             if (propertyNames.length) {
                 return function (styleConfig, feature) {
+                    self.recentReplacementCount = 0;
+                    self.recentReplacementVariables = 0;
                     const valuesOut = Object.assign({}, styleConfig);
                     const data = dataCallback(feature);
                     propertyNames.forEach(function (prop) {
@@ -290,6 +295,8 @@ window.Mapbender.StyleUtil = (function () {
                             if (escapeHtml) {
                                 dataValue = fnEscapeHtml(dataValue);
                             }
+                            self.recentReplacementVariables++;
+                            self.recentReplacementCount += dataValue ? 1 : 0;
                             return dataValue || (prop === 'label' ? '' : dataValue);
                         });
                     });

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/StyleUtil.js
@@ -296,7 +296,7 @@ window.Mapbender.StyleUtil = (function () {
                                 dataValue = fnEscapeHtml(dataValue);
                             }
                             self.recentReplacementVariables++;
-                            self.recentReplacementCount += dataValue ? 1 : 0;
+                            self.recentReplacementCount += (dataValue !== null && dataValue !== undefined && dataValue !== '') ? 1 : 0;
                             return dataValue || (prop === 'label' ? '' : dataValue);
                         });
                     });

--- a/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesConfigGenerator.php
+++ b/src/Mapbender/OgcApiFeaturesBundle/Component/OgcApiFeaturesConfigGenerator.php
@@ -227,6 +227,6 @@ class OgcApiFeaturesConfigGenerator extends SourceInstanceConfigGenerator
             $properties[$name] = $label;
         }
 
-        return $this->twig->render($propertyMapTwigTemplate, ['properties' => $properties]);
+        return $this->twig->render($propertyMapTwigTemplate, ['properties' => $properties, 'layer' => $layer]);
     }
 }

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.sourcelayer.js
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/public/geosource.ogc_api_features.sourcelayer.js
@@ -68,13 +68,14 @@ class OgcApiSourceLayer extends Mapbender.SourceLayer {
             );
         }
 
+
         const featureInfo = this.featureInfoPlaceholderResolver(this.featureInfoWrapper, feature).featureInfo;
-        if (!featureInfo) return null;
+        // if no replacements were made, we don't want to show the feature info, unless the feature info is static (no placeholders at all).
+        if (!featureInfo || (Mapbender.StyleUtil.recentReplacementCount === 0 && Mapbender.StyleUtil.recentReplacementVariables !== 0)) return null;
 
         const fragment = document.createElement('div');
         fragment.innerHTML = featureInfo;
         this.removeEmptyRows(fragment, '.-js-filter-empty-rows tr', '.ogc-api-featureinfo-val');
-        if (!fragment.childElementCount) return null;
 
         const label = this?.options?.title || this?.options?.collectionId || '';
 
@@ -84,13 +85,6 @@ class OgcApiSourceLayer extends Mapbender.SourceLayer {
         fragment.setAttribute('data-geometry', wkt.writeFeature(feature));
         fragment.setAttribute('data-srid', Mapbender.Model.getCurrentProjectionCode());
         fragment.setAttribute('data-label', label);
-
-        if (label) {
-            const h5 = document.createElement('h5');
-            h5.className = 'featureinfo__title mt-3';
-            h5.textContent = label;
-            fragment.prepend(h5);
-        }
         return fragment;
     }
 

--- a/src/Mapbender/OgcApiFeaturesBundle/Resources/views/featureinfo-propertymap.html.twig
+++ b/src/Mapbender/OgcApiFeaturesBundle/Resources/views/featureinfo-propertymap.html.twig
@@ -1,3 +1,8 @@
+{% if layer.title or layer.sourceItem.collectionId %}
+    <h5 class="featureinfo__title mt-3">
+        {{ layer.title | default(layer.sourceItem.collectionId) }}
+    </h5>
+{% endif %}
 <table class="table table-striped table-bordered table-condensed featureinfo__table ogc-api-featureinfo-table -js-filter-empty-rows">
     <tbody>
         {% for key, value in properties %}


### PR DESCRIPTION
it can be added manually to the custom html if it is desired. It is still shown for YAML and property lists mode.

Also improved the mechanism to detect whether there were replacements made: The StyleUtil now has tracks how many variables were found and how many of them were replaced. If there was no replacement made, the featureinfo is not shown, unless the template is static (i.e. no variables exist)