### PR TITLE
Improvements for new applicationswitcher element

### DIFF
--- a/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
+++ b/src/Mapbender/CoreBundle/Element/ApplicationSwitcher.php
@@ -127,8 +127,9 @@ class ApplicationSwitcher extends AbstractElementService implements ConfigMigrat
                 }
                 $preparedAppConfig[$group][$slug] = $appConfig;
             } catch (AccessDeniedException | NotFoundHttpException $e) {
-                // external app (neither yaml nor database app)
-                if ($e::class === NotFoundHttpException::class) {
+                // external app (neither yaml nor database app).
+                // If it's neither an internal app nor a url is found, ignore the entry
+                if ($e::class === NotFoundHttpException::class && (!empty($appConfig['url']) || !empty($appConfig['add_wms']))) {
                     $preparedAppConfig[$group][$slug] = $appConfig;
                 }
             }

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
 
     class MbApplicationSwitcher extends MapbenderElement {
         constructor(configuration, $element) {
@@ -17,14 +17,20 @@
         }
 
         _initEvents() {
-            $('a', this.$element).on('click', (e) => {
-                e.preventDefault();
+            $('a', this.$element).on('click pointerenter focus contextmenu', (e) => {
                 const $a = $(e.currentTarget);
+                const urlTemplate = $a.attr('data-href-template');
+                if (e.type !== 'click') {
+                    $a.attr('href', this.replacePlaceholders(urlTemplate));
+                    return;
+                }
+
+                e.preventDefault();
                 // no need to switch application, when Application Switcher is used to add a WMS
                 if (typeof $a.attr('data-mb-url') !== 'undefined') {
                     return;
                 }
-                this._switchApplication($a.attr('href'));
+                this._switchApplication(urlTemplate, e.shiftKey || e.ctrlKey);
             });
             $('select', this.$element).on('change', (e) => {
                 const slug = $(e.target).val();
@@ -33,10 +39,11 @@
             });
         }
 
-        _switchApplication(url) {
+        _switchApplication(url, forceNewTab) {
             url = this.replacePlaceholders(url);
-            if (this.options.open_in_new_tab) {
-                window.open(url);
+            if (this.options.open_in_new_tab || forceNewTab) {
+                const w = window.open(url);
+                if (w) w.focus();
             } else {
                 window.location.href = url;
             }

--- a/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
+++ b/src/Mapbender/CoreBundle/Resources/public/elements/MbApplicationSwitcher.js
@@ -17,7 +17,7 @@
         }
 
         _initEvents() {
-            $('a', this.$element).on('click pointerenter focus contextmenu', (e) => {
+            $('a[data-href-template]', this.$element).on('click pointerenter focus contextmenu', (e) => {
                 const $a = $(e.currentTarget);
                 const urlTemplate = $a.attr('data-href-template');
                 if (e.type !== 'click') {
@@ -26,10 +26,6 @@
                 }
 
                 e.preventDefault();
-                // no need to switch application, when Application Switcher is used to add a WMS
-                if (typeof $a.attr('data-mb-url') !== 'undefined') {
-                    return;
-                }
                 this._switchApplication(urlTemplate, e.shiftKey || e.ctrlKey);
             });
             $('select', this.$element).on('change', (e) => {
@@ -43,7 +39,10 @@
             url = this.replacePlaceholders(url);
             if (this.options.open_in_new_tab || forceNewTab) {
                 const w = window.open(url);
-                if (w) w.focus();
+                if (w) {
+                    w.opener = null;
+                    w.focus();
+                }
             } else {
                 window.location.href = url;
             }

--- a/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
@@ -44,11 +44,11 @@
                         {% endif %}
                     >
                 {% else %}
-                    <a href="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
+                    <a href="#" data-href-template="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
                 {% endif %}
                         <div class="list-content">
                             {% if app.img_url is defined and app.img_url != false %}
-                            <img src="{{ app.img_url }}" alt="{{ app.title }}">
+                            <img src="{{ app.img_url }}" alt="{{ app.title | default(slug) }}">
                             {% else %}
                                 <img class="bg-light" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAABHNCSVQICAgIfAhkiAAA
                                     ACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAABfElEQVR4
@@ -61,7 +61,7 @@
                                     bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdv2bdu2f2kEDuH7
                                     CTaTAAAAAElFTkSuQmCC" alt="">
                             {% endif %}
-                            <p class="text-center text-break my-2">{{ app.title }}</p>
+                            <p class="text-center text-break my-2">{{ app.title | default(slug) }}</p>
                         </div>
                     </a>
                 </li>

--- a/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
+++ b/src/Mapbender/CoreBundle/Resources/views/Element/application_switcher.html.twig
@@ -44,7 +44,7 @@
                         {% endif %}
                     >
                 {% else %}
-                    <a href="#" data-href-template="{{ app.url }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
+                    <a href="#" data-href-template="{{ app.url | default('#') }}"{% if app.description is defined and app.description %} title="{{ app.description }}"{% endif %}>
                 {% endif %}
                         <div class="list-content">
                             {% if app.img_url is defined and app.img_url != false %}


### PR DESCRIPTION
- Open link in new tab when having shift or ctrl key pressed while clicking on a link
- Replace templates when using the contextmenu => open in new tab to navigate
- Filter out invalid configurations (like references to non-existing internal applications or external links without url set), they used to throw an error 
- fallback to slug if "title" is not defined instead of throwing an error