### PR TITLE
Fix element type detection in csrf token util

### DIFF
--- a/src/Mapbender/CoreBundle/Resources/public/util.js
+++ b/src/Mapbender/CoreBundle/Resources/public/util.js
@@ -706,7 +706,7 @@ Mapbender.ElementUtil = {
      * on the server for independent sessions which results in (randomly) only one of the tokens being valid.
      */
     getCsrfToken: async function (element, url, forceRefresh = false) {
-        const elementType = Object.getPrototypeOf(element).widgetFullName;
+        const elementType = element.constructor.name;
         if (forceRefresh && this._csrfTokenCache[elementType]) {
             delete this._csrfTokenCache[elementType];
         }


### PR DESCRIPTION
the result was that when multiple elements that uses csrf (MbSearchRouter, MbViewManager) were present in an application, only one of them worked.