### PR TITLE
 Fix sources other than WMS were not working in BaseSourceSwitcher when using shared instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next bugfix release
 * Do not show loading spinner in layer tree indefinetely when disabling source while it's loading ([#PR1886](https://github.com/mapbender/mapbender/pull/1886))
 * Fix vector tiles with nested metadata could not be loaded ([#PR1924](https://github.com/mapbender/mapbender/pull/1924))
+* Fix sources other than WMS not working in BaseSourceSwitcher as free instances ([#PR1933](https://github.com/mapbender/mapbender/pull/1933))
 
 ## v4.2.6
 Features:

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
@@ -150,7 +150,7 @@
             }
             let sourceId = this.id;
             // if source id matches pattern "<assignmentId>_<sourceId>", extract sourceId part
-            const match = sourceId.match(/^[0-9]+_([0-9]+)$/);
+            const match = (sourceId ?? '').match(/^[0-9]+_([0-9]+)$/);
             if (match) {
                 sourceId = match[1];
             }

--- a/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
+++ b/src/Mapbender/CoreBundle/Resources/public/mapbender-model/Source.js
@@ -141,12 +141,21 @@
 
         /**
          * Returns the source id. This is by default just the id given in the source definition,
-         * but can be overridden by subclasses if needed, e.g. for WMS shared instances. There,
-         * include the instance id also contains the assignment id.
+         * except for shared instances, where the <sourceId> of <assignmentId>_<sourceId> is returned
          * @return {string|null}
          */
         getSourceId() {
-            return this.id;
+            if (this.cachedSourceId) {
+                return this.cachedSourceId;
+            }
+            let sourceId = this.id;
+            // if source id matches pattern "<assignmentId>_<sourceId>", extract sourceId part
+            const match = sourceId.match(/^[0-9]+_([0-9]+)$/);
+            if (match) {
+                sourceId = match[1];
+            }
+            this.cachedSourceId = sourceId;
+            return sourceId;
         }
 
         getSettings() {

--- a/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
+++ b/src/Mapbender/WmsBundle/Resources/public/mapbender.geosource.wms.js
@@ -92,20 +92,6 @@ window.Mapbender = Mapbender || {};
             return this.nativeLayers;
         }
 
-        getSourceId() {
-            if (this.cachedSourceId) {
-                return this.cachedSourceId;
-            }
-            let sourceId = this.id;
-            // if source id matches pattern "<assignmentId>_<sourceId>", extract sourceId part
-            const match = sourceId.match(/^[0-9]+_([0-9]+)$/);
-            if (match) {
-                sourceId = match[1];
-            }
-            this.cachedSourceId = sourceId;
-            return sourceId;
-        }
-
         /**
          * @return {SourceSettings}
          */


### PR DESCRIPTION
e.g. when using a WMTS or VectorTiles instance that is included as a shared/free instance, they were not toggled via the BaseSourceSwitcher. That's because the logic to exctract the id from the assignemnt id was (wrongly) only applied to WMS instances, not all other sources.

This will be also merged back into the develop branch.

see internal ticket 13626 