### PR TITLE
Fix print queue not showing after submitting print request; Default print queue directory changed to var/prints (for security reasons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Breaking changes (for details on migration process see [UPGRADING.md]):
 * Symfony updated to version 7.4 LTS
 * Doctrine DBAL updated to version 4.4
 * Doctrine ORM updated to version 3.6
-* Default print queue directory changed to var/prints
+* Default print queue directory changed to var/prints ([#PR1937](https://github.com/mapbender/mapbender/pull/1937))
 
 Security:
 * Allow custom permissions for source instances ([#PR1812](https://github.com/mapbender/mapbender/pull/1812), [#PR1825](https://github.com/mapbender/mapbender/pull/1825))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Breaking changes (for details on migration process see [UPGRADING.md]):
 * Symfony updated to version 7.4 LTS
 * Doctrine DBAL updated to version 4.4
 * Doctrine ORM updated to version 3.6
+* Default print queue directory changed to var/prints
 
 Security:
 * Allow custom permissions for source instances ([#PR1812](https://github.com/mapbender/mapbender/pull/1812), [#PR1825](https://github.com/mapbender/mapbender/pull/1825))

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -59,6 +59,10 @@ https://github.com/mapbender/mapbender/blob/develop/docs/elements/javascript_cla
 ### HTML & Copyright elements merged
 Configuration in general will still work unchanged for existing HTML and copyright elements. Only backwards-incompatible change: When no title was set for a copyright element, the title will change from "Copyright" to "HTML", as the default fallback is the element name. Modify the title for these instances. 
 
+### Default print queue directory changed to var/prints
+(only relevant when having `mapbender.print.queueable` set to true). Print queue prints were in the default setting saved to public/prints, which resulted them to be publicly accessible via the Webserver, circumventing all access restrictions.
+The new default print queue directory is application/var/prints, which is not publicly accessible. The files can still be accessed via the print queue tab, but with access control being checked. If you still want to maintain the prints publicly accessible, change the parameter `mapbender.print.queue.storage_dir` to `%kernel.project_dir%/public/prints` (or similar) in your parameters.yaml file.
+
 ## 4.2.5
 When using `MapbenderModel.getSourceById` or `Source.getLayerById`, be aware that both the source id and layer id now may contain
 a prefix, separated by an underscore. This change was introduced to fix issues with multiple instances of 

--- a/src/Mapbender/PrintBundle/Resources/config/services.xml
+++ b/src/Mapbender/PrintBundle/Resources/config/services.xml
@@ -30,9 +30,7 @@
         <parameter key="mapbender.print.plugin.queue.class">Mapbender\PrintBundle\Component\Plugin\PrintQueuePlugin</parameter>
         <!-- can only be activated safely if there is a cron job executing the queued jobs -->
         <parameter key="mapbender.print.queueable">false</parameter>
-        <!-- Storage path can be anywhere, should probably be /var/ in proper LSB setups
-             Storage in web is pre-standardization legacy behavior -->
-        <parameter key="mapbender.print.queue.storage_dir">%kernel.project_dir%/public/prints</parameter>
+        <parameter key="mapbender.print.queue.storage_dir">%kernel.project_dir%/var/prints</parameter>
         <!-- Queue load path is the same as storage_path by default, but can be set to some
              other value to support a "print queue server" installed separately from the browser-facing
              Mapbender install. This value will be used to retrieve the finished PDF when serving the

--- a/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
+++ b/src/Mapbender/PrintBundle/Resources/public/element/MbPrint.js
@@ -558,15 +558,15 @@
                 // prevent submit without selection (sidepane mode has separate button to start selecting)
                 return false;
             }
-            const proceed = super._onSubmit(evt);
+            const preventDefault = super._onSubmit(evt);
             let $tabs = $('.tab-container', this.$element);
-            if (proceed && $tabs.length) {
+            if (!preventDefault && $tabs.length) {
                 // switch to queue display tab on successful submit
                 window.setTimeout(function() {
                     $tabs.tabs({active: 1});
                 }, 50);
             }
-            return proceed;
+            return preventDefault;
         }
 
         _onTemplateChange() {


### PR DESCRIPTION
(only relevant when having `mapbender.print.queueable` set to true). Print queue prints were in the default setting saved to public/prints, which resulted them to be publicly accessible via the Webserver, circumventing all access restrictions.
The new default print queue directory is application/var/prints, which is not publicly accessible. The files can still be accessed via the print queue tab, but with access control being checked. If you still want to maintain the prints publicly accessible, change the parameter `mapbender.print.queue.storage_dir` to `%kernel.project_dir%/public/prints` (or similar) in your parameters.yaml file.

Related starter PR: https://github.com/mapbender/mapbender-starter/pull/180

Also, fixed that the print queue was not showing after submitting print request.