### PR TITLE
Fix WmsInstance ratio default value type

### DIFF
--- a/src/Mapbender/WmsBundle/Entity/WmsInstance.php
+++ b/src/Mapbender/WmsBundle/Entity/WmsInstance.php
@@ -64,7 +64,7 @@ class WmsInstance extends SourceInstance implements SupportsOpacity, SupportsPro
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     protected $buffer = 0;
 
-    #[ORM\Column(type: 'decimal', precision: 10, scale: 2, options: ['default' => '1.25'])]
+    #[ORM\Column(type: 'decimal', precision: 10, scale: 2, options: ['default' => 1.25])]
     protected $ratio = 1.25;
 
     #[ORM\Column(name: 'refresh_interval', type: 'integer', nullable: true, options: ['default' => null])]


### PR DESCRIPTION
The Oracle database complains if the default value for ‘ratio’ is not numeric. doctrine:schema:create fails. 